### PR TITLE
fix:移除競技場與地下城本地 JSON 存檔依賴

### DIFF
--- a/docs/gdd/18_frontend_architecture.md
+++ b/docs/gdd/18_frontend_architecture.md
@@ -312,7 +312,7 @@ Important persisted paths used by frontend architecture:
 - `user://config/*.json`
 - `user://player_data/scooper/*.json`
 
-Other player save data is also persisted via `PlayerData`, `PlayerArenaData`, `PlayerDungeonData`, and per-cat save files.
+Player-specific runtime persistence should flow through `PlayerData`, per-cat save files, and `GameState` cache files under `user://`. Arena and dungeon overview state should not read from repo-local save JSON.
 
 Project rule: persistent local runtime data must use `user://`, not `res://`.
 

--- a/scripts/data/player_arena_data.gd
+++ b/scripts/data/player_arena_data.gd
@@ -1,11 +1,7 @@
 class_name PlayerArenaData
 extends Resource
 
-## 玩家競技場存檔
-## 對應 data/saves/player_arena.json
-
-# TODO(auth-persistence-migration): Move arena save persistence to `user://` with legacy fallback + one-time migration.
-# Remove this marker after the `res://` save path has been retired.
+# Legacy paths kept only for cleanup and compatibility markers.
 const SAVE_PATH: String = "res://data/saves/player_arena.json"
 const ARENA_DATA_PATH: String = "res://data/arena/arena_data.json"
 
@@ -13,49 +9,28 @@ const DAILY_FREE_TICKETS: int = 10
 const MAX_DAILY_PURCHASES: int = 5
 const TICKETS_PER_PURCHASE: int = 3
 
-# ── 玩家基本資料 ──────────────────────────────────────
 var player_id: String = ""
 var player_name: String = ""
-
-# ── 積分 ──────────────────────────────────────────────
 var score: int = 0
-
-# ── 競技券 ────────────────────────────────────────────
 var tickets: int = DAILY_FREE_TICKETS
-var daily_purchase_count: int = 0   # 今日已購買次數（每日重置）
-var last_reset_date: String = ""    # 上次每日重置（UTC+8，YYYY-MM-DD）
-
-# ── 連勝 / 連敗 ───────────────────────────────────────
+var daily_purchase_count: int = 0
+var last_reset_date: String = ""
 var win_streak: int = 0
 var loss_streak: int = 0
-
-# ── 段位獎勵 ──────────────────────────────────────────
-## 已領取的段位 key 列表，例如 ["bronze_3", "bronze_2"]
 var claimed_rank_rewards: Array = []
-
-# ── 賽季 ──────────────────────────────────────────────
-var season_end_date: String = ""    # 由 Config 設定，格式 YYYY-MM-DD
-
-# ── 防守快照 ───────────────────────────────────────────
-## 記錄設定防守隊伍當下的貓咪強化狀態，供對手戰鬥使用
-## 格式：{ cat_id: { "cat_food_level", "special_food_points", "rank" } }
+var season_end_date: String = ""
 var defense_snapshot: Dictionary = {}
 
 
-# ── 初始化 ────────────────────────────────────────────
-
-## 建立新玩家資料，生成唯一 player_id 與預設名稱
 static func create_new() -> PlayerArenaData:
 	var d := PlayerArenaData.new()
 	d.player_id = "player_" + str(randi() % 900000 + 100000)
-	d.player_name = "測試玩家" + str(randi() % 9000 + 1000)
+	d.player_name = "arena_player_" + str(randi() % 9000 + 1000)
 	d.score = 0
 	d.tickets = DAILY_FREE_TICKETS
 	d.last_reset_date = _today_utc8()
 	return d
 
-
-# ── 每日重置 ──────────────────────────────────────────
 
 func check_daily_reset() -> void:
 	var today := _today_utc8()
@@ -64,7 +39,6 @@ func check_daily_reset() -> void:
 	last_reset_date = today
 	tickets = DAILY_FREE_TICKETS
 	daily_purchase_count = 0
-	save()
 
 
 static func _today_utc8() -> String:
@@ -74,16 +48,13 @@ static func _today_utc8() -> String:
 	return "%04d-%02d-%02d" % [dict["year"], dict["month"], dict["day"]]
 
 
-# ── 競技券操作 ────────────────────────────────────────
-
 func consume_ticket() -> bool:
 	if tickets <= 0:
 		return false
 	tickets -= 1
 	return true
 
-## 購買競技券，費用由外部（Config）傳入
-## 回傳 false 若今日已達購買上限或鑽石不足
+
 func purchase_tickets(cost: int, player_data: PlayerData) -> bool:
 	if daily_purchase_count >= MAX_DAILY_PURCHASES:
 		return false
@@ -94,62 +65,58 @@ func purchase_tickets(cost: int, player_data: PlayerData) -> bool:
 	daily_purchase_count += 1
 	return true
 
+
 func get_next_purchase_cost(cost_table: Array) -> int:
 	if daily_purchase_count >= cost_table.size():
-		return -1  # 已達上限
+		return -1
 	return cost_table[daily_purchase_count]
+
 
 func can_purchase_more() -> bool:
 	return daily_purchase_count < MAX_DAILY_PURCHASES
 
 
-# ── 積分操作 ──────────────────────────────────────────
-
 func add_score(delta: int) -> void:
 	score = maxi(0, score + delta)
+
 
 func record_win() -> void:
 	win_streak += 1
 	loss_streak = 0
+
 
 func record_loss() -> void:
 	loss_streak += 1
 	win_streak = 0
 
 
-# ── 防守快照 ──────────────────────────────────────────
-
-## 更新防守隊伍快照（存檔配置時呼叫）
-## defense_team: Array[String]（cat_id 列表）
-## cat_cache: Dictionary（cat_id → PlayerCatData）
 func update_defense_snapshot(defense_team: Array, cat_cache: Dictionary) -> void:
 	defense_snapshot = {}
 	for cat_id: String in defense_team:
 		var pcat: PlayerCatData = cat_cache.get(cat_id)
 		if pcat == null:
-			defense_snapshot[cat_id] = { "cat_food_level": 1, "special_food_points": {"hp":0,"atk":0,"def":0}, "rank": 0 }
+			defense_snapshot[cat_id] = {
+				"cat_food_level": 1,
+				"special_food_points": {"hp": 0, "atk": 0, "def": 0},
+				"rank": 0,
+			}
 		else:
 			defense_snapshot[cat_id] = {
-				"cat_food_level":      pcat.cat_food_level,
+				"cat_food_level": pcat.cat_food_level,
 				"special_food_points": pcat.special_food_points.duplicate(),
-				"rank":                pcat.rank,
+				"rank": pcat.rank,
 			}
 
 
-# ── 段位獎勵 ──────────────────────────────────────────
-
 func has_claimed_reward(rank_key: String) -> bool:
 	return claimed_rank_rewards.has(rank_key)
+
 
 func claim_reward(rank_key: String) -> void:
 	if not has_claimed_reward(rank_key):
 		claimed_rank_rewards.append(rank_key)
 
 
-# ── 賽季重置 ──────────────────────────────────────────
-
-## 檢查賽季是否已結束，若是則執行重置
-## 應在遊戲啟動時呼叫
 func check_season_reset() -> bool:
 	if season_end_date.is_empty():
 		return false
@@ -159,121 +126,79 @@ func check_season_reset() -> bool:
 	_apply_season_reset()
 	return true
 
+
 func _apply_season_reset() -> void:
 	var old_score := score
-	# 依段位決定重置積分
-	if old_score >= 1200:         # 鑽石以上（含大師/菁英）
-		score = 1200              # 退回鑽石III
-	elif old_score >= 600:        # 金牌以上（含白金/鑽石）
-		score = 600               # 退回金牌III
-	elif old_score >= 300:        # 銀牌以上（含白金）
-		score = 300               # 退回銀牌III
-	else:                         # 銅牌
+	if old_score >= 1200:
+		score = 1200
+	elif old_score >= 600:
+		score = 600
+	elif old_score >= 300:
+		score = 300
+	else:
 		score = 0
-	# 重置段位獎勵（降段後可重新領取降段以下的獎勵）
 	claimed_rank_rewards = claimed_rank_rewards.filter(
 		func(key: String) -> bool:
 			return ArenaRankSystem.rank_key_to_min_score(key) >= score
 	)
 
 
-# ── 排行榜（arena_data.json）操作 ─────────────────────
-
-## 將本玩家積分寫入排行榜
 func flush_to_leaderboard() -> void:
-	var leaderboard := _load_leaderboard()
-	leaderboard[player_id] = { "score": score }
-	_save_leaderboard(leaderboard)
+	return
+
 
 static func _load_leaderboard() -> Dictionary:
-	if not FileAccess.file_exists(ARENA_DATA_PATH):
-		return {}
-	var file := FileAccess.open(ARENA_DATA_PATH, FileAccess.READ)
-	var json := JSON.new()
-	if json.parse(file.get_as_text()) != OK:
-		file.close()
-		return {}
-	file.close()
-	return json.get_data()
+	return {}
+
 
 static func _save_leaderboard(data: Dictionary) -> void:
-	var file := FileAccess.open(ARENA_DATA_PATH, FileAccess.WRITE)
-	if file == null:
-		push_error("PlayerArenaData: 無法寫入排行榜：" + ARENA_DATA_PATH)
-		return
-	file.store_string(JSON.stringify(data, "\t"))
-	file.close()
+	return
 
-## 取得排行榜（供 matchmaking 使用）
+
 static func load_leaderboard() -> Dictionary:
 	return _load_leaderboard()
 
 
-# ── 載入 ──────────────────────────────────────────────
-
 static func load_or_create() -> PlayerArenaData:
-	if not FileAccess.file_exists(SAVE_PATH):
-		var fresh := create_new()
-		fresh.save()
-		fresh.flush_to_leaderboard()
-		return fresh
-	var file := FileAccess.open(SAVE_PATH, FileAccess.READ)
-	var json := JSON.new()
-	if json.parse(file.get_as_text()) != OK:
-		file.close()
-		push_error("PlayerArenaData: 存檔解析失敗，重新建立")
-		var fresh := create_new()
-		fresh.save()
-		fresh.flush_to_leaderboard()
-		return fresh
-	file.close()
-	return _from_dict(json.get_data())
+	return PlayerArenaData.new()
 
 
 static func _from_dict(data: Dictionary) -> PlayerArenaData:
 	var d := PlayerArenaData.new()
-	d.player_id           = data.get("player_id",           "")
-	d.player_name         = data.get("player_name",         "")
-	d.score               = data.get("score",               0)
-	d.tickets             = data.get("tickets",             DAILY_FREE_TICKETS)
+	d.player_id = data.get("player_id", "")
+	d.player_name = data.get("player_name", "")
+	d.score = data.get("score", 0)
+	d.tickets = data.get("tickets", DAILY_FREE_TICKETS)
 	d.daily_purchase_count = data.get("daily_purchase_count", 0)
-	d.last_reset_date     = data.get("last_reset_date",     "")
-	d.win_streak          = data.get("win_streak",          0)
-	d.loss_streak         = data.get("loss_streak",         0)
+	d.last_reset_date = data.get("last_reset_date", "")
+	d.win_streak = data.get("win_streak", 0)
+	d.loss_streak = data.get("loss_streak", 0)
 	d.claimed_rank_rewards = data.get("claimed_rank_rewards", [])
-	d.season_end_date     = data.get("season_end_date",     "")
-	d.defense_snapshot    = data.get("defense_snapshot",    {})
-	# 若 player_id 為空（舊存檔），重新初始化
+	d.season_end_date = data.get("season_end_date", "")
+	d.defense_snapshot = data.get("defense_snapshot", {})
 	if d.player_id.is_empty():
 		d.player_id = "player_" + str(randi() % 900000 + 100000)
 	if d.player_name.is_empty():
-		d.player_name = "測試玩家" + str(randi() % 9000 + 1000)
+		d.player_name = "arena_player_" + str(randi() % 9000 + 1000)
 	return d
 
 
-# ── 儲存 ──────────────────────────────────────────────
-
 func save() -> void:
-	var file := FileAccess.open(SAVE_PATH, FileAccess.WRITE)
-	if file == null:
-		push_error("PlayerArenaData: 無法寫入存檔：" + SAVE_PATH)
-		return
-	file.store_string(JSON.stringify(_to_dict(), "\t"))
-	file.close()
+	return
 
 
 func _to_dict() -> Dictionary:
 	return {
-		"schema_version":       1,
-		"player_id":            player_id,
-		"player_name":          player_name,
-		"score":                score,
-		"tickets":              tickets,
+		"schema_version": 1,
+		"player_id": player_id,
+		"player_name": player_name,
+		"score": score,
+		"tickets": tickets,
 		"daily_purchase_count": daily_purchase_count,
-		"last_reset_date":      last_reset_date,
-		"win_streak":           win_streak,
-		"loss_streak":          loss_streak,
+		"last_reset_date": last_reset_date,
+		"win_streak": win_streak,
+		"loss_streak": loss_streak,
 		"claimed_rank_rewards": claimed_rank_rewards,
-		"season_end_date":      season_end_date,
-		"defense_snapshot":     defense_snapshot,
+		"season_end_date": season_end_date,
+		"defense_snapshot": defense_snapshot,
 	}

--- a/scripts/data/player_dungeon_data.gd
+++ b/scripts/data/player_dungeon_data.gd
@@ -1,39 +1,21 @@
 class_name PlayerDungeonData
 extends Resource
 
-## 玩家地下城進度存檔
-## 新增地下城只需在 dungeon_config.json 中加入，舊存檔讀取時會自動補上預設值
-
-# TODO(auth-persistence-migration): Move dungeon save persistence to `user://` with legacy fallback + one-time migration.
-# Remove this marker after the `res://` save path has been retired.
+# Legacy path kept only so GameState can clean up older files.
 const SAVE_PATH: String = "res://data/saves/player_dungeons.json"
 
-## 每個地下城的進度記錄
-## key: dungeon_id (String)
-## value: {
-##   "max_level": int,      最高通關關卡
-##   "tickets": int,        當前卷數（每日重置為 daily_free_tickets）
-##   "ad_views_used": int,  今日已看廣告次數（每日重置為 0）
-## }
 var dungeons: Dictionary = {}
-
-## 上次每日重置的日期（UTC+8，YYYY-MM-DD）
 var last_reset_date: String = ""
 
 
-# ── 每日重置 ───────────────────────────────────
-
-## 檢查並執行每日重置（UTC+8 午夜）
-## 應在遊戲啟動時呼叫一次，需傳入 daily_free_tickets 作為重置後的卷數基準
 func check_daily_reset(daily_free: int) -> void:
 	var today := _today_utc8()
 	if last_reset_date == today:
 		return
 	last_reset_date = today
 	for key: String in dungeons:
-		dungeons[key]["tickets"]       = daily_free
+		dungeons[key]["tickets"] = daily_free
 		dungeons[key]["ad_views_used"] = 0
-	save()
 
 
 static func _today_utc8() -> String:
@@ -43,31 +25,25 @@ static func _today_utc8() -> String:
 	return "%04d-%02d-%02d" % [dict["year"], dict["month"], dict["day"]]
 
 
-# ── 進度查詢 ───────────────────────────────────
-
-## 取得指定地下城的進度（找不到時自動建立預設值）
 func get_dungeon(dungeon_id: String, daily_free: int = 2) -> Dictionary:
 	if not dungeons.has(dungeon_id):
 		dungeons[dungeon_id] = {
-			"max_level":    0,
-			"tickets":      daily_free,
+			"max_level": 0,
+			"tickets": daily_free,
 			"ad_views_used": 0,
 		}
 	return dungeons[dungeon_id]
 
 
-## 當前卷數
 func get_tickets(dungeon_id: String, daily_free: int) -> int:
 	return get_dungeon(dungeon_id, daily_free).get("tickets", daily_free)
 
 
-## 今日剩餘可看廣告次數
 func get_ad_views_remaining(dungeon_id: String, ad_per_type: int) -> int:
 	var d: Dictionary = get_dungeon(dungeon_id)
 	return maxi(0, ad_per_type - d.get("ad_views_used", 0))
 
 
-## 消耗一張卷（回傳 false 若無卷）
 func consume_ticket(dungeon_id: String, daily_free: int) -> bool:
 	var d: Dictionary = get_dungeon(dungeon_id, daily_free)
 	if d.get("tickets", 0) <= 0:
@@ -76,17 +52,15 @@ func consume_ticket(dungeon_id: String, daily_free: int) -> bool:
 	return true
 
 
-## 看廣告後獲得一張卷（回傳 false 若已達今日上限）
 func grant_ad_ticket(dungeon_id: String, ad_per_type: int, daily_free: int) -> bool:
 	if get_ad_views_remaining(dungeon_id, ad_per_type) <= 0:
 		return false
 	var d: Dictionary = get_dungeon(dungeon_id, daily_free)
 	d["ad_views_used"] = d.get("ad_views_used", 0) + 1
-	d["tickets"]       = d.get("tickets", 0) + 1
+	d["tickets"] = d.get("tickets", 0) + 1
 	return true
 
 
-## 計算指定地下城在指定關卡的獎勵
 static func calculate_rewards(dungeon_cfg: Dictionary, level: int) -> Dictionary:
 	var r: Dictionary = dungeon_cfg.get("rewards", {})
 	var rewards: Dictionary = {}
@@ -114,35 +88,22 @@ static func calculate_rewards(dungeon_cfg: Dictionary, level: int) -> Dictionary
 	return rewards
 
 
-## 將獎勵套用至 PlayerData
 static func apply_rewards(pd: PlayerData, rewards: Dictionary) -> void:
-	pd.cat_food         += rewards.get("cat_food",         0)
+	pd.cat_food += rewards.get("cat_food", 0)
 	pd.special_cat_food += rewards.get("special_cat_food", 0)
-	pd.diamonds         += rewards.get("diamonds",         0)
-	pd.trap_cages       += rewards.get("trap_cages",       0)
-	pd.whisker_shards   += rewards.get("whisker_shards",   0)
+	pd.diamonds += rewards.get("diamonds", 0)
+	pd.trap_cages += rewards.get("trap_cages", 0)
+	pd.whisker_shards += rewards.get("whisker_shards", 0)
 
 
-## 更新最高通關關卡（僅在新紀錄時更新）
 func update_max_level(dungeon_id: String, level: int) -> void:
 	var d: Dictionary = get_dungeon(dungeon_id)
 	if level > d.get("max_level", 0):
 		d["max_level"] = level
 
 
-# ── 載入 ───────────────────────────────────────
-
 static func load_or_default() -> PlayerDungeonData:
-	if not FileAccess.file_exists(SAVE_PATH):
-		return PlayerDungeonData.new()
-	var file := FileAccess.open(SAVE_PATH, FileAccess.READ)
-	var json := JSON.new()
-	if json.parse(file.get_as_text()) != OK:
-		file.close()
-		push_error("PlayerDungeonData: 存檔解析失敗，使用預設值")
-		return PlayerDungeonData.new()
-	file.close()
-	return _from_dict(json.get_data())
+	return PlayerDungeonData.new()
 
 
 static func _from_dict(data: Dictionary) -> PlayerDungeonData:
@@ -152,27 +113,20 @@ static func _from_dict(data: Dictionary) -> PlayerDungeonData:
 	for key: String in saved:
 		var entry: Dictionary = saved[key]
 		pd.dungeons[key] = {
-			"max_level":    entry.get("max_level",    0),
-			"tickets":      entry.get("tickets",      2),
+			"max_level": entry.get("max_level", 0),
+			"tickets": entry.get("tickets", 2),
 			"ad_views_used": entry.get("ad_views_used", 0),
 		}
 	return pd
 
 
-# ── 儲存 ───────────────────────────────────────
-
 func save() -> void:
-	var file := FileAccess.open(SAVE_PATH, FileAccess.WRITE)
-	if file == null:
-		push_error("PlayerDungeonData: 無法寫入存檔：" + SAVE_PATH)
-		return
-	file.store_string(JSON.stringify(_to_dict(), "\t"))
-	file.close()
+	return
 
 
 func _to_dict() -> Dictionary:
 	return {
 		"schema_version": 1,
 		"last_reset_date": last_reset_date,
-		"dungeons":        dungeons,
+		"dungeons": dungeons,
 	}

--- a/scripts/gamestate/GameState.gd
+++ b/scripts/gamestate/GameState.gd
@@ -73,6 +73,11 @@ func clear_auth_and_player_state() -> void:
 	clear_persisted_player_state()
 
 
+func _cleanup_legacy_runtime_save_files() -> void:
+	FileUtils.delete_file_if_exists(LEGACY_PLAYER_DUNGEON_DATA_PATH)
+	FileUtils.delete_file_if_exists(LEGACY_PLAYER_ARENA_DATA_PATH)
+
+
 func load_persisted_auth_session() -> bool:
 	if not FileAccess.file_exists(AUTH_SESSION_PATH):
 		return false
@@ -318,20 +323,18 @@ var shop_data: Dictionary = {}
 
 
 func _ready() -> void:
+	_cleanup_legacy_runtime_save_files()
 	player_data = PlayerData.load_or_default()
 	current_global_stage = player_data.current_stage
 	dungeon_config = FileUtils.load_json("res://data/default/dungeon_config.json")
 	boss_config = FileUtils.load_json("res://data/default/boss_config.json")
-	dungeon_data = PlayerDungeonData.load_or_default()
-	dungeon_data.check_daily_reset(int(dungeon_config.get("daily_free_tickets", 2)))
+	dungeon_data = PlayerDungeonData.new()
 	update_dungeon_overview(_load_dungeon_cache_array())
 	for cat_id: String in player_data.owned_cat_ids:
 		_player_cat_cache[cat_id] = PlayerCatData.load_or_default(cat_id)
 	arena_config = FileUtils.load_json("res://data/default/arena_config.json")
-	arena_data = PlayerArenaData.load_or_create()
+	arena_data = PlayerArenaData.new()
 	arena_data.season_end_date = arena_config.get("season_end_date", arena_data.season_end_date)
-	arena_data.check_daily_reset()
-	arena_data.check_season_reset()
 	arena_overview_data = CacheIO.load_config_dict("arena")
 	if not player_data.boss_team.is_empty():
 		player_team = player_data.boss_team.duplicate()
@@ -643,9 +646,6 @@ func get_player_cat(cat_id: String) -> PlayerCatData:
 func save_all() -> void:
 	player_data.current_stage = current_global_stage
 	player_data.save()
-	dungeon_data.save()
-	arena_data.save()
-	arena_data.flush_to_leaderboard()
 	for cat_id: String in _player_cat_cache:
 		_player_cat_cache[cat_id].save()
 


### PR DESCRIPTION
## 變更摘要
- 移除 arena 與 dungeon 執行期對 es://data/saves/*.json 的載入與回寫
- 啟動時清理舊的競技場與地下城 legacy 存檔
- 保留 legacy path 常數僅供清理用途
- 更新前端架構文件，說明 arena/dungeon overview 應只依賴 bootstrap/API 與 user:// cache

## 驗證
- 重新掃描主專案後，PlayerArenaData 與 PlayerDungeonData 已無本地 JSON 讀寫邏輯
- GameState 主流程已不再呼叫 arena/dungeon 的本地存檔載入與儲存
- 未執行 Godot 實機測試

Closes #78