### PR TITLE
#3: 將遊戲名稱與專案檔更名為 RunningCat

### DIFF
--- a/RunningCat.csproj
+++ b/RunningCat.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Godot.NET.Sdk/4.6.2">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework Condition=" '$(GodotTargetPlatform)' == 'android' ">net9.0</TargetFramework>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+  </PropertyGroup>
+</Project>

--- a/RunningCat.sln
+++ b/RunningCat.sln
@@ -1,0 +1,19 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RunningCat", "RunningCat.csproj", "{E09683DC-6F24-42EC-8FA8-3A08FD80D4D5}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+	Debug|Any CPU = Debug|Any CPU
+	ExportDebug|Any CPU = ExportDebug|Any CPU
+	ExportRelease|Any CPU = ExportRelease|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E09683DC-6F24-42EC-8FA8-3A08FD80D4D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E09683DC-6F24-42EC-8FA8-3A08FD80D4D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E09683DC-6F24-42EC-8FA8-3A08FD80D4D5}.ExportDebug|Any CPU.ActiveCfg = ExportDebug|Any CPU
+		{E09683DC-6F24-42EC-8FA8-3A08FD80D4D5}.ExportDebug|Any CPU.Build.0 = ExportDebug|Any CPU
+		{E09683DC-6F24-42EC-8FA8-3A08FD80D4D5}.ExportRelease|Any CPU.ActiveCfg = ExportRelease|Any CPU
+		{E09683DC-6F24-42EC-8FA8-3A08FD80D4D5}.ExportRelease|Any CPU.Build.0 = ExportRelease|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/project.godot
+++ b/project.godot
@@ -10,7 +10,7 @@ config_version=5
 
 [application]
 
-config/name="新遊戲專案"
+config/name="RunningCat"
 run/main_scene="res://scenes/StartScene.tscn"
 config/features=PackedStringArray("4.6", "Forward Plus", "Mobile")
 config/icon="res://icon.svg"


### PR DESCRIPTION
## 關聯 Issue
Closes #3

## 實作方式

### 1. 更新 project.godot
將 `config/name` 從 `"新遊戲專案"` 改為 `"RunningCat"`，Godot Editor 標題列與匯出的遊戲名稱都會同步顯示。

### 2. 重新命名 .csproj / .sln
Godot mono 版本會自動產生這兩個檔案供 C# 使用。將舊的 `新遊戲專案.csproj` / `新遊戲專案.sln` 刪除，建立 `RunningCat.csproj` / `RunningCat.sln`。

### 3. 更新 .sln 內部參照
`.sln` 內部有兩處寫死舊名稱：
- `Project(...) = "新遊戲專案"` → `"RunningCat"`
- `"新遊戲專案.csproj"` → `"RunningCat.csproj"`

## 變更檔案
- `project.godot` — 更新遊戲名稱
- `RunningCat.csproj` — 新增（取代舊檔）
- `RunningCat.sln` — 新增（取代舊檔，內部參照同步更新）