### PR TITLE
fix:改為優先使用 bootstrap 載入功能頁資料

### DIFF
--- a/scripts/ApiClient.gd
+++ b/scripts/ApiClient.gd
@@ -108,6 +108,10 @@ func claim_achievement(achievement_id: int, callback: Callable) -> void:
 	_api_post("scooper/achievement/claim", {"achievementId": achievement_id}, callback)
 
 
+func get_authenticated_bootstrap(callback: Callable) -> void:
+	_api_get("auth/bootstrap", callback)
+
+
 func get_mail_summary(callback: Callable) -> void:
 	_api_get("mail/summary", callback)
 

--- a/scripts/arenaScene/ArenaScene.gd
+++ b/scripts/arenaScene/ArenaScene.gd
@@ -24,6 +24,8 @@ func _ready() -> void:
 	_build_ui()
 	if not GameState.arena_overview_data.is_empty():
 		_apply_overview(GameState.arena_overview_data)
+	if _has_cached_opponents(GameState.arena_overview_data):
+		return
 	_refresh_overview([])
 
 
@@ -312,6 +314,11 @@ func _on_purchase_pressed() -> void:
 
 func _show_dialog(title_text: String, body_text: String) -> void:
 	DialogManager.show_info(title_text, body_text)
+
+
+func _has_cached_opponents(overview: Dictionary) -> bool:
+	var opponents_variant: Variant = overview.get("opponents", [])
+	return opponents_variant is Array and not (opponents_variant as Array).is_empty()
 
 
 func _get_current_opponent_ids() -> Array:

--- a/scripts/gacha/GachaScene.gd
+++ b/scripts/gacha/GachaScene.gd
@@ -16,7 +16,6 @@ var _pull_buttons: Array[Button] = []
 func _ready() -> void:
 	_build_ui()
 	_render_overview()
-	call_deferred("_refresh_overview", false)
 
 
 func _build_ui() -> void:
@@ -108,11 +107,10 @@ func _build_ui() -> void:
 	root.add_child(hint)
 
 
-func _refresh_overview(show_error_dialog: bool) -> void:
-	_api_client.get_gacha_overview(func(success: bool, data: Variant, error: Dictionary) -> void:
-		if success:
-			if data is Dictionary:
-				GameState.update_gacha(data)
+func refresh_from_bootstrap(show_error_dialog: bool = true) -> void:
+	_api_client.get_authenticated_bootstrap(func(success: bool, data: Variant, error: Dictionary) -> void:
+		if success and data is Dictionary:
+			GameState.apply_player_bootstrap(data)
 			_render_overview()
 			return
 		if show_error_dialog:
@@ -183,18 +181,9 @@ func _on_pull_completed(success: bool, data: Variant, error: Dictionary) -> void
 		DialogManager.show_info("\u8a98\u6355\u5931\u6557", str(error.get("message", "\u7121\u6cd5\u5b8c\u6210\u672c\u6b21\u8a98\u6355\u3002")))
 		return
 	var payload: Dictionary = data if data is Dictionary else {}
-	var overview: Variant = payload.get("overview", {})
-	if overview is Dictionary:
-		GameState.update_gacha(overview)
-	var player_cats: Variant = payload.get("playerCats", [])
-	if player_cats is Array:
-		GameState.update_player_cats(player_cats)
-	var enhance_cats: Variant = payload.get("enhanceCats", [])
-	if enhance_cats is Array:
-		GameState.update_enhance(enhance_cats)
-	_render_overview()
 	var results_variant: Variant = payload.get("results", [])
 	var results: Array = results_variant if results_variant is Array else []
+	refresh_from_bootstrap(false)
 	_show_results(results)
 
 

--- a/scripts/scooper/ScooperScene.gd
+++ b/scripts/scooper/ScooperScene.gd
@@ -209,6 +209,22 @@ func _apply_profile_to_player_data(profile: Dictionary) -> void:
 	_refresh_resource_label()
 
 
+func refresh_from_bootstrap(on_completed: Callable = Callable()) -> void:
+	ApiClient.get_authenticated_bootstrap(func(ok: bool, data: Variant, err: Dictionary) -> void:
+		if ok and data is Dictionary:
+			GameState.apply_player_bootstrap(data)
+			_refresh_resource_label()
+			if _tab_content != null:
+				_rebuild_tab_content()
+		elif not on_completed.is_null():
+			on_completed.call(false, {}, err)
+			return
+
+		if not on_completed.is_null():
+			on_completed.call(ok, data, err)
+	)
+
+
 # ── 資源列更新 ─────────────────────────────────────────────
 
 func _refresh_resource_label() -> void:

--- a/scripts/scooper/scooper_tab_achievement.gd
+++ b/scripts/scooper/scooper_tab_achievement.gd
@@ -40,13 +40,6 @@ func build(scene: Control) -> void:
 		scene._refresh_tab_button_labels()
 	else:
 		scene._show_loading_in(scene._achievement_list)
-	scene.ApiClient.get_achievements(func(ok: bool, data: Variant, _err: Dictionary) -> void:
-		if ok and data is Array:
-			scene.GameState.update_scooper_achievement(data)
-		if scene._current_tab == "achievement":
-			_refresh_achievement_tab(scene)
-			scene._refresh_tab_button_labels()
-	)
 
 
 func _refresh_achievement_tab(scene: Control) -> void:
@@ -285,18 +278,9 @@ func _claim_achievement(scene: Control, achievement_id: int) -> void:
 			]
 		)
 
-		# 重拉成就、profile
-		scene.ApiClient.get_achievements(func(a_ok: bool, a_data: Variant, _a_err: Dictionary) -> void:
-			if a_ok and a_data is Array:
-				scene.GameState.update_scooper_achievement(a_data)
-			if scene._current_tab == "achievement":
-				_refresh_achievement_tab(scene)
-				scene._refresh_tab_button_labels()
-		)
-		scene.ApiClient.get_scooper_profile(func(p_ok: bool, p_data: Variant, _p_err: Dictionary) -> void:
-			if p_ok and p_data is Dictionary:
-				scene.GameState.update_scooper_profile(p_data)
-				scene._apply_profile_to_player_data(p_data)
+		scene.refresh_from_bootstrap(func(refresh_ok: bool, _refresh_data: Variant, refresh_err: Dictionary) -> void:
+			if not refresh_ok:
+				scene.DialogManager.show_info("同步失敗", str(refresh_err.get("message", "成就資料同步失敗")))
 		)
 	)
 

--- a/scripts/scooper/scooper_tab_memory.gd
+++ b/scripts/scooper/scooper_tab_memory.gd
@@ -39,16 +39,6 @@ func build(scene: Control) -> void:
 		_refresh_memory_tab(scene)
 	else:
 		scene._show_loading_in(scene._memory_list)
-	_fetch_memory_data(scene)
-
-
-func _fetch_memory_data(scene: Control) -> void:
-	scene.ApiClient.get_memories(func(ok: bool, data: Variant, _err: Dictionary) -> void:
-		if ok and data is Array:
-			scene.GameState.update_scooper_memory(data)
-		if scene._current_tab == "memory":
-			_refresh_memory_tab(scene)
-	)
 
 
 func _refresh_memory_tab(scene: Control) -> void:
@@ -264,7 +254,10 @@ func _confirm_unlock_memory(scene: Control, memory_id: int, memory_item: Diction
 						_memory_bonus_desc(memory_item),
 					]
 				)
-				_fetch_memory_data(scene)
+				scene.refresh_from_bootstrap(func(refresh_ok: bool, _refresh_data: Variant, refresh_err: Dictionary) -> void:
+					if not refresh_ok:
+						scene.DialogManager.show_info("同步失敗", str(refresh_err.get("message", "回憶資料同步失敗")))
+				)
 			)
 	)
 

--- a/scripts/scooper/scooper_tab_scooper.gd
+++ b/scripts/scooper/scooper_tab_scooper.gd
@@ -92,7 +92,6 @@ func build(scene: Control) -> void:
 
 	# 先用本地快取資料渲染，再拉 API 更新
 	_refresh_scooper_tab_from_local(scene)
-	_fetch_scooper_tab_data(scene)
 
 
 func process(scene: Control, delta: float) -> void:
@@ -100,29 +99,6 @@ func process(scene: Control, delta: float) -> void:
 		return
 	scene._scoop_cooldown_remaining = maxf(0.0, scene._scoop_cooldown_remaining - delta)
 	_refresh_scoop_ui(scene)
-
-
-func _fetch_scooper_tab_data(scene: Control) -> void:
-	scene.ApiClient.get_scooper_profile(func(ok: bool, data: Variant, err: Dictionary) -> void:
-		if ok and data is Dictionary:
-			scene.GameState.update_scooper_profile(data)
-			scene._apply_profile_to_player_data(data)
-		if scene._current_tab == "scooper":
-			_refresh_scooper_profile_ui(scene)
-			_refresh_scoop_ui(scene)
-	)
-	scene.ApiClient.get_abilities(func(ok: bool, data: Variant, err: Dictionary) -> void:
-		if ok and data is Array:
-			scene.GameState.update_scooper_ability(data)
-		if scene._current_tab == "scooper":
-			_refresh_ability_ui(scene)
-	)
-	scene.ApiClient.get_equipment_list(func(ok: bool, data: Variant, err: Dictionary) -> void:
-		if ok and data is Array:
-			scene.GameState.update_scooper_equipment(data)
-		if scene._current_tab == "scooper":
-			_rebuild_equip_list(scene)
-	)
 
 
 func _refresh_scooper_tab_from_local(scene: Control) -> void:
@@ -281,8 +257,14 @@ func _on_scoop_pressed(scene: Control) -> void:
 			scene._scoop_result_label.text = _format_scoop_result(result)
 
 		scene._scoop_cooldown_remaining = scene.SCOOP_COOLDOWN
-		_refresh_scooper_profile_ui(scene)
-		_refresh_scoop_ui(scene)
+		scene.refresh_from_bootstrap(func(refresh_ok: bool, _refresh_data: Variant, refresh_err: Dictionary) -> void:
+			if not refresh_ok:
+				var msg: String = refresh_err.get("message") if refresh_err.get("message") != null else "鏟屎官資料同步失敗"
+				if scene._scoop_result_label != null:
+					scene._scoop_result_label.text = msg
+				_refresh_scooper_profile_ui(scene)
+				_refresh_scoop_ui(scene)
+		)
 	)
 
 
@@ -472,18 +454,9 @@ func _do_equipment_action(scene: Control, action: String, equip_id: int) -> void
 
 
 func _refresh_resource_after_action(scene: Control) -> void:
-	scene.ApiClient.get_scooper_profile(func(ok: bool, data: Variant, _err: Dictionary) -> void:
-		if ok and data is Dictionary:
-			scene.GameState.update_scooper_profile(data)
-			scene._apply_profile_to_player_data(data)
-		if scene._current_tab == "scooper":
-			_refresh_scooper_profile_ui(scene)
-	)
-	scene.ApiClient.get_equipment_list(func(ok: bool, data: Variant, _err: Dictionary) -> void:
-		if ok and data is Array:
-			scene.GameState.update_scooper_equipment(data)
-		if scene._current_tab == "scooper":
-			_rebuild_equip_list(scene)
+	scene.refresh_from_bootstrap(func(ok: bool, _data: Variant, err: Dictionary) -> void:
+		if not ok:
+			scene.DialogManager.show_info("同步失敗", str(err.get("message", "鏟屎官資料同步失敗")))
 	)
 
 

--- a/scripts/scooper/scooper_tab_treasure.gd
+++ b/scripts/scooper/scooper_tab_treasure.gd
@@ -39,12 +39,6 @@ func build(scene: Control) -> void:
 		_refresh_treasure_tab(scene)
 	else:
 		scene._show_loading_in(scene._treasure_list)
-	scene.ApiClient.get_treasures(func(ok: bool, data: Variant, _err: Dictionary) -> void:
-		if ok and data is Array:
-			scene.GameState.update_scooper_treasure(data)
-		if scene._current_tab == "treasure":
-			_refresh_treasure_tab(scene)
-	)
 
 
 func _refresh_treasure_tab(scene: Control) -> void:

--- a/scripts/shop/ShopBundleView.gd
+++ b/scripts/shop/ShopBundleView.gd
@@ -174,14 +174,12 @@ func _on_purchase_completed(success: bool, data: Variant, error: Dictionary) -> 
 		DialogManager.show_info("\u8cfc\u8cb7\u5931\u6557", _extract_error_message(error, "\u8cfc\u8cb7\u79ae\u5305\u5931\u6557\u3002"))
 		return
 	var payload: Dictionary = data if data is Dictionary else {}
-	var overview: Variant = payload.get("overview", {})
-	if overview is Dictionary:
-		GameState.update_shop(overview)
-	var treasures_variant: Variant = payload.get("scooperTreasures", [])
-	if treasures_variant is Array:
-		GameState.update_scooper_treasure(treasures_variant)
-	_rebuild()
 	emit_signal("request_refresh")
+	var owner := get_parent()
+	if owner != null and owner.has_method("get_parent"):
+		var scene := owner.get_parent()
+		if scene != null and scene.has_method("refresh_from_bootstrap"):
+			scene.refresh_from_bootstrap(false)
 	var reward_lines: Array[String] = []
 	var rewards_variant: Variant = payload.get("grantedRewards", [])
 	if rewards_variant is Array:

--- a/scripts/shop/ShopScene.gd
+++ b/scripts/shop/ShopScene.gd
@@ -17,7 +17,6 @@ var _current_view: String = "menu"
 func _ready() -> void:
 	_build_ui()
 	_refresh_currency()
-	call_deferred("_refresh_shop_overview", false)
 
 
 func _build_ui() -> void:
@@ -108,11 +107,10 @@ func _show_bundle_view() -> void:
 	view.setup()
 
 
-func _refresh_shop_overview(show_error_dialog: bool) -> void:
-	_api_client.get_shop_overview(func(success: bool, data: Variant, error: Dictionary) -> void:
-		if success:
-			if data is Dictionary:
-				GameState.update_shop(data)
+func refresh_from_bootstrap(show_error_dialog: bool = true) -> void:
+	_api_client.get_authenticated_bootstrap(func(success: bool, data: Variant, error: Dictionary) -> void:
+		if success and data is Dictionary:
+			GameState.apply_player_bootstrap(data)
 			_refresh_currency()
 			if _current_view == "trap_cages":
 				_show_trap_cage_view()

--- a/scripts/shop/ShopTrapCageView.gd
+++ b/scripts/shop/ShopTrapCageView.gd
@@ -99,12 +99,12 @@ func _on_purchase_completed(success: bool, data: Variant, error: Dictionary) -> 
 	if not success:
 		DialogManager.show_info("\u8cfc\u8cb7\u5931\u6557", _extract_error_message(error, "\u8cfc\u8cb7\u8a98\u6355\u7c60\u5931\u6557\u3002"))
 		return
-	var payload: Dictionary = data if data is Dictionary else {}
-	var overview: Variant = payload.get("overview", {})
-	if overview is Dictionary:
-		GameState.update_shop(overview)
-	_rebuild()
 	emit_signal("request_refresh")
+	var owner := get_parent()
+	if owner != null and owner.has_method("get_parent"):
+		var scene := owner.get_parent()
+		if scene != null and scene.has_method("refresh_from_bootstrap"):
+			scene.refresh_from_bootstrap(false)
 	DialogManager.show_info("\u8cfc\u8cb7\u6210\u529f", "\u5df2\u6210\u529f\u8cfc\u8cb7\u8a98\u6355\u7c60\u3002")
 
 


### PR DESCRIPTION
## 變更摘要
- 移除鏟屎官、回憶、寶藏、成就、商店與前往誘捕進場時的額外 overview / scooper API 讀取。
- 改為優先使用 `auth/bootstrap` 已同步到 `GameState` 的資料建立畫面。
- 將鏟屎、回憶解鎖、成就領獎、商店購買、誘捕完成後的資料同步流程，統一改為重新整理 bootstrap。
- 調整競技場進場邏輯：若 bootstrap 已有對手清單，直接使用快取資料，不再立刻重抓對手。

## 測試
- 未執行 Godot 實機點擊驗證

Closes #93