### PR TITLE
fix:修正客戶端載入提示與啟動畫面讀條流程

### DIFF
--- a/scripts/ApiClient.gd
+++ b/scripts/ApiClient.gd
@@ -1,16 +1,24 @@
 extends Node
 
-## 統一 HTTP API 客戶端 autoload，供各場景呼叫後端 Scooper API。
-## 使用 HTTPRequest 節點池支援並行請求，內建 401 自動 refresh token 重試。
-
 const POOL_SIZE := 3
 const REQUEST_TIMEOUT := 15.0
+const LOADING_LAYER := 90
+const DEFAULT_LOADING_MESSAGE := "loading."
 
 var _pool: Array[HTTPRequest] = []
 var _busy: Array[bool] = []
 var _pending_queue: Array[Dictionary] = []
 var _refreshing := false
 var _refresh_queue: Array[Dictionary] = []
+
+var _loading_canvas: CanvasLayer
+var _loading_message_label: Label
+var _loading_spinner: Control
+var _spinner_dots: Array[Control] = []
+var _loading_request_count := 0
+var _spinner_time := 0.0
+var _loading_text_phase := 0
+var _loading_text_elapsed := 0.0
 
 
 func _ready() -> void:
@@ -22,8 +30,31 @@ func _ready() -> void:
 		_pool.append(http)
 		_busy.append(false)
 
+	_build_loading_overlay()
+	set_process(false)
 
-# ── Public convenience methods ───────────────────────────────
+
+func _process(delta: float) -> void:
+	if _loading_request_count <= 0 or _loading_spinner == null:
+		return
+
+	_spinner_time += delta * 2.8
+	_loading_text_elapsed += delta
+	_loading_spinner.rotation = _spinner_time
+
+	for i in range(_spinner_dots.size()):
+		var dot := _spinner_dots[i]
+		if dot == null:
+			continue
+		var pulse: float = maxf(0.0, sin(_spinner_time * 2.0 - float(i) * 0.65))
+		var alpha: float = 0.35 + 0.65 * pulse
+		dot.modulate.a = alpha
+
+	if _loading_text_elapsed >= 0.28:
+		_loading_text_elapsed = 0.0
+		_loading_text_phase = (_loading_text_phase + 1) % 3
+		_update_loading_label()
+
 
 func get_scooper_profile(callback: Callable) -> void:
 	_api_get("scooper/profile", callback)
@@ -76,8 +107,6 @@ func get_achievements(callback: Callable) -> void:
 func claim_achievement(achievement_id: int, callback: Callable) -> void:
 	_api_post("scooper/achievement/claim", {"achievementId": achievement_id}, callback)
 
-
-# ── Config / Team API ────────────────────────────────────────
 
 func get_teams(callback: Callable) -> void:
 	_api_get("config/teams", callback)
@@ -181,7 +210,13 @@ func reset_cat_enhance(player_cat_id: int, callback: Callable) -> void:
 	_api_post("enhance/%d/reset" % player_cat_id, {}, callback)
 
 
-# ── Core request methods ─────────────────────────────────────
+func retain_loading_overlay(_message: String = DEFAULT_LOADING_MESSAGE) -> void:
+	_retain_loading_overlay()
+
+
+func release_loading_overlay() -> void:
+	_release_loading_overlay()
+
 
 func _api_get(path: String, callback: Callable) -> void:
 	_enqueue_request(path, HTTPClient.METHOD_GET, {}, callback)
@@ -203,12 +238,16 @@ func _api_patch(path: String, body: Dictionary, callback: Callable) -> void:
 	_enqueue_request(path, HTTPClient.METHOD_PATCH, body, callback)
 
 
-func _enqueue_request(path: String, method: int, body: Dictionary, callback: Callable) -> void:
+func _enqueue_request(path: String, method: int, body: Dictionary, callback: Callable, track_loading: bool = true) -> void:
+	if track_loading:
+		_retain_loading_overlay()
+
 	var entry := {
 		"path": path,
 		"method": method,
 		"body": body,
 		"callback": callback,
+		"track_loading": track_loading,
 	}
 
 	var slot := _find_free_slot()
@@ -229,10 +268,8 @@ func _dispatch(slot: int, entry: Dictionary) -> void:
 	_busy[slot] = true
 	_pool[slot].set_meta("entry", entry)
 
-	var base_url: String = GameState.api_base_url
-	var url := "%s/%s" % [base_url, entry["path"]]
+	var url := "%s/%s" % [GameState.api_base_url, entry["path"]]
 	var method: int = entry["method"]
-
 	var headers := PackedStringArray([
 		"Accept: application/json",
 		"Authorization: Bearer %s" % GameState.get_access_token(),
@@ -241,20 +278,23 @@ func _dispatch(slot: int, entry: Dictionary) -> void:
 	var has_body := method == HTTPClient.METHOD_POST \
 			or method == HTTPClient.METHOD_PUT \
 			or method == HTTPClient.METHOD_PATCH
+
+	var error := OK
 	if has_body:
 		headers.append("Content-Type: application/json")
-		var body_text := JSON.stringify(entry["body"])
-		var error := _pool[slot].request(url, headers, method, body_text)
-		if error != OK:
-			_busy[slot] = false
-			_invoke_callback(entry["callback"], false, {}, {"code": "HTTP.REQUEST_ERROR", "message": "無法送出請求，錯誤碼: %s" % error})
-			_flush_pending()
+		error = _pool[slot].request(url, headers, method, JSON.stringify(entry["body"]))
 	else:
-		var error := _pool[slot].request(url, headers, method)
-		if error != OK:
-			_busy[slot] = false
-			_invoke_callback(entry["callback"], false, {}, {"code": "HTTP.REQUEST_ERROR", "message": "無法送出請求，錯誤碼: %s" % error})
-			_flush_pending()
+		error = _pool[slot].request(url, headers, method)
+
+	if error != OK:
+		_busy[slot] = false
+		_pool[slot].remove_meta("entry")
+		_invoke_callback(entry["callback"], false, {}, {
+			"code": "HTTP.REQUEST_ERROR",
+			"message": "無法送出請求，錯誤碼: %s" % error,
+		})
+		_release_loading_overlay_if_tracked(entry)
+		_flush_pending()
 
 
 func _on_request_completed(_result: int, response_code: int, _headers: PackedStringArray, body: PackedByteArray, slot: int) -> void:
@@ -263,17 +303,25 @@ func _on_request_completed(_result: int, response_code: int, _headers: PackedStr
 	_busy[slot] = false
 
 	var callback: Callable = entry.get("callback", Callable())
-
 	var response_text := body.get_string_from_utf8()
 	var json := JSON.new()
+
 	if response_text == "" or json.parse(response_text) != OK:
-		_invoke_callback(callback, false, {}, {"code": "HTTP.PARSE_ERROR", "message": "伺服器回傳格式無法解析。"})
+		_invoke_callback(callback, false, {}, {
+			"code": "HTTP.PARSE_ERROR",
+			"message": "伺服器回傳格式無法解析。",
+		})
+		_release_loading_overlay_if_tracked(entry)
 		_flush_pending()
 		return
 
 	var payload: Variant = json.get_data()
 	if not (payload is Dictionary):
-		_invoke_callback(callback, false, {}, {"code": "HTTP.PARSE_ERROR", "message": "伺服器回傳格式無法解析。"})
+		_invoke_callback(callback, false, {}, {
+			"code": "HTTP.PARSE_ERROR",
+			"message": "伺服器回傳格式無法解析。",
+		})
+		_release_loading_overlay_if_tracked(entry)
 		_flush_pending()
 		return
 
@@ -284,10 +332,10 @@ func _on_request_completed(_result: int, response_code: int, _headers: PackedStr
 
 	if response_code >= 200 and response_code < 300 and success:
 		_invoke_callback(callback, true, data_variant, {})
+		_release_loading_overlay_if_tracked(entry)
 		_flush_pending()
 		return
 
-	# 401 → auto refresh token and retry
 	if response_code == 401 and GameState.get_refresh_token() != "":
 		_begin_refresh_and_retry(entry)
 		_flush_pending()
@@ -295,14 +343,12 @@ func _on_request_completed(_result: int, response_code: int, _headers: PackedStr
 
 	var error_dict: Dictionary = error_variant if error_variant is Dictionary else {}
 	_invoke_callback(callback, false, {}, error_dict)
+	_release_loading_overlay_if_tracked(entry)
 	_flush_pending()
 
 
-# ── Token refresh ────────────────────────────────────────────
-
 func _begin_refresh_and_retry(original_entry: Dictionary) -> void:
 	_refresh_queue.append(original_entry)
-
 	if _refreshing:
 		return
 
@@ -313,8 +359,7 @@ func _begin_refresh_and_retry(original_entry: Dictionary) -> void:
 	add_child(http)
 	http.request_completed.connect(_on_refresh_completed.bind(http))
 
-	var base_url: String = GameState.api_base_url
-	var url := "%s/auth/refresh" % base_url
+	var url := "%s/auth/refresh" % GameState.api_base_url
 	var headers := PackedStringArray([
 		"Content-Type: application/json",
 		"Accept: application/json",
@@ -343,17 +388,15 @@ func _on_refresh_completed(_result: int, response_code: int, _headers: PackedStr
 
 	var envelope: Dictionary = payload
 	var success := bool(envelope.get("success", false))
-
 	if response_code >= 200 and response_code < 300 and success:
 		var data_variant: Variant = envelope.get("data", {})
 		var data: Dictionary = data_variant if data_variant is Dictionary else {}
 		GameState.set_auth_session(GameState.api_base_url, data)
 
-		# Retry all queued requests
 		var queued := _refresh_queue.duplicate()
 		_refresh_queue.clear()
 		for entry: Dictionary in queued:
-			_enqueue_request(entry["path"], entry["method"], entry["body"], entry["callback"])
+			_enqueue_request(entry["path"], entry["method"], entry["body"], entry["callback"], false)
 		return
 
 	_on_refresh_failed()
@@ -365,13 +408,15 @@ func _on_refresh_failed() -> void:
 	_refresh_queue.clear()
 
 	for entry: Dictionary in queued:
-		_invoke_callback(entry.get("callback", Callable()), false, {}, {"code": "AUTH.SESSION_EXPIRED", "message": "登入已過期，請重新登入。"})
+		_invoke_callback(entry.get("callback", Callable()), false, {}, {
+			"code": "AUTH.SESSION_EXPIRED",
+			"message": "登入已過期，請重新登入。",
+		})
+		_release_loading_overlay_if_tracked(entry)
 
 	GameState.clear_auth_and_player_state()
 	get_tree().change_scene_to_file("res://scenes/StartScene.tscn")
 
-
-# ── Helpers ──────────────────────────────────────────────────
 
 func _invoke_callback(callback: Callable, success: bool, data: Variant, error: Dictionary) -> void:
 	if callback.is_valid():
@@ -385,3 +430,98 @@ func _flush_pending() -> void:
 			break
 		var entry: Dictionary = _pending_queue.pop_front()
 		_dispatch(slot, entry)
+
+
+func _release_loading_overlay_if_tracked(entry: Dictionary) -> void:
+	if bool(entry.get("track_loading", true)):
+		_release_loading_overlay()
+
+
+func _retain_loading_overlay() -> void:
+	_loading_request_count += 1
+	_ensure_loading_overlay()
+	_loading_text_phase = 0
+	_loading_text_elapsed = 0.0
+	_update_loading_label()
+	if _loading_canvas != null:
+		_loading_canvas.visible = true
+	set_process(true)
+
+
+func _release_loading_overlay() -> void:
+	_loading_request_count = max(_loading_request_count - 1, 0)
+	if _loading_request_count > 0:
+		return
+	if _loading_canvas != null:
+		_loading_canvas.visible = false
+	set_process(false)
+
+
+func _ensure_loading_overlay() -> void:
+	if _loading_canvas == null:
+		_build_loading_overlay()
+
+
+func _build_loading_overlay() -> void:
+	if _loading_canvas != null:
+		return
+
+	_loading_canvas = CanvasLayer.new()
+	_loading_canvas.layer = LOADING_LAYER
+	_loading_canvas.visible = false
+	add_child(_loading_canvas)
+
+	var overlay := ColorRect.new()
+	overlay.color = Color(0.0, 0.0, 0.0, 0.42)
+	overlay.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	overlay.mouse_filter = Control.MOUSE_FILTER_STOP
+	_loading_canvas.add_child(overlay)
+
+	var center := CenterContainer.new()
+	center.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	center.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_loading_canvas.add_child(center)
+
+	var content := VBoxContainer.new()
+	content.alignment = BoxContainer.ALIGNMENT_CENTER
+	content.add_theme_constant_override("separation", 14)
+	center.add_child(content)
+
+	_loading_spinner = Control.new()
+	_loading_spinner.custom_minimum_size = Vector2(84.0, 84.0)
+	_loading_spinner.pivot_offset = _loading_spinner.custom_minimum_size * 0.5
+	_loading_spinner.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	content.add_child(_loading_spinner)
+	_build_spinner_dots()
+
+	_loading_message_label = Label.new()
+	_loading_message_label.text = DEFAULT_LOADING_MESSAGE
+	_loading_message_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	_loading_message_label.add_theme_font_size_override("font_size", 24)
+	_loading_message_label.add_theme_color_override("font_color", Color("f7f1e7"))
+	content.add_child(_loading_message_label)
+
+
+func _build_spinner_dots() -> void:
+	_spinner_dots.clear()
+	if _loading_spinner == null:
+		return
+
+	var ring_center := _loading_spinner.custom_minimum_size * 0.5
+	var radius := 24.0
+	var dot_size := Vector2(12.0, 12.0)
+	for i in range(8):
+		var dot := ColorRect.new()
+		var angle := TAU * float(i) / 8.0
+		dot.color = Color("f7f1e7")
+		dot.size = dot_size
+		dot.position = ring_center + Vector2(cos(angle), sin(angle)) * radius - dot_size * 0.5
+		dot.mouse_filter = Control.MOUSE_FILTER_IGNORE
+		_loading_spinner.add_child(dot)
+		_spinner_dots.append(dot)
+
+
+func _update_loading_label() -> void:
+	if _loading_message_label == null:
+		return
+	_loading_message_label.text = "loading%s" % ".".repeat(_loading_text_phase + 1)

--- a/scripts/StartScene.gd
+++ b/scripts/StartScene.gd
@@ -51,6 +51,10 @@ var _secondary_button: Button
 var _status_label: Label
 var _logout_revoke_retry := false
 var _logout_dialog_open := false
+var _loading_fill_tween: Tween
+var _loading_percent_tween: Tween
+var _loading_animation_finished := false
+var _bootstrap_completed := false
 
 
 func _ready() -> void:
@@ -64,6 +68,7 @@ func _ready() -> void:
 	if GameState.load_persisted_auth_session():
 		_api_base_url = GameState.api_base_url
 		_sync_logout_button_visibility()
+		_show_loading_state()
 		_begin_authenticated_bootstrap("正在恢復登入...")
 
 
@@ -442,6 +447,7 @@ func _submit_login() -> void:
 	_request_kind = REQUEST_KIND_AUTH
 	_set_auth_interactable(false)
 	_set_status("\u6b63\u5728\u8207\u4f3a\u670d\u5668\u9023\u7dda...", false)
+	_retain_network_loading_overlay("\u6b63\u5728\u8207\u4f3a\u670d\u5668\u9023\u7dda...")
 
 	var headers := PackedStringArray([
 		"Content-Type: application/json",
@@ -485,6 +491,7 @@ func _submit_register() -> void:
 	_request_kind = REQUEST_KIND_AUTH
 	_set_auth_interactable(false)
 	_set_status("\u6b63\u5728\u8207\u4f3a\u670d\u5668\u9023\u7dda...", false)
+	_retain_network_loading_overlay("\u6b63\u5728\u8207\u4f3a\u670d\u5668\u9023\u7dda...")
 
 	var headers := PackedStringArray([
 		"Content-Type: application/json",
@@ -502,6 +509,7 @@ func _submit_register() -> void:
 	if error != OK:
 		_request_in_flight = false
 		_set_auth_interactable(true)
+		_release_network_loading_overlay()
 		_set_status("\u7121\u6cd5\u9001\u51fa\u8acb\u6c42\uff0c\u932f\u8aa4\u78bc: %s" % error, true)
 
 
@@ -530,11 +538,14 @@ func _on_request_completed(_result: int, response_code: int, _headers: PackedStr
 			GameState.set_auth_session(_api_base_url, data)
 			_api_base_url = GameState.api_base_url
 			_sync_logout_button_visibility()
+			if completed_request_kind == REQUEST_KIND_AUTH or _loading_block == null or not _loading_block.visible:
+				_show_loading_state()
 			_begin_authenticated_bootstrap("正在同步玩家資料...")
 			return
 		if completed_request_kind == REQUEST_KIND_BOOTSTRAP:
 			GameState.apply_player_bootstrap(data)
-			_show_loading_state()
+			_bootstrap_completed = true
+			_complete_loading_state()
 			return
 		if completed_request_kind == REQUEST_KIND_LOGOUT_REFRESH:
 			GameState.set_auth_session(GameState.api_base_url, data)
@@ -542,8 +553,10 @@ func _on_request_completed(_result: int, response_code: int, _headers: PackedStr
 			_begin_logout_revoke()
 			return
 		if completed_request_kind == REQUEST_KIND_LOGOUT_REVOKE:
+			_release_network_loading_overlay()
 			_finalize_logout()
 			return
+		_release_network_loading_overlay()
 		GameState.set_auth_session(_api_base_url, data)
 		_sync_logout_button_visibility()
 		_show_loading_state()
@@ -553,7 +566,14 @@ func _on_request_completed(_result: int, response_code: int, _headers: PackedStr
 		_begin_refresh_then_bootstrap()
 		return
 
+	if completed_request_kind == REQUEST_KIND_BOOTSTRAP:
+		_abort_loading_state()
+		var bootstrap_message := String(error_payload.get("message", "同步玩家資料失敗，請稍後再試。"))
+		_set_status(bootstrap_message, true)
+		return
+
 	if completed_request_kind == REQUEST_KIND_REFRESH:
+		_abort_loading_state()
 		GameState.clear_auth_session()
 		_api_base_url = _resolve_api_base_url()
 		_sync_logout_button_visibility()
@@ -562,11 +582,13 @@ func _on_request_completed(_result: int, response_code: int, _headers: PackedStr
 
 	if completed_request_kind == REQUEST_KIND_LOGOUT_REVOKE:
 		if response_code == 404:
+			_release_network_loading_overlay()
 			_finalize_logout()
 			return
 		if response_code == 401 and not _logout_revoke_retry and GameState.get_refresh_token() != "":
 			_begin_logout_refresh()
 			return
+		_release_network_loading_overlay()
 		var logout_message = error_payload.get("message") if error_payload.get("message") != null else "登出失敗，請稍後再試。"
 		_set_logout_button_state(true)
 		_set_status(logout_message, true)
@@ -574,14 +596,17 @@ func _on_request_completed(_result: int, response_code: int, _headers: PackedStr
 
 	if completed_request_kind == REQUEST_KIND_LOGOUT_REFRESH:
 		if response_code == 401 or response_code == 404:
+			_release_network_loading_overlay()
 			_finalize_logout()
 			return
+		_release_network_loading_overlay()
 		var logout_refresh_message = error_payload.get("message") if error_payload.get("message") != null else "更新登入狀態失敗，請稍後再試。"
 		_set_logout_button_state(true)
 		_set_status(logout_refresh_message, true)
 		return
 
 	var message = error_payload.get("message") if error_payload.get("message") != null else "登入失敗，請稍後再試。"
+	_release_network_loading_overlay()
 	_set_status(message, true)
 
 
@@ -609,6 +634,8 @@ func _begin_authenticated_bootstrap(status_message: String) -> void:
 		_request_in_flight = false
 		_request_kind = ""
 		_set_auth_interactable(true)
+		_abort_loading_state()
+		_release_network_loading_overlay()
 		_set_status("無法同步玩家資料，錯誤碼: %s" % error, true)
 
 
@@ -625,6 +652,7 @@ func _begin_refresh_then_bootstrap() -> void:
 	_request_in_flight = true
 	_request_kind = REQUEST_KIND_REFRESH
 	_set_auth_interactable(false)
+	_retain_network_loading_overlay("資料同步中...")
 	_set_status("正在更新登入資訊...", false)
 
 	var headers := PackedStringArray([
@@ -639,11 +667,16 @@ func _begin_refresh_then_bootstrap() -> void:
 		_request_in_flight = false
 		_request_kind = ""
 		_set_auth_interactable(true)
+		_abort_loading_state()
+		_release_network_loading_overlay()
 		_set_status("無法更新登入資訊，錯誤碼: %s" % error, true)
 
 
 func _show_loading_state() -> void:
 	_input_ready = false
+	_bootstrap_completed = false
+	_loading_animation_finished = false
+	_cancel_loading_tweens()
 	_sync_logout_button_visibility()
 	_set_status("", false)
 	if _auth_block != null:
@@ -666,17 +699,31 @@ func _start_fake_loading() -> void:
 	if _loading_fill == null:
 		return
 
-	var tween := create_tween()
-	tween.tween_property(_loading_fill, "size:x", _loading_track_fill_width, 2.0).set_trans(Tween.TRANS_LINEAR).set_ease(Tween.EASE_IN_OUT)
-	tween.finished.connect(_finish_fake_loading)
+	_loading_fill_tween = create_tween()
+	_loading_fill_tween.tween_property(_loading_fill, "size:x", _loading_track_fill_width, 2.0).set_trans(Tween.TRANS_LINEAR).set_ease(Tween.EASE_IN_OUT)
+	_loading_fill_tween.finished.connect(_on_loading_animation_finished)
 
-	var percent_tween := create_tween()
-	percent_tween.tween_method(_update_loading_progress, 0.0, 100.0, 2.0)
+	_loading_percent_tween = create_tween()
+	_loading_percent_tween.tween_method(_update_loading_progress, 0.0, 100.0, 2.0)
 
 
-func _finish_fake_loading() -> void:
+func _on_loading_animation_finished() -> void:
+	_loading_fill_tween = null
+	_loading_percent_tween = null
+	_loading_animation_finished = true
+	if _bootstrap_completed:
+		_complete_loading_state()
+
+
+func _complete_loading_state() -> void:
+	if not _bootstrap_completed or _input_ready:
+		return
+
+	_cancel_loading_tweens()
 	_input_ready = true
 	_sync_logout_button_visibility()
+	if _loading_fill != null:
+		_loading_fill.size.x = _loading_track_fill_width
 	if _loading_label != null:
 		_loading_label.text = "\u8c93\u54aa\u968a\u4f0d\u96c6\u5408\u5b8c\u7562"
 	if _loading_percent_label != null:
@@ -690,6 +737,32 @@ func _finish_fake_loading() -> void:
 		)
 	if _tap_hint != null:
 		_tap_hint.visible = true
+
+
+func _cancel_loading_tweens() -> void:
+	if _loading_fill_tween != null:
+		_loading_fill_tween.kill()
+		_loading_fill_tween = null
+	if _loading_percent_tween != null:
+		_loading_percent_tween.kill()
+		_loading_percent_tween = null
+
+
+func _abort_loading_state() -> void:
+	_cancel_loading_tweens()
+	_bootstrap_completed = false
+	_loading_animation_finished = false
+	if _auth_block != null:
+		_auth_block.visible = true
+	if _loading_block != null:
+		_loading_block.visible = false
+		_loading_block.modulate.a = 1.0
+	if _tap_hint != null:
+		_tap_hint.visible = false
+	if _loading_fill != null:
+		_loading_fill.size.x = 0.0
+	if _loading_percent_label != null:
+		_loading_percent_label.text = "0%"
 
 
 func _update_loading_progress(value: float) -> void:
@@ -724,6 +797,14 @@ func _set_status(message: String, is_error: bool) -> void:
 		return
 	_status_label.text = message
 	_status_label.add_theme_color_override("font_color", Color("7d2f2f") if is_error else Color("46613d"))
+
+
+func _retain_network_loading_overlay(message: String) -> void:
+	pass
+
+
+func _release_network_loading_overlay() -> void:
+	pass
 
 
 func _sync_logout_button_visibility() -> void:
@@ -829,11 +910,15 @@ func _begin_logout_refresh() -> void:
 
 func _finalize_logout() -> void:
 	_logout_dialog_open = false
+	_release_network_loading_overlay()
+	_cancel_loading_tweens()
 	GameState.clear_auth_and_player_state()
 	_api_base_url = _resolve_api_base_url()
 	_request_in_flight = false
 	_request_kind = ""
 	_input_ready = false
+	_bootstrap_completed = false
+	_loading_animation_finished = false
 	_set_auth_interactable(true)
 	_set_logout_button_state(true)
 	_sync_logout_button_visibility()


### PR DESCRIPTION
## 摘要
- 調整 `StartScene` 的讀條流程，讓啟動讀條與 bootstrap 同步進行。
- 讓 bootstrap 提前完成時可直接結束讀條，不再額外顯示遮罩。
- 新增一般 API 請求的簡單 loading 遮罩，並修正 spinner 旋轉中心與 loading 文字循環。

## 測試
- 尚未在本機執行 Godot CLI 驗證，因目前環境沒有 `godot` / `godot4` 指令。

Closes #80