### PR TITLE
#5: 建立貓咪資料系統 OOP 架構

### DIFF
--- a/data/default/cats/milk_cat.json
+++ b/data/default/cats/milk_cat.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "id": "milk_cat",
+  "display_name": "牛奶貓",
+  "cat_type": "tank",
+  "base_stats": {
+    "max_hp": 1000,
+    "atk": 150,
+    "defense": 50,
+    "speed": 80.0,
+    "weight": 200.0
+  },
+  "passive_skills": [
+    "team_cooldown_reduction"
+  ],
+  "active_skills": [
+    {
+      "id": "shield_bash",
+      "initial_delay": 0,
+      "cooldown": 5.0
+    }
+  ]
+}

--- a/data/default/skills/active/shield_bash.json
+++ b/data/default/skills/active/shield_bash.json
@@ -1,0 +1,11 @@
+{
+  "id": "shield_bash",
+  "display_name": "盾擊",
+  "description": "猛力撞擊正前方敵人，造成 150% 攻擊力的額外傷害並增加對方硬直時間",
+  "skill_type": "active",
+  "icon_path": "",
+  "cooldown": 5.0,
+  "effect_type": "damage",
+  "effect_value": 1.5,
+  "target_scope": "enemy_front"
+}

--- a/data/default/skills/passive/team_cooldown_reduction.json
+++ b/data/default/skills/passive/team_cooldown_reduction.json
@@ -1,0 +1,15 @@
+{
+  "id": "team_cooldown_reduction",
+  "display_name": "鬥志沸騰",
+  "description": "提升全隊主動技能冷卻速度，使冷卻時間減少 10%",
+  "skill_type": "passive",
+  "icon_path": "",
+  "scope": "team",
+  "effects": [
+    {
+      "stat": "cooldown",
+      "modifier_type": "percent",
+      "value": -10
+    }
+  ]
+}

--- a/data/saves/player_cats/milk_cat.json
+++ b/data/saves/player_cats/milk_cat.json
@@ -1,0 +1,10 @@
+{
+  "cat_id": "milk_cat",
+  "level": 3,
+  "cat_food_fed": 120,
+  "cat_can_fed": 2,
+  "cat_shards": 5,
+  "active_skill_settings": [
+    { "skill_id": "shield_bash", "initial_delay": 2 }
+  ]
+}

--- a/scripts/cats/base_cat.gd
+++ b/scripts/cats/base_cat.gd
@@ -1,0 +1,130 @@
+class_name BaseCat
+extends CharacterBody2D
+
+## 所有貓咪的基底類別
+## 子類別透過 override 特定方法來客製化行為，不需修改此檔案
+
+# ── 信號 ──────────────────────────────────────────────
+signal died(cat: BaseCat)
+signal hp_changed(current: int, maximum: int)
+
+# ── 資料參照 ──────────────────────────────────────────
+var data: CatData
+var team: String = "player"      # "player" 或 "enemy"
+var facing_direction: int = 1    # 1=向右，-1=向左
+
+# ── 運行時狀態 ────────────────────────────────────────
+var current_hp: int = 0
+var is_staggered: bool = false
+var stagger_timer: float = 0.0
+var is_alive: bool = true
+
+## 主動技能運行狀態
+## 格式：[{ "skill": ActiveSkillData, "timer": float }]
+var _active_skill_states: Array = []
+
+
+# ── 初始化 ────────────────────────────────────────────
+
+func setup(cat_data: CatData, cat_team: String, skill_states: Array = []) -> void:
+	data = cat_data
+	team = cat_team
+	current_hp = data.max_hp
+	facing_direction = 1 if team == "player" else -1
+	_active_skill_states = skill_states
+
+
+# ── 主循環 ────────────────────────────────────────────
+
+func _physics_process(delta: float) -> void:
+	if not is_alive:
+		return
+	_process_stagger(delta)
+	_process_active_skills(delta)
+	if not is_staggered:
+		_move_forward(delta)
+
+
+## 每幀前進，子類別可 override（例如刺客加速）
+func _move_forward(delta: float) -> void:
+	velocity.x = data.speed * facing_direction
+	move_and_slide()
+
+
+func _process_stagger(delta: float) -> void:
+	if is_staggered:
+		stagger_timer -= delta
+		if stagger_timer <= 0.0:
+			is_staggered = false
+			stagger_timer = 0.0
+
+
+func _process_active_skills(delta: float) -> void:
+	for state: Dictionary in _active_skill_states:
+		state["timer"] -= delta
+		if state["timer"] <= 0.0:
+			_trigger_active_skill(state["skill"])
+			state["timer"] = state["skill"].cooldown
+
+
+## 發動主動技能，子類別 override 實作具體效果
+func _trigger_active_skill(_skill: ActiveSkillData) -> void:
+	pass
+
+
+# ── 戰鬥方法 ──────────────────────────────────────────
+
+## 受到傷害（ignore_def 為未來無視防禦屬性，預設 0）
+func take_damage(atk: float, ignore_def: float = 0.0) -> void:
+	if not is_alive:
+		return
+	var dmg: float = CatStats.calc_damage(atk, data.defense, ignore_def)
+	current_hp -= int(dmg)
+	emit_signal("hp_changed", current_hp, data.max_hp)
+	if current_hp <= 0:
+		_die()
+
+
+## 與敵方碰撞時呼叫，子類別可 override（例如防守貓加反彈傷害）
+func on_collision_with(other: BaseCat) -> void:
+	if is_staggered or not is_alive:
+		return
+	take_damage(other.data.atk)
+	var knockback: float = CatStats.calc_knockback_distance(other.data.weight, data.weight)
+	_apply_knockback(knockback)
+
+
+func _apply_knockback(distance: float) -> void:
+	is_staggered = true
+	stagger_timer = get_stagger_time()
+	position.x -= facing_direction * distance
+
+
+## 撞牆時呼叫，子類別可 override（例如坦克貓減少撞牆硬直）
+func on_wall_bounce() -> void:
+	is_staggered = true
+	stagger_timer = get_wall_stagger_time()
+	facing_direction *= -1
+
+
+# ── 硬直時間（子類別可 override 調整） ───────────────
+
+func get_stagger_time() -> float:
+	return CatStats.STAGGER_TIME
+
+
+func get_wall_stagger_time() -> float:
+	return CatStats.WALL_STAGGER_TIME
+
+
+# ── 死亡 ──────────────────────────────────────────────
+
+func _die() -> void:
+	is_alive = false
+	emit_signal("died", self)
+	_play_death_animation()
+
+
+## 死亡動畫：拋物線彈飛出畫面，子類別可 override 客製化
+func _play_death_animation() -> void:
+	queue_free()

--- a/scripts/cats/base_cat.gd.uid
+++ b/scripts/cats/base_cat.gd.uid
@@ -1,0 +1,1 @@
+uid://odwoiqbqnrr7

--- a/scripts/cats/types/assassin_cat.gd
+++ b/scripts/cats/types/assassin_cat.gd
@@ -1,0 +1,18 @@
+class_name AssassinCat
+extends BaseCat
+
+## 刺客貓：高 ATK & 高 Speed，先手衝刺
+
+const SPEED_MULTIPLIER: float = 1.2
+
+
+func _move_forward(delta: float) -> void:
+	velocity.x = data.speed * facing_direction * SPEED_MULTIPLIER
+	move_and_slide()
+
+
+func _trigger_active_skill(skill: ActiveSkillData) -> void:
+	match skill.effect_type:
+		"dash":
+			# 衝刺：瞬間加速衝向前排（戰鬥系統完成後實作）
+			pass

--- a/scripts/cats/types/assassin_cat.gd.uid
+++ b/scripts/cats/types/assassin_cat.gd.uid
@@ -1,0 +1,1 @@
+uid://b6x1ikjcxtgup

--- a/scripts/cats/types/bouncer_cat.gd
+++ b/scripts/cats/types/bouncer_cat.gd
@@ -1,0 +1,15 @@
+class_name BouncerCat
+extends BaseCat
+
+## 反彈貓：利用牆壁/敵人排列造成連鎖傷害
+
+func on_wall_bounce() -> void:
+	# 撞牆後不進入硬直，直接反彈回去繼續攻擊
+	facing_direction *= -1
+
+
+func _trigger_active_skill(skill: ActiveSkillData) -> void:
+	match skill.effect_type:
+		"chain_bounce":
+			# 連鎖反彈：依序傷害多個敵人（戰鬥系統完成後實作）
+			pass

--- a/scripts/cats/types/bouncer_cat.gd.uid
+++ b/scripts/cats/types/bouncer_cat.gd.uid
@@ -1,0 +1,1 @@
+uid://wdek7ukhyu61

--- a/scripts/cats/types/cute_cat.gd
+++ b/scripts/cats/types/cute_cat.gd
@@ -1,0 +1,10 @@
+class_name CuteCat
+extends BaseCat
+
+## 趣味萌寵貓：高 HP 低 ATK，趣味技能干擾敵人
+
+func _trigger_active_skill(skill: ActiveSkillData) -> void:
+	match skill.effect_type:
+		"bubble":
+			# 吐泡泡：干擾敵人移動（戰鬥系統完成後實作）
+			pass

--- a/scripts/cats/types/cute_cat.gd.uid
+++ b/scripts/cats/types/cute_cat.gd.uid
@@ -1,0 +1,1 @@
+uid://feskw3daeo00

--- a/scripts/cats/types/defensive_cat.gd
+++ b/scripts/cats/types/defensive_cat.gd
@@ -1,0 +1,19 @@
+class_name DefensiveCat
+extends BaseCat
+
+## 防守貓：高 DEF & 中 Weight，碰撞時反彈傷害給攻擊者
+
+const REFLECT_RATIO: float = 0.3  # 反彈 30% 傷害
+
+
+func on_collision_with(other: BaseCat) -> void:
+	if is_staggered or not is_alive:
+		return
+	# 先承受傷害
+	take_damage(other.data.atk)
+	# 反彈傷害給對方
+	var reflect_dmg: float = data.defense * REFLECT_RATIO
+	other.take_damage(reflect_dmg)
+	# 回彈
+	var knockback: float = CatStats.calc_knockback_distance(other.data.weight, data.weight)
+	_apply_knockback(knockback)

--- a/scripts/cats/types/defensive_cat.gd.uid
+++ b/scripts/cats/types/defensive_cat.gd.uid
@@ -1,0 +1,1 @@
+uid://csg6nxjexga2e

--- a/scripts/cats/types/elemental_cat.gd
+++ b/scripts/cats/types/elemental_cat.gd
@@ -1,0 +1,13 @@
+class_name ElementalCat
+extends BaseCat
+
+## 元素貓：附加火/水/木元素效果，利用相剋策略
+
+var element: String = "fire"  # "fire", "water", "wood"
+
+
+func _trigger_active_skill(skill: ActiveSkillData) -> void:
+	match skill.effect_type:
+		"element_burst":
+			# 元素爆發：附加元素狀態效果（戰鬥系統完成後實作）
+			pass

--- a/scripts/cats/types/elemental_cat.gd.uid
+++ b/scripts/cats/types/elemental_cat.gd.uid
@@ -1,0 +1,1 @@
+uid://cy6p10ae0fu3r

--- a/scripts/cats/types/flying_cat.gd
+++ b/scripts/cats/types/flying_cat.gd
@@ -1,0 +1,10 @@
+class_name FlyingCat
+extends BaseCat
+
+## 飛行貓：可跳過敵方前排，直接撞後排
+
+func _trigger_active_skill(skill: ActiveSkillData) -> void:
+	match skill.effect_type:
+		"jump":
+			# 跳躍：飛越前排，直接命中後排（戰鬥系統完成後實作）
+			pass

--- a/scripts/cats/types/flying_cat.gd.uid
+++ b/scripts/cats/types/flying_cat.gd.uid
@@ -1,0 +1,1 @@
+uid://ov73edy85dtm

--- a/scripts/cats/types/speed_cat.gd
+++ b/scripts/cats/types/speed_cat.gd
@@ -1,0 +1,18 @@
+class_name SpeedCat
+extends BaseCat
+
+## 高速貓：極高速度，先手衝撞，短距離穿透
+
+const SPEED_MULTIPLIER: float = 1.5
+
+
+func _move_forward(delta: float) -> void:
+	velocity.x = data.speed * facing_direction * SPEED_MULTIPLIER
+	move_and_slide()
+
+
+func _trigger_active_skill(skill: ActiveSkillData) -> void:
+	match skill.effect_type:
+		"penetrate":
+			# 穿透衝刺：短距離穿過前排（戰鬥系統完成後實作）
+			pass

--- a/scripts/cats/types/speed_cat.gd.uid
+++ b/scripts/cats/types/speed_cat.gd.uid
@@ -1,0 +1,1 @@
+uid://cntmebosnyy2j

--- a/scripts/cats/types/tank_cat.gd
+++ b/scripts/cats/types/tank_cat.gd
@@ -1,0 +1,15 @@
+class_name TankCat
+extends BaseCat
+
+## 坦克貓：高 HP & 高 Weight，撞牆硬直減少
+
+func get_wall_stagger_time() -> float:
+	# 撞牆硬直只有一般的一半
+	return CatStats.WALL_STAGGER_TIME * 0.5
+
+
+func _trigger_active_skill(skill: ActiveSkillData) -> void:
+	match skill.effect_type:
+		"damage":
+			# 盾擊：對前排敵人造成額外傷害（戰鬥系統完成後實作）
+			pass

--- a/scripts/cats/types/tank_cat.gd.uid
+++ b/scripts/cats/types/tank_cat.gd.uid
@@ -1,0 +1,1 @@
+uid://dr2ab3b1slo8b

--- a/scripts/data/active_skill_data.gd.uid
+++ b/scripts/data/active_skill_data.gd.uid
@@ -1,0 +1,1 @@
+uid://dibhrddgd6wyu

--- a/scripts/data/cat_data.gd.uid
+++ b/scripts/data/cat_data.gd.uid
@@ -1,0 +1,1 @@
+uid://ld65bynf12ce

--- a/scripts/data/cat_data_migrator.gd.uid
+++ b/scripts/data/cat_data_migrator.gd.uid
@@ -1,0 +1,1 @@
+uid://d20shuh4rsfq0

--- a/scripts/data/cat_stats.gd.uid
+++ b/scripts/data/cat_stats.gd.uid
@@ -1,0 +1,1 @@
+uid://bjenns2wiaps7

--- a/scripts/data/cats/cat_data.gd
+++ b/scripts/data/cats/cat_data.gd
@@ -1,0 +1,65 @@
+class_name CatData
+extends Resource
+
+## 貓咪資料容器，從 JSON 載入
+## 新增屬性只需在此加欄位並給預設值，舊 JSON 不會壞掉
+## 欄位改名只需在 CatDataMigrator.STAT_ALIASES 加一行 alias
+
+# ── 識別 ──────────────────────────────────────────────
+var id: String = ""
+var display_name: String = ""
+var cat_type: String = "base"  # 對應 CatRegistry 的類型鍵值
+
+# ── 基礎屬性（新增屬性在此加，並給預設值） ────────────
+var max_hp: int = 100
+var atk: int = 10
+var defense: int = 0
+var speed: float = 100.0
+var weight: float = 100.0
+# 未來可新增（不影響舊 JSON）：
+# var ignore_def: float = 0.0
+# var crit_rate: float = 0.0
+
+# ── 技能參照 ──────────────────────────────────────────
+var passive_skill_ids: Array = []
+## 格式：[{ "id": "shield_bash", "initial_delay": 0, "cooldown": 5.0 }]
+var active_skill_configs: Array = []
+
+
+## 從 JSON 檔案載入，自動執行 migration
+static func from_json_file(path: String) -> CatData:
+	if not FileAccess.file_exists(path):
+		push_error("CatData: 找不到檔案：" + path)
+		return null
+
+	var file := FileAccess.open(path, FileAccess.READ)
+	var json := JSON.new()
+	var err := json.parse(file.get_as_text())
+	file.close()
+
+	if err != OK:
+		push_error("CatData: JSON 解析失敗：" + path)
+		return null
+
+	var raw: Dictionary = json.get_data()
+	var migrated: Dictionary = CatDataMigrator.migrate(raw)
+	return _from_dict(migrated)
+
+
+static func _from_dict(data: Dictionary) -> CatData:
+	var cat := CatData.new()
+	cat.id = data.get("id", "")
+	cat.display_name = data.get("display_name", "")
+	cat.cat_type = data.get("cat_type", "base")
+
+	var stats: Dictionary = data.get("base_stats", {})
+	cat.max_hp = stats.get("max_hp", 100)
+	cat.atk = stats.get("atk", 10)
+	cat.defense = stats.get("defense", 0)
+	cat.speed = stats.get("speed", 100.0)
+	cat.weight = stats.get("weight", 100.0)
+
+	cat.passive_skill_ids = data.get("passive_skills", [])
+	cat.active_skill_configs = data.get("active_skills", [])
+
+	return cat

--- a/scripts/data/cats/cat_data_migrator.gd
+++ b/scripts/data/cats/cat_data_migrator.gd
@@ -1,0 +1,48 @@
+class_name CatDataMigrator
+extends RefCounted
+
+## 負責處理 JSON schema 版本升級與欄位改名
+## 未來若屬性改名，在這裡加入 alias，不需要動其他程式碼
+
+const CURRENT_VERSION: int = 1
+
+# 欄位別名對照表：若 JSON 使用舊名稱，自動對應到新名稱
+# 格式："舊欄位名" -> "新欄位名"
+# 範例：若日後把 atk 改名為 attack，在此加入 "atk": "attack"
+const STAT_ALIASES: Dictionary = {
+	# "atk": "attack",  # 範例（未啟用）
+}
+
+
+static func migrate(raw: Dictionary) -> Dictionary:
+	var data: Dictionary = raw.duplicate(true)
+
+	# 解析 base_stats 中的欄位別名
+	if data.has("base_stats"):
+		data["base_stats"] = _resolve_aliases(data["base_stats"], STAT_ALIASES)
+
+	# 依版本號執行升級
+	var version: int = data.get("schema_version", 0)
+	data = _migrate_to_current(data, version)
+	data["schema_version"] = CURRENT_VERSION
+
+	return data
+
+
+static func _resolve_aliases(stats: Dictionary, aliases: Dictionary) -> Dictionary:
+	var resolved: Dictionary = stats.duplicate()
+	for old_key: String in aliases:
+		var new_key: String = aliases[old_key]
+		# 若 JSON 有舊欄位且沒有新欄位，自動轉換
+		if resolved.has(old_key) and not resolved.has(new_key):
+			resolved[new_key] = resolved[old_key]
+			resolved.erase(old_key)
+	return resolved
+
+
+static func _migrate_to_current(data: Dictionary, from_version: int) -> Dictionary:
+	## 每個版本升級在這裡加一個 if 區塊
+	## 範例：
+	# if from_version < 1:
+	#     data = _migrate_v0_to_v1(data)
+	return data

--- a/scripts/data/cats/cat_stats.gd
+++ b/scripts/data/cats/cat_stats.gd
@@ -1,0 +1,37 @@
+class_name CatStats
+extends RefCounted
+
+## 純計算層，所有數值公式集中在這裡
+## 不依賴任何場景節點，方便快速戰鬥模擬使用
+
+# 回彈距離上下限
+const MIN_KNOCKBACK: float = 30.0
+const MAX_KNOCKBACK: float = 300.0
+
+# 硬直時間常數
+const STAGGER_TIME: float = 0.2
+const WALL_STAGGER_TIME: float = 0.3
+
+
+## DEF 減傷公式：DEF / (DEF + 100)
+## DEF=0 → 0%，DEF=100 → 50%，DEF=300 → 75%，永遠不會達到 100%
+static func calc_def_reduction(defense: float) -> float:
+	if defense <= 0.0:
+		return 0.0
+	return defense / (defense + 100.0)
+
+
+## 計算實際傷害
+## ignore_def：無視防禦數值（未來屬性），直接削弱對方有效 DEF
+static func calc_damage(atk: float, defense: float, ignore_def: float = 0.0) -> float:
+	var effective_def: float = maxf(0.0, defense - ignore_def)
+	var reduction: float = calc_def_reduction(effective_def)
+	return maxf(1.0, atk * (1.0 - reduction))
+
+
+## 計算回彈距離
+## 攻擊方較重 → 被攻擊方回彈較遠，有最小/最大限制
+static func calc_knockback_distance(attacker_weight: float, target_weight: float) -> float:
+	var weight_diff: float = attacker_weight - target_weight
+	var base_knockback: float = 100.0 + weight_diff * 0.5
+	return clampf(base_knockback, MIN_KNOCKBACK, MAX_KNOCKBACK)

--- a/scripts/data/cats/player_cat_data.gd
+++ b/scripts/data/cats/player_cat_data.gd
@@ -1,0 +1,47 @@
+class_name PlayerCatData
+extends Resource
+
+## 玩家的貓咪存檔模型（每位玩家各自一份）
+## 只記錄「玩家改變了什麼」，不重複存 default 的原始數值
+## 執行時搭配 CatData（default）合併計算出實際數值
+
+# ── 識別 ──────────────────────────────────────────────
+var cat_id: String = ""       # 對應 default/cats/{cat_id}.json
+var level: int = 1
+
+# ── 強化記錄（只存投入量，實際數值由公式計算）─────────
+var cat_food_fed: int = 0     # 投入乾糧總量 → 影響 HP / ATK / DEF
+var cat_can_fed: int = 0      # 投入罐頭總量 → 影響 Weight
+var cat_shards: int = 0       # 持有鬍鬚數量 → 升星/技能升級
+
+# ── 配置設定（出戰畫面設定，每次可調整）────────────────
+## 格式：[{ "skill_id": "shield_bash", "initial_delay": 0 }]
+var active_skill_settings: Array = []
+
+# ── 未來擴充（加欄位不影響舊存檔）──────────────────────
+# var star_level: int = 0
+# var equipped_item_ids: Array = []
+
+
+## 從 Dictionary 解析（對應 JSON 或 Firebase 讀取的資料）
+static func from_dict(data: Dictionary) -> PlayerCatData:
+	var p := PlayerCatData.new()
+	p.cat_id = data.get("cat_id", "")
+	p.level = data.get("level", 1)
+	p.cat_food_fed = data.get("cat_food_fed", 0)
+	p.cat_can_fed = data.get("cat_can_fed", 0)
+	p.cat_shards = data.get("cat_shards", 0)
+	p.active_skill_settings = data.get("active_skill_settings", [])
+	return p
+
+
+## 轉為 Dictionary（用於存檔到 JSON 或 Firebase）
+func to_dict() -> Dictionary:
+	return {
+		"cat_id": cat_id,
+		"level": level,
+		"cat_food_fed": cat_food_fed,
+		"cat_can_fed": cat_can_fed,
+		"cat_shards": cat_shards,
+		"active_skill_settings": active_skill_settings,
+	}

--- a/scripts/data/passive_skill_data.gd.uid
+++ b/scripts/data/passive_skill_data.gd.uid
@@ -1,0 +1,1 @@
+uid://ma1d6rhpp82d

--- a/scripts/data/skill_data.gd.uid
+++ b/scripts/data/skill_data.gd.uid
@@ -1,0 +1,1 @@
+uid://cxcga7asj1i3d

--- a/scripts/data/skills/active_skill_data.gd
+++ b/scripts/data/skills/active_skill_data.gd
@@ -1,0 +1,29 @@
+class_name ActiveSkillData
+extends SkillData
+
+## 主動技能資料
+## 每隔 cooldown 秒自動發動，玩家可設定首次發動時間（0~9 秒）
+
+var cooldown: float = 5.0
+var effect_type: String = ""   # "damage", "buff", "debuff", "knockback" ...
+var effect_value: float = 0.0
+# 作用目標："enemy_front"（敵方前排）、"team"（我方全體）、"self" 等
+var target_scope: String = "enemy_front"
+
+
+static func from_json_file(path: String) -> ActiveSkillData:
+	var data := _load_json(path)
+	if data.is_empty():
+		return null
+	return _from_dict(data)
+
+
+static func _from_dict(data: Dictionary) -> ActiveSkillData:
+	var skill := ActiveSkillData.new()
+	_fill_base(skill, data)
+	skill.skill_type = "active"
+	skill.cooldown = data.get("cooldown", 5.0)
+	skill.effect_type = data.get("effect_type", "")
+	skill.effect_value = data.get("effect_value", 0.0)
+	skill.target_scope = data.get("target_scope", "enemy_front")
+	return skill

--- a/scripts/data/skills/passive_skill_data.gd
+++ b/scripts/data/skills/passive_skill_data.gd
@@ -1,0 +1,29 @@
+class_name PassiveSkillData
+extends SkillData
+
+## 被動技能資料
+## 戰鬥開始即生效，可對全隊 buff 或對敵方 debuff
+
+# 作用範圍："team"（我方全體）或 "enemy"（敵方全體）
+var scope: String = "team"
+
+## effects 格式：
+## [{ "stat": "cooldown", "modifier_type": "percent", "value": -10 }]
+## modifier_type 可為 "flat"（固定值）或 "percent"（百分比）
+var effects: Array = []
+
+
+static func from_json_file(path: String) -> PassiveSkillData:
+	var data := _load_json(path)
+	if data.is_empty():
+		return null
+	return _from_dict(data)
+
+
+static func _from_dict(data: Dictionary) -> PassiveSkillData:
+	var skill := PassiveSkillData.new()
+	_fill_base(skill, data)
+	skill.skill_type = "passive"
+	skill.scope = data.get("scope", "team")
+	skill.effects = data.get("effects", [])
+	return skill

--- a/scripts/data/skills/skill_data.gd
+++ b/scripts/data/skills/skill_data.gd
@@ -1,0 +1,30 @@
+class_name SkillData
+extends Resource
+
+## 技能資料基底類別
+## PassiveSkillData 與 ActiveSkillData 皆繼承此類
+
+var id: String = ""
+var display_name: String = ""
+var description: String = ""
+var skill_type: String = ""  # "passive" or "active"
+var icon_path: String = ""
+
+
+static func _load_json(path: String) -> Dictionary:
+	if not FileAccess.file_exists(path):
+		push_error("SkillData: 找不到檔案：" + path)
+		return {}
+	var file := FileAccess.open(path, FileAccess.READ)
+	var json := JSON.new()
+	json.parse(file.get_as_text())
+	file.close()
+	return json.get_data()
+
+
+static func _fill_base(skill: SkillData, data: Dictionary) -> void:
+	skill.id = data.get("id", "")
+	skill.display_name = data.get("display_name", "")
+	skill.description = data.get("description", "")
+	skill.skill_type = data.get("skill_type", "")
+	skill.icon_path = data.get("icon_path", "")

--- a/scripts/managers/cat_registry.gd
+++ b/scripts/managers/cat_registry.gd
@@ -1,0 +1,41 @@
+class_name CatRegistry
+extends Node
+
+## 貓咪註冊中心
+## 新增貓咪類型只需在 _type_map 加一行，不需改其他程式碼
+## 新增貓咪角色只需新增 JSON 檔案
+
+const CAT_DATA_PATH: String = "res://data/default/cats/"
+
+## 類型對照表：cat_type 字串 → GDScript 類別
+## 新增特殊型只需在此加入一行
+var _type_map: Dictionary = {
+	"tank":      TankCat,
+	"assassin":  AssassinCat,
+	"defensive": DefensiveCat,
+	"flying":    FlyingCat,
+	"elemental": ElementalCat,
+	"cute":      CuteCat,
+	"speed":     SpeedCat,
+	"bouncer":   BouncerCat,
+	"base":      BaseCat,  # fallback
+}
+
+
+## 建立貓咪節點，自動依 cat_type 選擇對應子類別
+func create_cat(cat_id: String, team: String, skill_states: Array = []) -> BaseCat:
+	var path: String = CAT_DATA_PATH + cat_id + ".json"
+	var data := CatData.from_json_file(path)
+	if data == null:
+		push_error("CatRegistry: 無法載入貓咪：" + cat_id)
+		return null
+
+	var CatClass = _type_map.get(data.cat_type, BaseCat)
+	var cat: BaseCat = CatClass.new()
+	cat.setup(data, team, skill_states)
+	return cat
+
+
+## 動態註冊新類型，不需修改 _type_map（例如 plugin 系統用）
+func register_type(type_name: String, cat_class) -> void:
+	_type_map[type_name] = cat_class

--- a/scripts/managers/cat_registry.gd.uid
+++ b/scripts/managers/cat_registry.gd.uid
@@ -1,0 +1,1 @@
+uid://cgv2yn26462rr

--- a/scripts/managers/skill_registry.gd
+++ b/scripts/managers/skill_registry.gd
@@ -1,0 +1,48 @@
+class_name SkillRegistry
+extends Node
+
+## 技能註冊中心，啟動時自動掃描並載入所有技能 JSON
+
+const PASSIVE_PATH: String = "res://data/default/skills/passive/"
+const ACTIVE_PATH: String = "res://data/default/skills/active/"
+
+var _passive_skills: Dictionary = {}
+var _active_skills: Dictionary = {}
+
+
+func _ready() -> void:
+	_load_all_skills()
+
+
+func _load_all_skills() -> void:
+	_load_from_dir(PASSIVE_PATH, "passive")
+	_load_from_dir(ACTIVE_PATH, "active")
+
+
+func _load_from_dir(path: String, skill_type: String) -> void:
+	var dir := DirAccess.open(path)
+	if dir == null:
+		push_warning("SkillRegistry: 資料夾不存在：" + path)
+		return
+	dir.list_dir_begin()
+	var file_name: String = dir.get_next()
+	while file_name != "":
+		if file_name.ends_with(".json"):
+			var full_path: String = path + file_name
+			if skill_type == "passive":
+				var skill := PassiveSkillData.from_json_file(full_path)
+				if skill:
+					_passive_skills[skill.id] = skill
+			else:
+				var skill := ActiveSkillData.from_json_file(full_path)
+				if skill:
+					_active_skills[skill.id] = skill
+		file_name = dir.get_next()
+
+
+func get_passive(skill_id: String) -> PassiveSkillData:
+	return _passive_skills.get(skill_id, null)
+
+
+func get_active(skill_id: String) -> ActiveSkillData:
+	return _active_skills.get(skill_id, null)

--- a/scripts/managers/skill_registry.gd.uid
+++ b/scripts/managers/skill_registry.gd.uid
@@ -1,0 +1,1 @@
+uid://diqbyq302p8ag


### PR DESCRIPTION
## 關聯 Issue
Closes #5

## 架構概覽

```
scripts/
  data/
    cats/   → CatData、PlayerCatData、CatStats、CatDataMigrator
    skills/ → SkillData、PassiveSkillData、ActiveSkillData
  cats/
    base_cat.gd        → 行為基底
    types/             → 8 種職業子類別
  managers/
    cat_registry.gd    → 依 cat_type 建立對應子類別
    skill_registry.gd  → 自動掃描載入所有技能 JSON
data/
  default/ → 遊戲設計師模板（所有人共用）
  saves/   → 玩家個人存檔（未來 Firebase）
```

## 彈性設計說明

### 新增屬性（如 ignore_def）
在 `CatData` 加一行並給預設值，舊 JSON 自動使用預設值，不會壞掉。

### 屬性改名（如 atk → attack）
在 `CatDataMigrator.STAT_ALIASES` 加一行 alias，新舊 JSON 皆可讀。

### 新增貓咪角色
只需在 `data/default/cats/` 新增 JSON，零程式碼。

### 新增貓咪類型（如 special）
建立 `scripts/cats/types/special_cat.gd` 繼承 `BaseCat`，在 `CatRegistry._type_map` 加一行。

## 數值公式（集中於 CatStats）
- 傷害：`ATK * (1 - DEF/(DEF+100))`，最低傷害 = 1
- 回彈：`clamp(100 + weight_diff * 0.5, 30, 300)`
- 硬直：碰撞 0.2s，撞牆 0.3s

## 子類別設計原則
子類別只 override 有差異的方法，其餘繼承 BaseCat：
- `TankCat`：撞牆硬直減半
- `AssassinCat`：移動速度 x1.2
- `DefensiveCat`：碰撞時附加反彈傷害
- `BouncerCat`：撞牆後不進入硬直直接反彈