### PR TITLE
#bug53:修正登出確認視窗開啟時點擊穿透導致進入遊戲的問題

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -12,8 +12,13 @@ config_version=5
 
 config/name="RunningCat"
 run/main_scene="res://scenes/StartScene.tscn"
-config/features=PackedStringArray("4.6", "Forward Plus", "Mobile")
+config/features=PackedStringArray("4.6", "C#", "Forward Plus", "Mobile")
 config/icon="res://icon.svg"
+
+[autoload]
+
+GameState="*res://scripts/GameState.gd"
+DialogManager="*res://scripts/DialogManager.gd"
 
 [display]
 
@@ -21,18 +26,17 @@ window/size/viewport_width=720
 window/size/viewport_height=1280
 window/stretch/mode="canvas_items"
 
-[physics]
+[dotnet]
 
-3d/physics_engine="Jolt Physics"
+project/assembly_name="RunningCat"
 
 [gui]
 
 theme/custom="res://resources/default_theme.tres"
 
-[autoload]
+[physics]
 
-GameState="*res://scripts/GameState.gd"
-DialogManager="*res://scripts/DialogManager.gd"
+3d/physics_engine="Jolt Physics"
 
 [rendering]
 

--- a/scripts/StartScene.gd
+++ b/scripts/StartScene.gd
@@ -755,10 +755,12 @@ func _on_logout_pressed() -> void:
 	if _request_in_flight:
 		return
 
+	_logout_dialog_open = true
 	DialogManager.show_confirm(
 		"登出",
-		"確定要登出目前帳號嗎？系統會撤銷 refresh token，並清除本機登入與玩家資料。",
-		Callable(self, "_begin_logout")
+		"您確定要登出嗎？(請注意：若先前為遊客登入，此動作將導致資料無法被找回)",
+		Callable(self, "_begin_logout"),
+		func() -> void: _logout_dialog_open = false
 	)
 
 


### PR DESCRIPTION
## 關聯 Issue

Close #53

## 變更說明

修正登出二次確認視窗開啟時，點擊遮罩空白處會直接進入遊戲的 bug。

**根本原因：** `_on_logout_pressed` 未將 `_logout_dialog_open` 設為 `true`，導致 `_input` 防護條件失效。

**修正：**
- 開啟 confirm dialog 前設定 `_logout_dialog_open = true`
- 傳入 `on_cancel` callback，點擊「取消」時重設旗標為 `false`
- `project.godot` 加入 C# / dotnet 設定

## 測試方式

1. 已登入狀態進入登入頁面
2. 點擊「登出」開啟二次確認視窗
3. 點擊遮罩空白處 → 應無反應
4. 點擊「取消」→ 視窗關閉，停留在登入頁
5. 再次點擊「登出」→「確定」→ 正常登出流程