### PR TITLE
fix:修正地城畫面布林型別推斷錯誤

### DIFF
--- a/scripts/dungeon/DungeonSceneUI.gd
+++ b/scripts/dungeon/DungeonSceneUI.gd
@@ -99,19 +99,20 @@ static func refresh_panel(scene, dungeon_id: int) -> void:
 	ad_label.text = "今日可補票次數：%d" % ad_count
 
 	var ad_button: Button = entry["ad_button"]
-	var can_get_ad_ticket := ad_count > 0 and not scene._action_inflight
+	var action_inflight: bool = bool(scene._action_inflight)
+	var can_get_ad_ticket: bool = ad_count > 0 and not action_inflight
 	ad_button.disabled = not can_get_ad_ticket
 	ad_button.modulate = Color(1.0, 1.0, 1.0, 1.0) if can_get_ad_ticket else Color(0.5, 0.5, 0.5, 1.0)
 
 	var sweep_button: Button = entry["sweep_button"]
-	var can_sweep := max_floor > 0 and ticket_count > 0 and not scene._action_inflight
+	var can_sweep: bool = max_floor > 0 and ticket_count > 0 and not action_inflight
 	sweep_button.text = "掃蕩 Lv.%d" % max_floor if max_floor > 0 else "掃蕩"
 	sweep_button.disabled = not can_sweep
 	sweep_button.modulate = Color(1.0, 1.0, 1.0, 1.0) if can_sweep else Color(0.5, 0.5, 0.5, 1.0)
 
 	var challenge_button: Button = entry["challenge_button"]
 	var next_floor := max_floor + 1
-	var can_challenge := ticket_count > 0 and not scene._action_inflight
+	var can_challenge: bool = ticket_count > 0 and not action_inflight
 	challenge_button.text = "挑戰 Lv.%d" % next_floor
 	challenge_button.disabled = not can_challenge
 	challenge_button.modulate = Color(1.0, 1.0, 1.0, 1.0) if can_challenge else Color(0.5, 0.5, 0.5, 1.0)


### PR DESCRIPTION
﻿## 摘要
- 將地城畫面按鈕狀態判斷改為明確的布林型別
- 先將 `scene._action_inflight` 收斂為 `bool` 後再套用到各按鈕狀態
- 一併修正 `can_get_ad_ticket`、`can_sweep`、`can_challenge` 的型別宣告

## 測試
- 未在本機執行 Godot 編譯驗證
- 依據錯誤訊息與腳本型別規則修正

Closes #67
