### PR TITLE
bug #51: 修正 Client 登入 bootstrap、session 持久化與登出流程

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ Thumbs.db
 # Runtime client config
 config/runtime_config.json
 config/runtime_config.local.json
+data/saves/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,4 +7,5 @@
 - Keep Godot client changes in GDScript and follow existing scene/script patterns already used in this project.
 - Prefer adding small, explicit UI state transitions instead of rewriting whole scene flows when only one stage changes.
 - Runtime API config is environment-specific: CI generates `config/runtime_config.json`, while local development may override with ignored `config/runtime_config.local.json`.
+- Persistent local runtime data such as login session and player save files must use `user://`, not `res://`.
 - When new stable project-specific constraints are discovered during work, record them here so future changes stay consistent.

--- a/docs/gdd/11_account.md
+++ b/docs/gdd/11_account.md
@@ -15,7 +15,10 @@
 3. 按下 `登入` 時，前端呼叫 `/api/auth/login` 驗證帳號密碼。
 4. 按下 `註冊` 後切換成註冊模式，補顯示名稱與再次輸入密碼欄位。
 5. 註冊模式送出時，前端呼叫 `/api/auth/register` 建立帳號。
-6. 成功後保存 token 與 API base URL，接著進入遊戲主流程。
+6. 成功後先保存 token 與 API base URL，接著呼叫 `/api/auth/bootstrap` 取得玩家核心資料。
+7. bootstrap 成功後，把登入 session 與玩家核心資料寫入 `user://` 本地存檔，再進入遊戲主流程。
+8. Client 重啟時若本地仍有 session，會先嘗試自動恢復登入；若 access token 過期，會用 refresh token 更新後再重新抓 bootstrap。
+9. 玩家從 `ConfigScene` 登出時，Client 會優先呼叫 `/api/auth/revoke` 撤銷目前 refresh token；若 access token 已過期，會先 refresh 再 revoke，最後清除本地 `user://auth_session.json` 與玩家存檔。
 
 ## Runtime API 設定
 

--- a/scripts/DialogManager.gd
+++ b/scripts/DialogManager.gd
@@ -92,7 +92,7 @@ func _build(
 		)
 	else:
 		# Confirm 框：overlay 不可點擊關閉
-		overlay.mouse_filter = Control.MOUSE_FILTER_IGNORE
+		overlay.mouse_filter = Control.MOUSE_FILTER_STOP
 
 	var center := CenterContainer.new()
 	center.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)

--- a/scripts/GameState.gd
+++ b/scripts/GameState.gd
@@ -1,5 +1,12 @@
 extends Node
 
+const AUTH_SESSION_PATH := "user://auth_session.json"
+const PLAYER_DATA_PATH := PlayerData.SAVE_PATH
+const LEGACY_PLAYER_DATA_PATH := PlayerData.LEGACY_SAVE_PATH
+const LEGACY_PLAYER_DUNGEON_DATA_PATH := PlayerDungeonData.SAVE_PATH
+const LEGACY_PLAYER_ARENA_DATA_PATH := PlayerArenaData.SAVE_PATH
+const LEGACY_PLAYER_CAT_DIR_PATH := PlayerCatData.SAVE_DIR
+
 var api_base_url: String = ""
 var auth_session: Dictionary = {}
 
@@ -15,11 +22,152 @@ var _player_cat_cache: Dictionary = {}
 func set_auth_session(base_url: String, session: Dictionary) -> void:
 	api_base_url = base_url
 	auth_session = session.duplicate(true)
+	_save_auth_session()
 
 
 func clear_auth_session() -> void:
 	api_base_url = ""
 	auth_session = {}
+	_delete_auth_session_file()
+
+
+func clear_persisted_player_state() -> void:
+	_delete_file_if_exists(PLAYER_DATA_PATH)
+	_delete_file_if_exists(LEGACY_PLAYER_DATA_PATH)
+	_delete_file_if_exists(LEGACY_PLAYER_DUNGEON_DATA_PATH)
+	_delete_file_if_exists(LEGACY_PLAYER_ARENA_DATA_PATH)
+	_delete_files_in_directory(LEGACY_PLAYER_CAT_DIR_PATH)
+
+	player_data = PlayerData.new()
+	_player_cat_cache = {}
+	player_team = ["milk_cat", "milk_cat", "milk_cat"]
+	skill_delays = {}
+	current_global_stage = 1
+	boss_available = false
+	dungeon_battle_id = ""
+	dungeon_battle_level = 1
+	dungeon_data = PlayerDungeonData.new()
+	arena_data = PlayerArenaData.new()
+	arena_opponent = {}
+
+
+func clear_auth_and_player_state() -> void:
+	clear_auth_session()
+	clear_persisted_player_state()
+
+
+func load_persisted_auth_session() -> bool:
+	if not FileAccess.file_exists(AUTH_SESSION_PATH):
+		return false
+
+	var file := FileAccess.open(AUTH_SESSION_PATH, FileAccess.READ)
+	if file == null:
+		return false
+
+	var content := file.get_as_text()
+	file.close()
+
+	var json := JSON.new()
+	if json.parse(content) != OK:
+		return false
+
+	var data: Variant = json.get_data()
+	if not (data is Dictionary):
+		return false
+
+	var payload: Dictionary = data
+	var session_variant: Variant = payload.get("session", {})
+	if not (session_variant is Dictionary):
+		return false
+
+	var persisted_base_url := String(payload.get("api_base_url", "")).strip_edges()
+	if persisted_base_url == "":
+		return false
+
+	var session: Dictionary = session_variant if session_variant is Dictionary else {}
+	api_base_url = persisted_base_url
+	auth_session = session.duplicate(true)
+	return not auth_session.is_empty()
+
+
+func get_access_token() -> String:
+	return String(auth_session.get("accessToken", "")).strip_edges()
+
+
+func get_refresh_token() -> String:
+	return String(auth_session.get("refreshToken", "")).strip_edges()
+
+
+func apply_player_bootstrap(data: Dictionary) -> void:
+	if player_data == null:
+		player_data = PlayerData.load_or_default()
+
+	player_data.account = String(data.get("account", player_data.account))
+	player_data.display_name = String(data.get("displayName", player_data.display_name))
+	player_data.player_public_id = String(data.get("playerPublicId", player_data.player_public_id))
+	player_data.player_name = String(data.get("playerName", player_data.player_name))
+	player_data.cat_food = int(data.get("catFood", player_data.cat_food))
+	player_data.special_cat_food = int(data.get("specialCatFood", player_data.special_cat_food))
+	player_data.gold = int(data.get("gold", player_data.gold))
+	player_data.diamonds = int(data.get("diamonds", player_data.diamonds))
+	player_data.trap_points = int(data.get("trapPoints", player_data.trap_points))
+	player_data.trap_cages = int(data.get("trapCages", player_data.trap_cages))
+	player_data.whisker_shards = int(data.get("whiskerShards", player_data.whisker_shards))
+	player_data.last_quit_time = int(data.get("lastQuitTimeUnixSeconds", player_data.last_quit_time))
+	player_data.poop_count = int(data.get("poopCount", player_data.poop_count))
+	player_data.memory_shards = int(data.get("memoryShards", player_data.memory_shards))
+	player_data.scooper_level = int(data.get("scooperLevel", player_data.scooper_level))
+	player_data.scooper_exp = int(data.get("scooperExp", player_data.scooper_exp))
+	player_data.total_pulls = int(data.get("totalPulls", player_data.total_pulls))
+	player_data.free_pull_count = int(data.get("freePullCount", player_data.free_pull_count))
+	player_data.last_free_pull_date = String(data.get("lastFreePullDate", player_data.last_free_pull_date))
+	player_data.current_stage = int(data.get("currentStage", player_data.current_stage))
+	current_global_stage = player_data.current_stage
+	player_data.save()
+
+
+func _save_auth_session() -> void:
+	var file := FileAccess.open(AUTH_SESSION_PATH, FileAccess.WRITE)
+	if file == null:
+		return
+
+	file.store_string(JSON.stringify({
+		"api_base_url": api_base_url,
+		"session": auth_session,
+	}, "\t"))
+	file.close()
+
+
+func _delete_auth_session_file() -> void:
+	_delete_file_if_exists(AUTH_SESSION_PATH)
+
+
+func _delete_file_if_exists(path: String) -> void:
+	if not FileAccess.file_exists(path):
+		return
+
+	var absolute_path := ProjectSettings.globalize_path(path)
+	DirAccess.remove_absolute(absolute_path)
+
+
+func _delete_files_in_directory(path: String) -> void:
+	var absolute_path := ProjectSettings.globalize_path(path)
+	if not DirAccess.dir_exists_absolute(absolute_path):
+		return
+
+	var directory := DirAccess.open(path)
+	if directory == null:
+		return
+
+	directory.list_dir_begin()
+	while true:
+		var entry_name := directory.get_next()
+		if entry_name == "":
+			break
+		if entry_name == "." or entry_name == ".." or directory.current_is_dir():
+			continue
+		directory.remove(entry_name)
+	directory.list_dir_end()
 
 ## 目前擁有的貓咪 ID 列表（從 player_data 讀取）
 func get_owned_cats() -> Array:

--- a/scripts/StartScene.gd
+++ b/scripts/StartScene.gd
@@ -10,6 +10,11 @@ const LOCAL_CONFIG_PATH := "res://config/runtime_config.local.json"
 const DEVICE_ID_PATH := "user://device_id.txt"
 const DEFAULT_ENVIRONMENT := "Local"
 const DEFAULT_API_BASE_URL := "http://localhost:5000/api"
+const REQUEST_KIND_AUTH := "auth"
+const REQUEST_KIND_BOOTSTRAP := "bootstrap"
+const REQUEST_KIND_REFRESH := "refresh"
+const REQUEST_KIND_LOGOUT_REVOKE := "logout_revoke"
+const REQUEST_KIND_LOGOUT_REFRESH := "logout_refresh"
 
 enum AuthMode
 {
@@ -20,6 +25,7 @@ enum AuthMode
 var _api_base_url := DEFAULT_API_BASE_URL
 var _device_id := ""
 var _request_in_flight := false
+var _request_kind := ""
 var _input_ready := false
 var _loading_track_fill_width := 0.0
 var _http_request: HTTPRequest
@@ -33,6 +39,7 @@ var _loading_label: Label
 var _loading_percent_label: Label
 var _paw_row: HBoxContainer
 var _tap_hint: Label
+var _logout_button: Button
 
 var _form_title: Label
 var _display_name_input: LineEdit
@@ -42,6 +49,8 @@ var _confirm_password_input: LineEdit
 var _primary_button: Button
 var _secondary_button: Button
 var _status_label: Label
+var _logout_revoke_retry := false
+var _logout_dialog_open := false
 
 
 func _ready() -> void:
@@ -52,6 +61,10 @@ func _ready() -> void:
 	_attach_http_request()
 	_play_idle_animation()
 	_apply_mode()
+	if GameState.load_persisted_auth_session():
+		_api_base_url = GameState.api_base_url
+		_sync_logout_button_visibility()
+		_begin_authenticated_bootstrap("正在恢復登入...")
 
 
 func _build_ui() -> void:
@@ -96,6 +109,10 @@ func _build_ui() -> void:
 	_tap_hint = _build_tap_hint()
 	_tap_hint.visible = false
 	layout.add_child(_tap_hint)
+
+	_logout_button = _build_logout_button()
+	layout.add_child(_logout_button)
+	_sync_logout_button_visibility()
 
 
 func _build_title_block() -> PanelContainer:
@@ -300,6 +317,24 @@ func _build_tap_hint() -> Label:
 	return hint
 
 
+func _build_logout_button() -> Button:
+	var button := Button.new()
+	button.text = "登出"
+	button.anchor_left = 1.0
+	button.anchor_top = 0.0
+	button.anchor_right = 1.0
+	button.anchor_bottom = 0.0
+	button.position = Vector2(-140, 28)
+	button.custom_minimum_size = Vector2(112, 48)
+	button.visible = false
+	button.mouse_filter = Control.MOUSE_FILTER_STOP
+	button.add_theme_stylebox_override("normal", _make_button_stylebox(Color("d4b593"), 10))
+	button.add_theme_stylebox_override("hover", _make_button_stylebox(Color("ddc19f"), 10))
+	button.add_theme_stylebox_override("pressed", _make_button_stylebox(Color("c59f78"), 8))
+	button.pressed.connect(_on_logout_pressed)
+	return button
+
+
 func _build_paw_row() -> HBoxContainer:
 	var row := HBoxContainer.new()
 	row.alignment = BoxContainer.ALIGNMENT_CENTER
@@ -404,6 +439,7 @@ func _submit_login() -> void:
 		return
 
 	_request_in_flight = true
+	_request_kind = REQUEST_KIND_AUTH
 	_set_auth_interactable(false)
 	_set_status("\u6b63\u5728\u8207\u4f3a\u670d\u5668\u9023\u7dda...", false)
 
@@ -446,6 +482,7 @@ func _submit_register() -> void:
 		return
 
 	_request_in_flight = true
+	_request_kind = REQUEST_KIND_AUTH
 	_set_auth_interactable(false)
 	_set_status("\u6b63\u5728\u8207\u4f3a\u670d\u5668\u9023\u7dda...", false)
 
@@ -470,6 +507,8 @@ func _submit_register() -> void:
 
 func _on_request_completed(_result: int, response_code: int, _headers: PackedStringArray, body: PackedByteArray) -> void:
 	_request_in_flight = false
+	var completed_request_kind := _request_kind
+	_request_kind = ""
 	_set_auth_interactable(true)
 
 	var response_text := body.get_string_from_utf8()
@@ -487,16 +526,125 @@ func _on_request_completed(_result: int, response_code: int, _headers: PackedStr
 	var error_payload: Dictionary = error_variant if error_variant is Dictionary else {}
 
 	if response_code >= 200 and response_code < 300 and success:
+		if completed_request_kind == REQUEST_KIND_AUTH or completed_request_kind == REQUEST_KIND_REFRESH:
+			GameState.set_auth_session(_api_base_url, data)
+			_api_base_url = GameState.api_base_url
+			_sync_logout_button_visibility()
+			_begin_authenticated_bootstrap("正在同步玩家資料...")
+			return
+		if completed_request_kind == REQUEST_KIND_BOOTSTRAP:
+			GameState.apply_player_bootstrap(data)
+			_show_loading_state()
+			return
+		if completed_request_kind == REQUEST_KIND_LOGOUT_REFRESH:
+			GameState.set_auth_session(GameState.api_base_url, data)
+			_sync_logout_button_visibility()
+			_begin_logout_revoke()
+			return
+		if completed_request_kind == REQUEST_KIND_LOGOUT_REVOKE:
+			_finalize_logout()
+			return
 		GameState.set_auth_session(_api_base_url, data)
+		_sync_logout_button_visibility()
 		_show_loading_state()
+		return
+
+	if completed_request_kind == REQUEST_KIND_BOOTSTRAP and response_code == 401 and GameState.get_refresh_token() != "":
+		_begin_refresh_then_bootstrap()
+		return
+
+	if completed_request_kind == REQUEST_KIND_REFRESH:
+		GameState.clear_auth_session()
+		_api_base_url = _resolve_api_base_url()
+		_sync_logout_button_visibility()
+		_set_status("登入已過期，請重新登入。", true)
+		return
+
+	if completed_request_kind == REQUEST_KIND_LOGOUT_REVOKE:
+		if response_code == 404:
+			_finalize_logout()
+			return
+		if response_code == 401 and not _logout_revoke_retry and GameState.get_refresh_token() != "":
+			_begin_logout_refresh()
+			return
+		var logout_message := String(error_payload.get("message", "登出失敗，請稍後再試。"))
+		_set_logout_button_state(true)
+		_set_status(logout_message, true)
+		return
+
+	if completed_request_kind == REQUEST_KIND_LOGOUT_REFRESH:
+		if response_code == 401 or response_code == 404:
+			_finalize_logout()
+			return
+		var logout_refresh_message := String(error_payload.get("message", "更新登入狀態失敗，請稍後再試。"))
+		_set_logout_button_state(true)
+		_set_status(logout_refresh_message, true)
 		return
 
 	var message := String(error_payload.get("message", "\u767b\u5165\u5931\u6557\uff0c\u8acb\u7a0d\u5f8c\u518d\u8a66\u3002"))
 	_set_status(message, true)
 
 
+func _begin_authenticated_bootstrap(status_message: String) -> void:
+	if _request_in_flight:
+		return
+
+	var access_token := GameState.get_access_token()
+	if access_token == "":
+		GameState.clear_auth_session()
+		_set_status("登入資訊遺失，請重新登入。", true)
+		return
+
+	_request_in_flight = true
+	_request_kind = REQUEST_KIND_BOOTSTRAP
+	_set_auth_interactable(false)
+	_set_status(status_message, false)
+
+	var headers := PackedStringArray([
+		"Accept: application/json",
+		"Authorization: Bearer %s" % access_token
+	])
+	var error := _http_request.request("%s/auth/bootstrap" % _api_base_url, headers, HTTPClient.METHOD_GET)
+	if error != OK:
+		_request_in_flight = false
+		_request_kind = ""
+		_set_auth_interactable(true)
+		_set_status("無法同步玩家資料，錯誤碼: %s" % error, true)
+
+
+func _begin_refresh_then_bootstrap() -> void:
+	if _request_in_flight:
+		return
+
+	var refresh_token := GameState.get_refresh_token()
+	if refresh_token == "":
+		GameState.clear_auth_session()
+		_set_status("登入已過期，請重新登入。", true)
+		return
+
+	_request_in_flight = true
+	_request_kind = REQUEST_KIND_REFRESH
+	_set_auth_interactable(false)
+	_set_status("正在更新登入資訊...", false)
+
+	var headers := PackedStringArray([
+		"Content-Type: application/json",
+		"Accept: application/json"
+	])
+	var body := JSON.stringify({
+		"refreshToken": refresh_token
+	})
+	var error := _http_request.request("%s/auth/refresh" % _api_base_url, headers, HTTPClient.METHOD_POST, body)
+	if error != OK:
+		_request_in_flight = false
+		_request_kind = ""
+		_set_auth_interactable(true)
+		_set_status("無法更新登入資訊，錯誤碼: %s" % error, true)
+
+
 func _show_loading_state() -> void:
 	_input_ready = false
+	_sync_logout_button_visibility()
 	_set_status("", false)
 	if _auth_block != null:
 		_auth_block.visible = false
@@ -528,6 +676,7 @@ func _start_fake_loading() -> void:
 
 func _finish_fake_loading() -> void:
 	_input_ready = true
+	_sync_logout_button_visibility()
 	if _loading_label != null:
 		_loading_label.text = "\u8c93\u54aa\u968a\u4f0d\u96c6\u5408\u5b8c\u7562"
 	if _loading_percent_label != null:
@@ -563,10 +712,16 @@ func _start_game() -> void:
 func _input(event: InputEvent) -> void:
 	if not _input_ready:
 		return
+	if _logout_dialog_open:
+		return
 
 	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+		if _is_event_on_logout_button(event.position):
+			return
 		_start_game()
 	elif event is InputEventScreenTouch and event.pressed:
+		if _is_event_on_logout_button(event.position):
+			return
 		_start_game()
 
 
@@ -575,6 +730,135 @@ func _set_status(message: String, is_error: bool) -> void:
 		return
 	_status_label.text = message
 	_status_label.add_theme_color_override("font_color", Color("7d2f2f") if is_error else Color("46613d"))
+
+
+func _sync_logout_button_visibility() -> void:
+	if _logout_button == null:
+		return
+	_logout_button.visible = _input_ready and not GameState.auth_session.is_empty()
+
+
+func _is_event_on_logout_button(event_position: Vector2) -> bool:
+	if _logout_button == null or not _logout_button.visible:
+		return false
+	return _logout_button.get_global_rect().has_point(event_position)
+
+
+func _set_logout_button_state(enabled: bool, button_text: String = "登出") -> void:
+	if _logout_button == null:
+		return
+	_logout_button.disabled = not enabled
+	_logout_button.text = button_text
+
+
+func _on_logout_pressed() -> void:
+	if _request_in_flight:
+		return
+
+	DialogManager.show_confirm(
+		"登出",
+		"確定要登出目前帳號嗎？系統會撤銷 refresh token，並清除本機登入與玩家資料。",
+		Callable(self, "_begin_logout")
+	)
+
+
+func _begin_logout() -> void:
+	_logout_revoke_retry = false
+	_begin_logout_revoke()
+
+
+func _begin_logout_revoke() -> void:
+	var refresh_token := GameState.get_refresh_token()
+	if refresh_token == "":
+		_finalize_logout()
+		return
+
+	var access_token := GameState.get_access_token()
+	if access_token == "":
+		_begin_logout_refresh()
+		return
+
+	_request_in_flight = true
+	_request_kind = REQUEST_KIND_LOGOUT_REVOKE
+	_set_auth_interactable(false)
+	_set_logout_button_state(false, "登出中...")
+	_set_status("正在登出...", false)
+
+	var headers := PackedStringArray([
+		"Content-Type: application/json",
+		"Accept: application/json",
+		"Authorization: Bearer %s" % access_token
+	])
+	var body := JSON.stringify({
+		"refreshToken": refresh_token,
+		"reason": "Player logout from client."
+	})
+	var error := _http_request.request("%s/auth/revoke" % GameState.api_base_url, headers, HTTPClient.METHOD_POST, body)
+	if error != OK:
+		_request_in_flight = false
+		_request_kind = ""
+		_set_auth_interactable(true)
+		_set_logout_button_state(true)
+		_set_status("無法送出登出請求，錯誤碼: %s" % error, true)
+
+
+func _begin_logout_refresh() -> void:
+	var refresh_token := GameState.get_refresh_token()
+	if refresh_token == "":
+		_finalize_logout()
+		return
+
+	_logout_revoke_retry = true
+	_request_in_flight = true
+	_request_kind = REQUEST_KIND_LOGOUT_REFRESH
+	_set_auth_interactable(false)
+	_set_logout_button_state(false, "更新中...")
+	_set_status("正在更新登入狀態...", false)
+
+	var headers := PackedStringArray([
+		"Content-Type: application/json",
+		"Accept: application/json"
+	])
+	var body := JSON.stringify({
+		"refreshToken": refresh_token
+	})
+	var error := _http_request.request("%s/auth/refresh" % GameState.api_base_url, headers, HTTPClient.METHOD_POST, body)
+	if error != OK:
+		_request_in_flight = false
+		_request_kind = ""
+		_set_auth_interactable(true)
+		_set_logout_button_state(true)
+		_set_status("無法更新登入狀態，錯誤碼: %s" % error, true)
+
+
+func _finalize_logout() -> void:
+	_logout_dialog_open = false
+	GameState.clear_auth_and_player_state()
+	_api_base_url = _resolve_api_base_url()
+	_request_in_flight = false
+	_request_kind = ""
+	_input_ready = false
+	_set_auth_interactable(true)
+	_set_logout_button_state(true)
+	_sync_logout_button_visibility()
+	_mode = AuthMode.LOGIN
+	_apply_mode()
+	if _auth_block != null:
+		_auth_block.visible = true
+	if _loading_block != null:
+		_loading_block.visible = false
+		_loading_block.modulate.a = 1.0
+	if _tap_hint != null:
+		_tap_hint.visible = false
+	if _loading_fill != null:
+		_loading_fill.size.x = 0.0
+	if _loading_percent_label != null:
+		_loading_percent_label.text = "0%"
+	_account_input.text = ""
+	_password_input.text = ""
+	_confirm_password_input.text = ""
+	_display_name_input.text = ""
+	_set_status("已登出。", false)
 
 
 func _resolve_api_base_url() -> String:

--- a/scripts/data/cats/player_cat_data.gd
+++ b/scripts/data/cats/player_cat_data.gd
@@ -5,6 +5,8 @@ extends Resource
 ## 只記錄「玩家改變了什麼」，不重複存 default 的原始數值
 ## 執行時搭配 CatData（default）合併計算出實際數值
 
+# TODO(auth-persistence-migration): Move player cat saves to `user://` with legacy fallback + one-time migration.
+# Remove this marker after the `res://` save path has been retired.
 const SAVE_DIR: String = "res://data/saves/player_cats/"
 const MAX_CAT_FOOD_LEVEL: int = 30
 

--- a/scripts/data/player_arena_data.gd
+++ b/scripts/data/player_arena_data.gd
@@ -4,6 +4,8 @@ extends Resource
 ## 玩家競技場存檔
 ## 對應 data/saves/player_arena.json
 
+# TODO(auth-persistence-migration): Move arena save persistence to `user://` with legacy fallback + one-time migration.
+# Remove this marker after the `res://` save path has been retired.
 const SAVE_PATH: String = "res://data/saves/player_arena.json"
 const ARENA_DATA_PATH: String = "res://data/arena/arena_data.json"
 

--- a/scripts/data/player_data.gd
+++ b/scripts/data/player_data.gd
@@ -4,7 +4,8 @@ extends Resource
 ## 玩家全域資源存檔
 ## 新增欄位只需加上預設值，舊存檔讀取時不會壞掉
 
-const SAVE_PATH: String = "res://data/saves/player_data.json"
+const SAVE_PATH: String = "user://player_data.json"
+const LEGACY_SAVE_PATH: String = "res://data/saves/player_data.json"
 
 # ── 資源 ──────────────────────────────────────────────
 var cat_food: int = 0
@@ -14,6 +15,10 @@ var diamonds: int = 0
 var trap_points: int = 0         # 誘捕點數，用於商店兌換
 var trap_cages: int = 0          # 誘捕籠道具（消耗品，可存放後手動使用）
 var whisker_shards: int = 0      # 通用鬍鬚（地下城獎勵等來源）
+var account: String = ""
+var display_name: String = ""
+var player_public_id: String = ""
+var player_name: String = ""
 
 # ── 誘捕籠 ────────────────────────────────────────────
 var total_pulls: int = 0          # 累計誘捕次數，決定誘捕技術等級
@@ -88,9 +93,10 @@ static func _today_string() -> String:
 # ── 載入 ───────────────────────────────────────────────
 
 static func load_or_default() -> PlayerData:
-	if not FileAccess.file_exists(SAVE_PATH):
+	var load_path := SAVE_PATH if FileAccess.file_exists(SAVE_PATH) else LEGACY_SAVE_PATH
+	if not FileAccess.file_exists(load_path):
 		return PlayerData.new()
-	var file := FileAccess.open(SAVE_PATH, FileAccess.READ)
+	var file := FileAccess.open(load_path, FileAccess.READ)
 	var json := JSON.new()
 	if json.parse(file.get_as_text()) != OK:
 		file.close()
@@ -102,6 +108,10 @@ static func load_or_default() -> PlayerData:
 
 static func _from_dict(data: Dictionary) -> PlayerData:
 	var p := PlayerData.new()
+	p.account           = data.get("account",           "")
+	p.display_name      = data.get("display_name",      "")
+	p.player_public_id  = data.get("player_public_id",  "")
+	p.player_name       = data.get("player_name",       "")
 	p.cat_food          = data.get("cat_food",          0)
 	p.special_cat_food  = data.get("special_cat_food",  0)
 	p.gold              = data.get("gold",              0)
@@ -147,6 +157,10 @@ func save() -> void:
 func _to_dict() -> Dictionary:
 	return {
 		"schema_version":     1,
+		"account":            account,
+		"display_name":       display_name,
+		"player_public_id":   player_public_id,
+		"player_name":        player_name,
 		"cat_food":           cat_food,
 		"special_cat_food":   special_cat_food,
 		"gold":               gold,

--- a/scripts/data/player_dungeon_data.gd
+++ b/scripts/data/player_dungeon_data.gd
@@ -4,6 +4,8 @@ extends Resource
 ## 玩家地下城進度存檔
 ## 新增地下城只需在 dungeon_config.json 中加入，舊存檔讀取時會自動補上預設值
 
+# TODO(auth-persistence-migration): Move dungeon save persistence to `user://` with legacy fallback + one-time migration.
+# Remove this marker after the `res://` save path has been retired.
 const SAVE_PATH: String = "res://data/saves/player_dungeons.json"
 
 ## 每個地下城的進度記錄


### PR DESCRIPTION
﻿## 摘要
- 補上登入後 `bootstrap` 同步流程，將玩家核心資料寫入 `user://`
- 補上本地 session 持久化與 Client 重啟自動恢復登入
- 在 `StartScene` 新增登出入口，並調整確認視窗輸入攔截
- 新增 `res://` 存檔遷移 TODO 標記與相關文件同步

## 驗證
- Godot headless 載入檢查通過
- 已在本機驗證登入、bootstrap 寫檔、自動恢復登入流程

## 追蹤
- Closes #51
