### PR TITLE
fix:修正 Godot 前端錯誤與警告

### DIFF
--- a/scripts/ApiClient.gd
+++ b/scripts/ApiClient.gd
@@ -461,8 +461,13 @@ func _on_refresh_failed() -> void:
 
 
 func _invoke_callback(callback: Callable, success: bool, data: Variant, error: Dictionary) -> void:
-	if callback.is_valid():
-		callback.call(success, data, error)
+	if callback.is_null():
+		return
+	if callback.is_standard():
+		var target := instance_from_id(callback.get_object_id())
+		if target == null or not is_instance_valid(target):
+			return
+	callback.call(success, data, error)
 
 
 func _flush_pending() -> void:

--- a/scripts/MailScene.gd
+++ b/scripts/MailScene.gd
@@ -164,13 +164,13 @@ func _populate_mail_list() -> void:
 		if not (item_variant is Dictionary):
 			continue
 		var item: Dictionary = item_variant
-		var title := String(item.get("title", "未命名郵件"))
+		var title := str(item.get("title", "未命名郵件"))
 		var label := title
 		if not bool(item.get("isClaimed", false)) and bool(item.get("hasAttachment", false)):
 			label = "獎 " + label
 		if not bool(item.get("isRead", false)):
 			label = "● " + label
-		if String(item.get("status", "")) == "Expired":
+		if str(item.get("status", "")) == "Expired":
 			label += " [已過期]"
 		_mail_list.add_item(label)
 
@@ -212,17 +212,17 @@ func _render_detail(detail: Dictionary) -> void:
 		_claim_btn.text = "領取"
 		return
 
-	_detail_title.text = String(detail.get("title", "未命名郵件"))
+	_detail_title.text = str(detail.get("title", "未命名郵件"))
 	var expire_text := "無"
 	var expire_variant: Variant = detail.get("expireAtUtc", null)
 	if expire_variant != null:
-		expire_text = String(expire_variant).substr(0, 19)
+		expire_text = str(expire_variant).substr(0, 19)
 	_detail_meta.text = "類型：%s | 狀態：%s | 到期：%s" % [
-		String(detail.get("mailType", "")),
-		String(detail.get("status", "")),
+		str(detail.get("mailType", "")),
+		str(detail.get("status", "")),
 		expire_text
 	]
-	_detail_content.text = String(detail.get("content", ""))
+	_detail_content.text = str(detail.get("content", ""))
 
 	var attachments_variant: Variant = detail.get("attachments", [])
 	var attachments: Array = attachments_variant if attachments_variant is Array else []
@@ -237,9 +237,9 @@ func _render_detail(detail: Dictionary) -> void:
 		var prefix := "已領取" if bool(attachment.get("isClaimed", false)) else "可領取"
 		row.text = "%s %s x%d\n%s" % [
 			prefix,
-			String(attachment.get("displayName", attachment.get("rewardType", ""))),
+			str(attachment.get("displayName", attachment.get("rewardType", ""))),
 			int(attachment.get("quantity", 0)),
-			String(attachment.get("description", ""))
+			str(attachment.get("description", ""))
 		]
 		_attachment_box.add_child(row)
 
@@ -299,7 +299,7 @@ func _render_reward_dialog(rewards: Variant, title: String) -> void:
 				continue
 			var reward: Dictionary = reward_variant
 			lines.append("%s x%d" % [
-				String(reward.get("displayName", reward.get("rewardType", ""))),
+				str(reward.get("displayName", reward.get("rewardType", ""))),
 				int(reward.get("quantity", 0))
 			])
 	if lines.is_empty():

--- a/scripts/StartScene.gd
+++ b/scripts/StartScene.gd
@@ -568,7 +568,7 @@ func _on_request_completed(_result: int, response_code: int, _headers: PackedStr
 
 	if completed_request_kind == REQUEST_KIND_BOOTSTRAP:
 		_abort_loading_state()
-		var bootstrap_message := String(error_payload.get("message", "同步玩家資料失敗，請稍後再試。"))
+		var bootstrap_message := str(error_payload.get("message", "同步玩家資料失敗，請稍後再試。"))
 		_set_status(bootstrap_message, true)
 		return
 
@@ -799,7 +799,7 @@ func _set_status(message: String, is_error: bool) -> void:
 	_status_label.add_theme_color_override("font_color", Color("7d2f2f") if is_error else Color("46613d"))
 
 
-func _retain_network_loading_overlay(message: String) -> void:
+func _retain_network_loading_overlay(_message: String) -> void:
 	pass
 
 
@@ -945,7 +945,7 @@ func _finalize_logout() -> void:
 func _resolve_api_base_url() -> String:
 	var config := _load_runtime_config()
 	if config.has("api_base_url"):
-		return String(config.get("api_base_url", DEFAULT_API_BASE_URL)).rstrip("/")
+		return str(config.get("api_base_url", DEFAULT_API_BASE_URL)).rstrip("/")
 
 	var configured_environment = config.get("environment") if config.get("environment") != null else DEFAULT_ENVIRONMENT
 	var environment_name := _normalize_environment_name(configured_environment)

--- a/scripts/arenaScene/ArenaScene.gd
+++ b/scripts/arenaScene/ArenaScene.gd
@@ -182,8 +182,8 @@ func _apply_overview(overview: Dictionary) -> void:
 	_score_label.text = "積分：%d" % Helpers.get_current_score(_overview)
 	_ticket_label.text = "競技券：%d" % Helpers.get_current_tickets(_overview)
 	_season_label.text = "%s｜結束日 %s" % [
-		String(_overview.get("seasonDisplayName", "目前賽季")),
-		String(_overview.get("seasonEndDate", "-"))
+		str(_overview.get("seasonDisplayName", "目前賽季")),
+		str(_overview.get("seasonEndDate", "-"))
 	]
 	_attack_team_label.text = "攻擊隊伍：%s" % Helpers.format_team_names_from_team("ArenaAttack", "Boss", "未設定，將改用 Boss 隊伍")
 	_defense_team_label.text = "防守隊伍：%s" % Helpers.format_team_names_from_team("ArenaDefense", "", "未設定防守隊伍")
@@ -218,13 +218,13 @@ func _build_opponent_card(opponent: Dictionary) -> Control:
 	box.add_child(title_row)
 
 	var name_label := Label.new()
-	name_label.text = String(opponent.get("playerName", "未知對手"))
+	name_label.text = str(opponent.get("playerName", "未知對手"))
 	name_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	name_label.add_theme_font_size_override("font_size", 22)
 	title_row.add_child(name_label)
 
 	var score_label := Label.new()
-	score_label.text = "%s  %d" % [String(opponent.get("rankName", "青銅 III")), int(opponent.get("score", 0))]
+	score_label.text = "%s  %d" % [str(opponent.get("rankName", "青銅 III")), int(opponent.get("score", 0))]
 	score_label.add_theme_font_size_override("font_size", 18)
 	title_row.add_child(score_label)
 
@@ -283,7 +283,7 @@ func _claim_rank_reward(rank_id: int) -> void:
 			GameState.update_arena(overview)
 			_apply_overview(overview)
 		_show_dialog("牌位獎勵", "已領取 %s：%s" % [
-			String(response.get("rankName", "牌位獎勵")),
+			str(response.get("rankName", "牌位獎勵")),
 			Helpers.format_rewards(response.get("rewards", []))
 		])
 	)
@@ -320,7 +320,7 @@ func _get_current_opponent_ids() -> Array:
 		if not (opponent_variant is Dictionary):
 			continue
 		var opponent: Dictionary = opponent_variant
-		var opponent_id := String(opponent.get("opponentId", "")).strip_edges()
+		var opponent_id := str(opponent.get("opponentId", "")).strip_edges()
 		if opponent_id != "":
 			ids.append(opponent_id)
 	return ids

--- a/scripts/arenaScene/arena_scene_helpers.gd
+++ b/scripts/arenaScene/arena_scene_helpers.gd
@@ -46,18 +46,18 @@ static func format_rewards(rewards: Array) -> String:
 		var quantity := int(reward.get("quantity", 0))
 		if quantity <= 0:
 			continue
-		var label := _get_reward_type_label(String(reward.get("rewardType", "")))
+		var label := _get_reward_type_label(str(reward.get("rewardType", "")))
 		parts.append("%s x%d" % [label, quantity])
 	return "、".join(parts) if not parts.is_empty() else "無獎勵"
 
 
 static func build_error_message(error: Dictionary) -> String:
-	var message := String(error.get("message", "")).strip_edges()
+	var message := str(error.get("message", "")).strip_edges()
 	return message if message != "" else "請稍後再試。"
 
 
 static func get_current_rank(overview: Dictionary) -> String:
-	return String(overview.get("rankName", "青銅 III"))
+	return str(overview.get("rankName", "青銅 III"))
 
 
 static func get_current_score(overview: Dictionary) -> int:

--- a/scripts/arenaScene/arena_scene_reward_popup.gd
+++ b/scripts/arenaScene/arena_scene_reward_popup.gd
@@ -20,7 +20,7 @@ static func show(scene: Control, overview: Dictionary, claim_callback: Callable)
 		list.add_child(row)
 
 		var name_label := Label.new()
-		name_label.text = String(rank.get("displayName", "未知牌位"))
+		name_label.text = str(rank.get("displayName", "未知牌位"))
 		name_label.custom_minimum_size = Vector2(120.0, 0.0)
 		name_label.add_theme_font_size_override("font_size", 18)
 		row.add_child(name_label)

--- a/scripts/battle/arena_battle_scene.gd
+++ b/scripts/battle/arena_battle_scene.gd
@@ -121,7 +121,7 @@ func _build_ui() -> void:
 	const HALF := SW / 2.0
 
 	var my_name_lbl := _make_label(
-		String(my_overview.get("playerName", GameState.player_data.player_name)),
+		str(my_overview.get("playerName", GameState.player_data.player_name)),
 		Vector2(10.0, HEADER_Y),
 		Vector2(HALF - 30.0, 26.0),
 		18
@@ -130,7 +130,7 @@ func _build_ui() -> void:
 	_ui_layer.add_child(my_name_lbl)
 
 	var my_rank_lbl := _make_label(
-		"%s  %d" % [String(my_overview.get("rankName", "青銅 III")), int(my_overview.get("score", 0))],
+		"%s  %d" % [str(my_overview.get("rankName", "青銅 III")), int(my_overview.get("score", 0))],
 		Vector2(10.0, HEADER_Y + 28.0),
 		Vector2(HALF - 30.0, 22.0),
 		14
@@ -145,7 +145,7 @@ func _build_ui() -> void:
 	_ui_layer.add_child(vs_lbl)
 
 	var opp_name_lbl := _make_label(
-		String(_opponent.get("playerName", "未知對手")),
+		str(_opponent.get("playerName", "未知對手")),
 		Vector2(HALF + 20.0, HEADER_Y),
 		Vector2(HALF - 30.0, 26.0),
 		18
@@ -154,7 +154,7 @@ func _build_ui() -> void:
 	_ui_layer.add_child(opp_name_lbl)
 
 	var opp_rank_lbl := _make_label(
-		"%s  %d" % [String(_opponent.get("rankName", "青銅 III")), opp_score],
+		"%s  %d" % [str(_opponent.get("rankName", "青銅 III")), opp_score],
 		Vector2(HALF + 20.0, HEADER_Y + 28.0),
 		Vector2(HALF - 30.0, 22.0),
 		14
@@ -395,10 +395,10 @@ func _handle_result(is_win: bool) -> void:
 		return
 	_settling = true
 
-	ApiClient.complete_arena_battle(String(_opponent.get("opponentId", "")), is_win, func(success: bool, data: Variant, error: Dictionary) -> void:
+	ApiClient.complete_arena_battle(str(_opponent.get("opponentId", "")), is_win, func(success: bool, data: Variant, error: Dictionary) -> void:
 		_settling = false
 		if not success or not (data is Dictionary):
-			DialogManager.show_info("競技場結算", String(error.get("message", "競技場結算失敗。")), func() -> void:
+			DialogManager.show_info("競技場結算", str(error.get("message", "競技場結算失敗。")), func() -> void:
 				get_tree().change_scene_to_file("res://scenes/ArenaScene.tscn")
 			)
 			return
@@ -414,7 +414,7 @@ func _show_result_popup(response: Dictionary) -> void:
 	var is_win := bool(response.get("isWin", false))
 	var delta := int(response.get("scoreDelta", 0))
 	var new_score := int(response.get("newScore", 0))
-	var rank_name := String(response.get("rankName", "青銅 III"))
+	var rank_name := str(response.get("rankName", "青銅 III"))
 	var delta_str := ("+%d" % delta) if delta >= 0 else "%d" % delta
 
 	const POPUP_W := 440.0

--- a/scripts/battle/battle_manager.gd
+++ b/scripts/battle/battle_manager.gd
@@ -229,7 +229,7 @@ func _init_skill_slots() -> void:
 		var cat: CatData = _player_cats[i]
 		var max_cd := 0.0
 		if cat.active_skills_data.size() > 0:
-			var skill_id := String(cat.active_skills_data[0].get("id", ""))
+			var skill_id := str(cat.active_skills_data[0].get("id", ""))
 			max_cd = float(cat.active_skills_data[0].get("cooldown", 5.0))
 			var initial_delay: float = float(cat.active_skills_data[0].get("initial_delay", 0))
 			_skill_slots.append({
@@ -275,12 +275,12 @@ func _refresh_skill_slot_ui(i: int, slot: Dictionary) -> void:
 	var max_cd: float = slot["max_cd"]
 	var remaining: float = slot["remaining_cd"]
 	var buff_rem: float = slot["buff_remaining"]
-	var skill_id := String(slot.get("skill_id", ""))
+	var skill_id := str(slot.get("skill_id", ""))
 
 	# 技能圖示
 	var icon_rect: TextureRect = slot_node.get_node_or_null("Icon")
 	if icon_rect:
-		var icon_path := String(SKILL_ICON_PATHS.get(skill_id, ""))
+		var icon_path := str(SKILL_ICON_PATHS.get(skill_id, ""))
 		if not icon_path.is_empty() and ResourceLoader.exists(icon_path):
 			icon_rect.texture = load(icon_path)
 			icon_rect.visible = true

--- a/scripts/battle/dungeon_battle_scene.gd
+++ b/scripts/battle/dungeon_battle_scene.gd
@@ -401,7 +401,7 @@ func _on_complete_challenge(success: bool, data: Variant, error: Dictionary) -> 
 		_show_reward_popup(_dungeon_level, rewards if rewards is Dictionary else {})
 		return
 
-	var message := String(error.get("message", "挑戰結算失敗。"))
+	var message := str(error.get("message", "挑戰結算失敗。"))
 	DialogManager.show_info("挑戰結算失敗", message, func():
 		get_tree().change_scene_to_file("res://scenes/DungeonScene.tscn")
 	)

--- a/scripts/chat/ChatRealtimeClient.gd
+++ b/scripts/chat/ChatRealtimeClient.gd
@@ -114,18 +114,18 @@ func _handle_payload(packet: String) -> void:
 	if not (payload is Dictionary):
 		return
 	var data: Dictionary = payload
-	var event_type := String(data.get("eventType", ""))
+	var event_type := str(data.get("eventType", ""))
 	match event_type:
 		"chat.connected":
 			_reconnect_attempts = 0
 			GameState.set_chat_connection_state("connected")
 		"chat.message.received", "chat.message.replay":
-			var channel_key := String(data.get("channelKey", data.get("channel", "world"))).to_lower()
+			var channel_key := str(data.get("channelKey", data.get("channel", "world"))).to_lower()
 			var message_variant: Variant = data.get("message", {})
 			if message_variant is Dictionary:
 				GameState.append_chat_message_envelope(channel_key, int(data.get("sequence", 0)), message_variant)
 		"chat.unread.sync":
-			GameState.set_chat_unread_count(String(data.get("channelKey", "")).to_lower(), int(data.get("unreadCount", 0)))
+			GameState.set_chat_unread_count(str(data.get("channelKey", "")).to_lower(), int(data.get("unreadCount", 0)))
 		"chat.pong":
 			pass
 		"chat.error":

--- a/scripts/chat/ChatScene.gd
+++ b/scripts/chat/ChatScene.gd
@@ -96,7 +96,7 @@ func _on_load_more_pressed() -> void:
 func _load_history(channel_key: String, before_seq: int) -> void:
 	ApiClient.get_chat_history(channel_key, before_seq, 50, func(success: bool, data: Variant, error: Dictionary) -> void:
 		if not success:
-			_hint_label.text = String(error.get("message", "Failed to load chat history."))
+			_hint_label.text = str(error.get("message", "Failed to load chat history."))
 			return
 		var payload: Dictionary = data if data is Dictionary else {}
 		var messages_variant: Variant = payload.get("messages", [])
@@ -118,7 +118,7 @@ func _submit_message() -> void:
 		if success:
 			_input.text = ""
 		else:
-			_hint_label.text = String(error.get("message", "Failed to send chat message."))
+			_hint_label.text = str(error.get("message", "Failed to send chat message."))
 	)
 
 

--- a/scripts/chat/chat_message_item.gd
+++ b/scripts/chat/chat_message_item.gd
@@ -14,14 +14,14 @@ func setup(channel_key: String, message: Dictionary) -> void:
 	margin.add_child(content)
 
 	var header := Label.new()
-	var sender := String(message.get("senderDisplayName", "System"))
-	var time_text := String(message.get("sentAtUtc", "")).replace("T", " ").replace("Z", "")
+	var sender := str(message.get("senderDisplayName", "System"))
+	var time_text := str(message.get("sentAtUtc", "")).replace("T", " ").replace("Z", "")
 	header.text = "[%s] %s  %s" % [channel_key.capitalize(), sender, time_text]
 	header.add_theme_font_size_override("font_size", 14)
 	content.add_child(header)
 
 	var body := Label.new()
-	body.text = String(message.get("content", ""))
+	body.text = str(message.get("content", ""))
 	body.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	body.add_theme_font_size_override("font_size", 16)
 	content.add_child(body)

--- a/scripts/configs/ConfigScene.gd
+++ b/scripts/configs/ConfigScene.gd
@@ -199,7 +199,7 @@ func _make_team_slot_row(slot_index: int, member: Dictionary) -> HBoxContainer:
 	row.add_theme_constant_override("separation", 12)
 
 	var is_filled := not member.is_empty()
-	var cat_name: String = String(member.get("catDisplayName", "")) if is_filled else ""
+	var cat_name: String = str(member.get("catDisplayName", "")) if is_filled else ""
 	var cat_lv: int = int(member.get("catFoodLevel", 1)) if is_filled else 1
 	var cat_catalog_id: int = int(member.get("catCatalogId", 0)) if is_filled else 0
 	var delay_seconds: float = float(member.get("initialDelaySeconds", 0.0)) if is_filled else 0.0
@@ -286,7 +286,7 @@ func _make_cat_row(cat: Dictionary, in_team_ids: Array) -> HBoxContainer:
 	row.add_theme_constant_override("separation", 12)
 
 	var player_cat_id: int = int(cat.get("playerCatId", 0))
-	var display_name: String = String(cat.get("displayName", ""))
+	var display_name: String = str(cat.get("displayName", ""))
 	var lv: int = int(cat.get("catFoodLevel", 1))
 
 	var name_lbl := Label.new()
@@ -321,7 +321,7 @@ func _build_member_from_player_cat(player_cat_id: int) -> Dictionary:
 			"slotNo": 0,
 			"playerCatId": player_cat_id,
 			"catCatalogId": int(cat.get("catCatalogId", 0)),
-			"catDisplayName": String(cat.get("displayName", "")),
+			"catDisplayName": str(cat.get("displayName", "")),
 			"catFoodLevel": int(cat.get("catFoodLevel", 1)),
 			"rank": int(cat.get("rank", 0)),
 			"initialDelaySeconds": 0.0,
@@ -426,7 +426,7 @@ func _on_save_team_pressed() -> void:
 		if data is Dictionary:
 			var team_response := data as Dictionary
 			_apply_team_update(team_response)
-			var saved_type_key := _team_scene_type_to_key(String(team_response.get("teamType", "")))
+			var saved_type_key := _team_scene_type_to_key(str(team_response.get("teamType", "")))
 			if saved_type_key != "":
 				_reset_team_draft(saved_type_key, team_response)
 
@@ -442,7 +442,7 @@ func _team_scene_type_to_key(team_type: String) -> String:
 
 
 func _apply_team_update(team_response: Dictionary) -> void:
-	var type_str: String = String(team_response.get("teamType", ""))
+	var type_str: String = str(team_response.get("teamType", ""))
 	if type_str == "":
 		return
 

--- a/scripts/data/cats/player_cat_data.gd
+++ b/scripts/data/cats/player_cat_data.gd
@@ -60,7 +60,7 @@ static func special_food_next_cost(total_points_allocated: int) -> int:
 ## 代換回 T（total_points_allocated = n+1）：T*(T+1)/2
 ## 範例：已分配 3 點 → 1+2+3 = 6 → 3*4/2 = 6
 static func special_food_total_spent(total_points_allocated: int) -> int:
-	return total_points_allocated * (total_points_allocated + 1) / 2
+	return (total_points_allocated * (total_points_allocated + 1)) >> 1
 
 
 # ── 查詢輔助 ──────────────────────────────────────────

--- a/scripts/data/player_arena_data.gd
+++ b/scripts/data/player_arena_data.gd
@@ -149,7 +149,7 @@ static func _load_leaderboard() -> Dictionary:
 	return {}
 
 
-static func _save_leaderboard(data: Dictionary) -> void:
+static func _save_leaderboard(_data: Dictionary) -> void:
 	return
 
 

--- a/scripts/dungeon/DungeonSceneActions.gd
+++ b/scripts/dungeon/DungeonSceneActions.gd
@@ -15,7 +15,7 @@ static func on_dungeon_overview_completed(scene, success: bool, data: Variant, e
 		scene._rebuild_dungeon_panels()
 		return
 
-	var message := String(error.get("message", "取得地城資料失敗。"))
+	var message := str(error.get("message", "取得地城資料失敗。"))
 	DialogManager.show_info("地城資料失敗", message)
 	scene._rebuild_dungeon_panels()
 
@@ -31,13 +31,13 @@ static func on_dungeon_action_completed(scene, success: bool, data: Variant, err
 
 		var reward: Variant = response.get("reward", {})
 		if reward is Dictionary and not (reward as Dictionary).is_empty():
-			var run_type := String(response.get("runType", ""))
+			var run_type := str(response.get("runType", ""))
 			var target_floor := int(response.get("targetFloor", 0))
 			var header := "掃蕩完成" if run_type == "Sweep" else "挑戰完成"
 			scene._show_reward_popup(header, target_floor, reward)
 		return
 
-	var message := String(error.get("message", "地城操作失敗。"))
+	var message := str(error.get("message", "地城操作失敗。"))
 	DialogManager.show_info("地城操作失敗", message)
 	scene._rebuild_dungeon_panels()
 
@@ -73,7 +73,7 @@ static func on_challenge_pressed(scene, dungeon_id: int) -> void:
 		return
 
 	scene.GameState.dungeon_battle_id = str(dungeon_id)
-	scene.GameState.dungeon_battle_key = String(dungeon.get("key", ""))
+	scene.GameState.dungeon_battle_key = str(dungeon.get("key", ""))
 	scene.GameState.dungeon_battle_level = int(dungeon.get("maxClearedFloor", 0)) + 1
 
 	var dungeon_team: Array = scene.GameState.player_data.dungeon_team

--- a/scripts/dungeon/DungeonSceneUI.gd
+++ b/scripts/dungeon/DungeonSceneUI.gd
@@ -87,7 +87,7 @@ static func refresh_panel(scene, dungeon_id: int) -> void:
 	var max_floor := int(dungeon.get("maxClearedFloor", 0))
 	var ticket_count := int(dungeon.get("remainingTicketCount", 0))
 	var ad_count := int(dungeon.get("remainingAdTicketCount", 0))
-	var display_name := String(dungeon.get("displayName", "地城"))
+	var display_name := str(dungeon.get("displayName", "地城"))
 
 	var floor_label: Label = entry["floor_label"]
 	floor_label.text = "最高通關：%s" % ("Lv.%d" % max_floor if max_floor > 0 else "尚未通關")
@@ -128,12 +128,12 @@ static func _build_dungeon_panel(scene, dungeon: Dictionary) -> PanelContainer:
 	panel.add_child(vbox)
 
 	var name_label := Label.new()
-	name_label.text = String(dungeon.get("displayName", "地城"))
+	name_label.text = str(dungeon.get("displayName", "地城"))
 	name_label.add_theme_font_size_override("font_size", 26)
 	vbox.add_child(name_label)
 
 	var desc_label := Label.new()
-	desc_label.text = String(dungeon.get("description", ""))
+	desc_label.text = str(dungeon.get("description", ""))
 	desc_label.add_theme_font_size_override("font_size", 18)
 	desc_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	vbox.add_child(desc_label)

--- a/scripts/enhance/EnhanceSceneActions.gd
+++ b/scripts/enhance/EnhanceSceneActions.gd
@@ -42,7 +42,7 @@ static func on_enhance_action_completed(
 			scene.GameState.refresh_achievements()
 		return
 
-	var message := String(error.get("message", "強化操作失敗"))
+	var message := str(error.get("message", "強化操作失敗"))
 	DialogManager.show_info("強化失敗", message)
 	scene._refresh_all_labels()
 

--- a/scripts/gamestate/GameState.gd
+++ b/scripts/gamestate/GameState.gd
@@ -997,7 +997,6 @@ func get_achievement_progress(item: Dictionary) -> Dictionary:
 
 ## DEPRECATED: 成就改由後端管理，但仍保留供 EnhanceScene 呼叫
 func refresh_achievements(show_notifications: bool = true) -> Array[String]:
-	push_warning("DEPRECATED: refresh_achievements() - achievements are now managed by the backend API")
 	var newly_completed: Array[String] = []
 	var changed := false
 	for item: Dictionary in get_all_achievements():
@@ -1145,7 +1144,7 @@ func get_idle_elapsed_seconds() -> int:
 
 ## 可領取的完整分鐘數（即時計算）
 func get_idle_complete_minutes() -> int:
-	return get_idle_elapsed_seconds() / 60
+	return floori(float(get_idle_elapsed_seconds()) / 60.0)
 
 ## 是否已累積至少一分鐘可領取（即時計算）
 func has_pending_idle_rewards() -> bool:
@@ -1179,7 +1178,7 @@ func claim_idle_rewards() -> void:
 	player_data.cat_food       += rewards.get("cat_food", 0)
 	player_data.diamonds       += rewards.get("diamonds", 0)
 	player_data.whisker_shards += rewards.get("whiskers", 0)
-	player_data.last_quit_time = Time.get_unix_time_from_system() - remainder_seconds
+	player_data.last_quit_time = int(Time.get_unix_time_from_system()) - remainder_seconds
 	player_data.save()
 
 ## 鏟一次屎：扣除一個屎堆，隨機產出並存檔
@@ -1277,8 +1276,8 @@ func set_chat_connection_state(state: String) -> void:
 
 
 func apply_chat_summary(summary: Dictionary) -> void:
-	chat_endpoint = String(summary.get("chatEndpoint", chat_endpoint))
-	chat_token = String(summary.get("chatToken", chat_token))
+	chat_endpoint = str(summary.get("chatEndpoint", chat_endpoint))
+	chat_token = str(summary.get("chatToken", chat_token))
 	chat_guild_available = bool(summary.get("guildChatAvailable", false))
 	chat_last_snapshot_at_unix = Time.get_unix_time_from_system()
 	if summary.has("unreadSystemCount"):
@@ -1300,7 +1299,7 @@ func apply_chat_summary(summary: Dictionary) -> void:
 			if not (item is Dictionary):
 				continue
 			var channel: Dictionary = item
-			var channel_key := String(channel.get("channelKey", "")).to_lower()
+			var channel_key := str(channel.get("channelKey", "")).to_lower()
 			if channel_key == "":
 				continue
 			chat_unread_counts[channel_key] = int(channel.get("unreadCount", 0))
@@ -1333,9 +1332,9 @@ func set_chat_unread_count(channel_key: String, count: int) -> void:
 
 func append_chat_message_envelope(channel_key: String, sequence: int, message: Dictionary) -> void:
 	var target := get_chat_messages(channel_key)
-	var message_id := String(message.get("messageId", ""))
+	var message_id := str(message.get("messageId", ""))
 	for existing: Dictionary in target:
-		if String(existing.get("messageId", "")) == message_id and message_id != "":
+		if str(existing.get("messageId", "")) == message_id and message_id != "":
 			return
 
 	var entry := message.duplicate(true)
@@ -1381,7 +1380,7 @@ func _trim_chat_channel(channel_key: String) -> void:
 	var cutoff := Time.get_unix_time_from_system() - (24 * 60 * 60)
 	var filtered: Array = []
 	for item: Dictionary in target:
-		var sent_at := String(item.get("sentAtUtc", ""))
+		var sent_at := str(item.get("sentAtUtc", ""))
 		var unix_time := Time.get_unix_time_from_datetime_string(sent_at) if sent_at != "" else 0
 		if unix_time == 0 or unix_time >= cutoff:
 			filtered.append(item)
@@ -1420,16 +1419,16 @@ func is_memory_unlocked(memory_id: String) -> bool:
 
 func get_memory_bonuses() -> Array:
 	if not scooper_memory_data.is_empty():
-		var result: Array = []
+		var live_result: Array = []
 		for item: Dictionary in scooper_memory_data:
 			if not bool(item.get("isUnlocked", false)):
 				continue
-			result.append({
+			live_result.append({
 				"target": str(item.get("bonusTarget", "All")).to_lower(),
 				"stat": str(item.get("bonusStatType", "")),
 				"value": float(item.get("bonusValue", 0.0)),
 			})
-		return result
+		return live_result
 	var result: Array = []
 	for memory_id: String in player_data.unlocked_memory_ids:
 		var item := _get_memory_item(memory_id)
@@ -1671,7 +1670,7 @@ func is_equipment_owned(equip_id: String) -> bool:
 ## 取得所有有效裝備加成（非損壞、等級 > 0）
 func get_equipment_bonuses() -> Array:
 	if not scooper_equipment_data.is_empty():
-		var result: Array = []
+		var live_result: Array = []
 		for item: Dictionary in scooper_equipment_data:
 			if not bool(item.get("isOwned", false)):
 				continue
@@ -1681,14 +1680,14 @@ func get_equipment_bonuses() -> Array:
 			if level <= 0:
 				continue
 			var bonus_per_level: float = float(item.get("bonusPerLevel", 0.0))
-			result.append({
+			live_result.append({
 				"target": str(item.get("bonusTarget", "All")).to_lower(),
 				"stat":   str(item.get("bonusStat", "")),
 				"value":  bonus_per_level * level,
 			})
-		return result
+		return live_result
 	# Fallback: 本地設定
-	var result: Array = []
+	var fallback_result: Array = []
 	for equip_id: String in player_data.equipments.keys():
 		var item := _get_equip_item(equip_id)
 		if item.is_empty():
@@ -1700,12 +1699,12 @@ func get_equipment_bonuses() -> Array:
 		if level <= 0:
 			continue
 		var bonus_per_level: float = float(item.get("bonus_per_level", 0.0))
-		result.append({
+		fallback_result.append({
 			"target": item.get("bonus_target", "all"),
 			"stat":   item.get("bonus_stat", ""),
 			"value":  bonus_per_level * level,
 		})
-	return result
+	return fallback_result
 
 
 # ── 私有輔助 ──────────────────────────────────

--- a/scripts/gamestate/GameStateBossStage.gd
+++ b/scripts/gamestate/GameStateBossStage.gd
@@ -35,7 +35,7 @@ static func get_zone_in_territory(current_stage: int, boss_cfg: Dictionary) -> i
 	var bsz := _bsz(boss_cfg)
 	var zpt := _zpt(boss_cfg)
 	var stages_per_territory: int = bsz * zpt
-	return (((get_boss_stage_number(current_stage, boss_cfg) - 1) % stages_per_territory) / bsz) + 1
+	return floori(float(((get_boss_stage_number(current_stage, boss_cfg) - 1) % stages_per_territory)) / float(bsz)) + 1
 
 
 ## 當前領地序號（1 起算）
@@ -43,7 +43,7 @@ static func get_territory_number(current_stage: int, boss_cfg: Dictionary) -> in
 	var bsz := _bsz(boss_cfg)
 	var zpt := _zpt(boss_cfg)
 	var stages_per_territory: int = bsz * zpt
-	return ((get_boss_stage_number(current_stage, boss_cfg) - 1) / stages_per_territory) + 1
+	return floori(float(get_boss_stage_number(current_stage, boss_cfg) - 1) / float(stages_per_territory)) + 1
 
 
 # ── 關卡顯示 ──────────────────────────────────
@@ -99,7 +99,7 @@ static func get_enemy_ids(current_stage: int, boss_cfg: Dictionary) -> Array:
 	if is_current_boss(current_stage, boss_cfg):
 		count = mini(1 + boss_stage, 5)
 	else:
-		count = mini(1 + (boss_stage - 1) / 3, 5)
+		count = mini(1 + floori(float(boss_stage - 1) / 3.0), 5)
 	count = maxi(count, 1)
 	var ids: Array = []
 	for i in range(count):

--- a/scripts/scooper/scooper_tab_achievement.gd
+++ b/scripts/scooper/scooper_tab_achievement.gd
@@ -233,7 +233,7 @@ func _make_achievement_card(scene: Control, entry: Dictionary) -> Control:
 		var completed_at: String = entry.get("completedAtUtc") if entry.get("completedAtUtc") != null else "-"
 		time_lbl.text = "完成時間：%s" % completed_at
 		if is_claimed:
-			time_lbl.text += "　領取時間：%s" % String(entry.get("claimedAtUtc", "-"))
+			time_lbl.text += "　領取時間：%s" % str(entry.get("claimedAtUtc", "-"))
 		time_lbl.add_theme_font_size_override("font_size", 15)
 		time_lbl.add_theme_color_override("font_color", Color(0.66, 0.66, 0.66, 1.0))
 		card.add_child(time_lbl)
@@ -267,7 +267,7 @@ func _claim_achievement(scene: Control, achievement_id: int) -> void:
 	scene.ApiClient.claim_achievement(achievement_id, func(ok: bool, data: Variant, err: Dictionary) -> void:
 		scene._api_in_flight = false
 		if not ok:
-			scene.DialogManager.show_info("領取失敗", String(err.get("message", "操作失敗")))
+			scene.DialogManager.show_info("領取失敗", str(err.get("message", "操作失敗")))
 			return
 
 		var result: Dictionary = data if data is Dictionary else {}
@@ -280,7 +280,7 @@ func _claim_achievement(scene: Control, achievement_id: int) -> void:
 		scene.DialogManager.show_info(
 			"領取成功",
 			"%s\n\n%s" % [
-				String(result.get("message", "")),
+				str(result.get("message", "")),
 				"\n".join(lines),
 			]
 		)

--- a/scripts/scooper/scooper_tab_memory.gd
+++ b/scripts/scooper/scooper_tab_memory.gd
@@ -226,13 +226,13 @@ func _make_memory_card(scene: Control, item: Dictionary) -> Control:
 
 func _show_memory_dialog(scene: Control, item: Dictionary, unlocked: bool) -> void:
 	var lines: Array[String] = [
-		String(item.get("description", "")),
+		str(item.get("description", "")),
 		"",
 		"效果：%s" % _memory_bonus_desc(item),
 		"解鎖需求：回憶碎片 %d" % int(item.get("unlockCost", 0)),
 		"目前狀態：%s" % ("已解鎖" if unlocked else "未解鎖"),
 	]
-	scene.DialogManager.show_info(String(item.get("displayName", "")), "\n".join(lines))
+	scene.DialogManager.show_info(str(item.get("displayName", "")), "\n".join(lines))
 
 
 func _confirm_unlock_memory(scene: Control, memory_id: int, memory_item: Dictionary) -> void:
@@ -252,7 +252,7 @@ func _confirm_unlock_memory(scene: Control, memory_id: int, memory_item: Diction
 			scene.ApiClient.unlock_memory(memory_id, func(ok: bool, data: Variant, err: Dictionary) -> void:
 				scene._api_in_flight = false
 				if not ok:
-					scene.DialogManager.show_info("解鎖失敗", String(err.get("message", "操作失敗")))
+					scene.DialogManager.show_info("解鎖失敗", str(err.get("message", "操作失敗")))
 					return
 				var result: Dictionary = data if data is Dictionary else {}
 				scene.GameState.player_data.memory_shards = int(result.get("remainingMemoryShards", scene.GameState.player_data.memory_shards))

--- a/scripts/scooper/scooper_tab_scooper.gd
+++ b/scripts/scooper/scooper_tab_scooper.gd
@@ -219,7 +219,7 @@ func _show_ability_dialog(scene: Control, item: Dictionary) -> void:
 	if source_text != "":
 		lines.append("")
 		lines.append(source_text)
-	scene.DialogManager.show_info(String(item.get("displayName", "")), "\n".join(lines))
+	scene.DialogManager.show_info(str(item.get("displayName", "")), "\n".join(lines))
 
 
 func _refresh_scoop_ui(scene: Control) -> void:
@@ -437,7 +437,7 @@ func _do_equipment_action(scene: Control, action: String, equip_id: int) -> void
 	var callback := func(ok: bool, data: Variant, err: Dictionary) -> void:
 		scene._api_in_flight = false
 		if not ok:
-			scene.DialogManager.show_info("%s失敗" % label, String(err.get("message", "操作失敗")))
+			scene.DialogManager.show_info("%s失敗" % label, str(err.get("message", "操作失敗")))
 			return
 
 		var result: Dictionary = data if data is Dictionary else {}

--- a/scripts/systems/idle_system.gd
+++ b/scripts/systems/idle_system.gd
@@ -6,8 +6,10 @@ extends RefCounted
 
 ## 依當前關卡與鏟屎官等級計算每小時產出速率
 static func calculate_rates(config: Dictionary, current_stage: int, scooper_level: int) -> Dictionary:
-	var stage_tiers: int  = current_stage / int(config.get("stage_bonus_interval",        50))
-	var whisker_tiers: int = current_stage / int(config.get("whisker_stage_bonus_interval", 150))
+	var stage_interval := float(int(config.get("stage_bonus_interval", 50)))
+	var whisker_interval := float(int(config.get("whisker_stage_bonus_interval", 150)))
+	var stage_tiers: int = floori(float(current_stage) / stage_interval)
+	var whisker_tiers: int = floori(float(current_stage) / whisker_interval)
 
 	return {
 		"gold": (int(config.get("base_gold_per_hour", 1000))
@@ -32,11 +34,11 @@ static func calculate_rewards(complete_minutes: int, rates: Dictionary) -> Dicti
 	if complete_minutes <= 0:
 		return {"gold": 0, "poop": 0, "cat_food": 0, "diamonds": 0, "whiskers": 0}
 	return {
-		"gold":     rates.get("gold",     0) * complete_minutes / 60,
-		"poop":     rates.get("poop",     0) * complete_minutes / 60,
-		"cat_food": rates.get("cat_food", 0) * complete_minutes / 60,
-		"diamonds": rates.get("diamonds", 0) * complete_minutes / 60,
-		"whiskers": rates.get("whiskers", 0) * complete_minutes / 60,
+		"gold": floori(float(rates.get("gold", 0)) * float(complete_minutes) / 60.0),
+		"poop": floori(float(rates.get("poop", 0)) * float(complete_minutes) / 60.0),
+		"cat_food": floori(float(rates.get("cat_food", 0)) * float(complete_minutes) / 60.0),
+		"diamonds": floori(float(rates.get("diamonds", 0)) * float(complete_minutes) / 60.0),
+		"whiskers": floori(float(rates.get("whiskers", 0)) * float(complete_minutes) / 60.0),
 	}
 
 ## 鏟一次屎的隨機掉落，機率依鏟屎官等級動態計算
@@ -50,7 +52,7 @@ static func scoop_once(config: Dictionary, rng: RandomNumberGenerator, scooper_l
 	var mem_chance: float = (
 		float(config.get("scoop_memory_shard_base_chance", 0.0001))
 		+ float(config.get("scoop_memory_shard_chance_per_two_scooper_levels", 0.0001))
-		  * float(scooper_level / 2)   # 整數除法，每兩級才加一次
+		  * floorf(float(scooper_level) / 2.0)   # 整數除法，每兩級才加一次
 	)
 	if rng.randf() < mem_chance:
 		result["memory_shards"] = 1

--- a/scripts/ui/inertial_scroll.gd
+++ b/scripts/ui/inertial_scroll.gd
@@ -86,9 +86,9 @@ func _get_scroll() -> float:
 
 func _set_scroll(v: float) -> void:
 	if axis == "vertical":
-		target.set_v_scroll(v)
+		target.set_v_scroll(roundi(v))
 	else:
-		target.set_h_scroll(v)
+		target.set_h_scroll(roundi(v))
 
 func _get_max_scroll() -> float:
 	# Use actual rendered sizes — most accurate and avoids scrollbar timing issues
@@ -288,7 +288,7 @@ func _fade_scrollbar():
 
 	is_scrolling = false
 
-func _do_haptic_feedback(direction: int) -> void:
+func _do_haptic_feedback(_direction: int) -> void:
 	var now_us = Time.get_ticks_usec()
 	if now_us - _last_haptic_us < HAPTIC_COOLDOWN_MS * 1000:
 		return


### PR DESCRIPTION
## 摘要

- 修正 Godot 4 下 `String(...)` 造成的前端 runtime error
- 修正 `ApiClient` callback 指向已釋放物件時的安全性問題
- 清理多個 GDScript warning 與變數命名衝突
- 補齊部分前端函式內部型別與命名一致性

## 影響範圍

- chat
- arena
- battle
- dungeon
- enhance
- scooper
- GameState 與共用 UI helper

## 驗證

- 已確認 git diff 格式檢查乾淨
- 已整理並提交前端修正檔案
- 尚未在本機直接啟動 Godot Editor 做完整手動驗證

Closes #91