### PR TITLE
fix:主畫面常駐導覽與Dialog視窗調整

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,9 @@
 - Keep Godot client changes in GDScript and follow existing scene/script patterns already used in this project.
 - Before making Client frontend architecture, UI flow, scene flow, or shared-state changes, first read `docs/gdd/18_frontend_architecture.md`.
 - Prefer adding small, explicit UI state transitions instead of rewriting whole scene flows when only one stage changes.
+- The home flow now runs through `HomeShellScene` + `SceneNavigator`; keep `BattleScene` persistent there and open home subpages as overlays instead of replacing the battle scene with `change_scene_to_file(...)`.
 - Runtime API config is environment-specific: CI generates `config/runtime_config.json`, while local development may override with ignored `config/runtime_config.local.json`.
 - Persistent local runtime data such as login session and player save files must use `user://`, not `res://`.
 - Treat auth/session `roleType`, `role`, and `permissions` as explicit API string contract values. Do not infer frontend authority from numeric enum ordering.
+- Preserve original file encoding when editing client files with Chinese text. Treat repo GDScript/docs as `UTF-8`, and avoid shell rewrite flows that can re-encode text into mojibake such as `é...`, `?��`, or corrupted `%` lines.
 - When new stable project-specific constraints are discovered during work, record them here so future changes stay consistent.

--- a/docs/gdd/18_frontend_architecture.md
+++ b/docs/gdd/18_frontend_architecture.md
@@ -14,6 +14,7 @@ This document describes the current frontend architecture of `MeowPartyDashClien
 - Primary language: GDScript
 - .NET project exists for Godot integration, but current gameplay/frontend logic is implemented in GDScript
 - Main entry scene: `res://scenes/StartScene.tscn`
+- Home shell scene: `res://scenes/HomeShellScene.tscn`
 - Theme resource: `res://resources/default_theme.tres`
 - Runtime viewport baseline: `720 x 1280`
 
@@ -32,6 +33,8 @@ Defined in `project.godot`:
   - `GameState = res://scripts/gamestate/GameState.gd`
   - `DialogManager = res://scripts/DialogManager.gd`
   - `ApiClient = res://scripts/ApiClient.gd`
+  - `ChatRealtimeClient = res://scripts/chat/ChatRealtimeClient.gd`
+  - `SceneNavigator = res://scripts/navigation/SceneNavigator.gd`
 
 ### 2.2 Start Flow
 
@@ -61,6 +64,7 @@ Project rule from `AGENTS.md`: preserve the established visual identity of `Star
 Contains top-level scene entry files such as:
 
 - `StartScene.tscn`
+- `HomeShellScene.tscn`
 - `BattleScene.tscn`
 - `ActivityScene.tscn`
 - `DungeonScene.tscn`
@@ -373,27 +377,29 @@ Do not manually patch many labels from raw response if the feature already has a
 
 ## 8. Navigation Map
 
-Current high-level navigation is scene-to-scene via `get_tree().change_scene_to_file(...)`.
+Current high-level navigation uses `HomeShellScene` for the main home loop, plus direct `get_tree().change_scene_to_file(...)` for dedicated flows.
 
 Common flow:
 
-- `StartScene` -> `BattleScene`
-- `BattleScene` bottom nav opens:
+- `StartScene` -> `HomeShellScene`
+- `HomeShellScene` keeps `BattleScene` mounted in the background
+- `BattleScene` bottom nav opens home overlays through `SceneNavigator`:
   - `ScooperScene`
   - `ConfigScene`
   - `EnhanceScene`
   - `ActivityScene`
   - `ShopScene`
+  - `MailScene`
+- `ActivityScene` can open `DungeonScene` and `ArenaScene` as deeper home overlays
+- `ShopScene` can open `GachaScene` as another home overlay
 - `ActivityScene` opens:
   - `DungeonScene`
   - `ArenaScene`
-- `ShopScene` can open:
-  - `GachaScene`
 - battle-specific routes also open:
   - `ArenaBattleScene`
   - `DungeonBattleScene`
 
-There is no central router object. Navigation is currently distributed across scene scripts.
+`SceneNavigator` coordinates the home overlays, while dedicated battle/activity routes still change scenes directly when leaving the home shell.
 
 ---
 

--- a/project.godot
+++ b/project.godot
@@ -21,6 +21,7 @@ GameState="*res://scripts/gamestate/GameState.gd"
 DialogManager="*res://scripts/DialogManager.gd"
 ApiClient="*res://scripts/ApiClient.gd"
 ChatRealtimeClient="*res://scripts/chat/ChatRealtimeClient.gd"
+SceneNavigator="*res://scripts/navigation/SceneNavigator.gd"
 
 [display]
 

--- a/scenes/HomeShellScene.tscn
+++ b/scenes/HomeShellScene.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/navigation/HomeShellScene.gd" id="1"]
+
+[node name="HomeShellScene" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1")

--- a/scripts/ActivityScene.gd
+++ b/scripts/ActivityScene.gd
@@ -98,12 +98,12 @@ func _make_entry_button(title_text: String, subtitle_text: String, callback: Cal
 
 
 func _on_dungeon_pressed() -> void:
-	get_tree().change_scene_to_file("res://scenes/DungeonScene.tscn")
+	SceneNavigator.open_overlay_scene("res://scenes/DungeonScene.tscn")
 
 
 func _on_arena_pressed() -> void:
-	get_tree().change_scene_to_file("res://scenes/ArenaScene.tscn")
+	SceneNavigator.open_overlay_scene("res://scenes/ArenaScene.tscn")
 
 
 func _on_back_pressed() -> void:
-	get_tree().change_scene_to_file("res://scenes/BattleScene.tscn")
+	SceneNavigator.return_to_battle()

--- a/scripts/DialogManager.gd
+++ b/scripts/DialogManager.gd
@@ -13,6 +13,8 @@
 extends Node
 
 const _PANEL_MIN_W := 480.0
+const _PANEL_W_MEDIUM := 560.0
+const _PANEL_W_LARGE := 640.0
 const _PANEL_MIN_H := 0.0
 const _FONT_TITLE   := 22
 const _FONT_CONTENT := 18
@@ -24,16 +26,16 @@ const _INERTIAL_SCROLL := preload("res://scripts/ui/inertial_scroll.gd")
 
 # ── 公開 API ────────────────────────────────────────────
 
-func show_info(title: String, text: String, on_close: Callable = Callable()) -> Callable:
+func show_info(title: String, text: String, on_close: Callable = Callable(), width_size: String = "small") -> Callable:
 	var lbl := Label.new()
 	lbl.text = text
 	lbl.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	lbl.add_theme_font_size_override("font_size", _FONT_CONTENT)
-	return _build(title, lbl, false, on_close, Callable())
+	return _build(title, lbl, false, on_close, Callable(), "確定", "取消", width_size)
 
 
 ## 回傳一個 Callable，呼叫它可從外部主動關閉這個 dialog
-func show_info_node(title: String, content: Control, on_close: Callable = Callable()) -> Callable:
+func show_info_node(title: String, content: Control, on_close: Callable = Callable(), width_size: String = "small") -> Callable:
 	# If the content is a ScrollContainer, attach the inertial scroller helper so touch drag has inertia/bounce
 	if content is ScrollContainer:
 		# Prefer calling the registered class; fallback to the preloaded script if needed
@@ -41,7 +43,7 @@ func show_info_node(title: String, content: Control, on_close: Callable = Callab
 			InertialScroller.attach(content)
 		elif _INERTIAL_SCROLL != null:
 			_INERTIAL_SCROLL.attach(content)
-	return _build(title, content, false, on_close, Callable())
+	return _build(title, content, false, on_close, Callable(), "確定", "取消", width_size)
 
 
 func show_confirm(
@@ -50,13 +52,50 @@ func show_confirm(
 		on_confirm: Callable,
 		on_cancel: Callable = Callable(),
 		ok_text: String = "確定",
-		cancel_text: String = "取消"
+		cancel_text: String = "取消",
+		width_size: String = "small"
 ) -> Callable:
 	var lbl := Label.new()
 	lbl.text = text
 	lbl.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	lbl.add_theme_font_size_override("font_size", _FONT_CONTENT)
-	return _build(title, lbl, true, on_confirm, on_cancel, ok_text, cancel_text)
+	return _build(title, lbl, true, on_confirm, on_cancel, ok_text, cancel_text, width_size)
+
+
+func _resolve_panel_width(width_size: String) -> float:
+	match width_size.to_lower():
+		"medium":
+			return _PANEL_W_MEDIUM
+		"large":
+			return _PANEL_W_LARGE
+		_:
+			return _PANEL_MIN_W
+
+
+func _measure_label_min_size(label: Label, content_width: float) -> Vector2:
+	var font: Font = label.get_theme_font("font")
+	var font_size := label.get_theme_font_size("font_size")
+	if font == null:
+		return Vector2(content_width, 4.0 * 24.0)
+
+	var line_height := font.get_height(font_size)
+	var measured_lines := 0
+	for raw_line: String in label.text.split("\n", false):
+		var line_text := raw_line if raw_line != "" else " "
+		var line_width := font.get_string_size(line_text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x
+		measured_lines += maxi(1, ceili(line_width / maxf(1.0, content_width)))
+
+	measured_lines = maxi(measured_lines, 1)
+	return Vector2(content_width, measured_lines * line_height)
+
+
+func _get_content_min_size(content: Control, content_width: float) -> Vector2:
+	if content is Label:
+		return _measure_label_min_size(content as Label, content_width)
+
+	var min_size := content.get_combined_minimum_size()
+	min_size.x = maxf(min_size.x, content_width)
+	return min_size
 
 
 # ── 內部建構 ────────────────────────────────────────────
@@ -69,8 +108,15 @@ func _build(
 		on_ok: Callable,
 		on_cancel: Callable,
 		ok_text: String = "確定",
-		cancel_text: String = "取消"
+		cancel_text: String = "取消",
+		width_size: String = "small"
 ) -> Callable:
+	var panel_width := _resolve_panel_width(width_size)
+	var content_width := panel_width - 32.0
+	if content is Label or content is RichTextLabel:
+		content.custom_minimum_size.x = content_width
+	content.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+
 	var canvas := CanvasLayer.new()
 	canvas.layer = 100
 	add_child(canvas)
@@ -102,11 +148,12 @@ func _build(
 	var dialog_stack := VBoxContainer.new()
 	dialog_stack.alignment = BoxContainer.ALIGNMENT_CENTER
 	dialog_stack.add_theme_constant_override("separation", 10)
+	dialog_stack.custom_minimum_size.x = panel_width
 	center.add_child(dialog_stack)
 
 	# 主面板（吸收點擊，避免穿透到 overlay）
 	var panel := PanelContainer.new()
-	panel.custom_minimum_size = Vector2(_PANEL_MIN_W, _PANEL_MIN_H)
+	panel.custom_minimum_size = Vector2(panel_width, _PANEL_MIN_H)
 	var panel_style := StyleBoxFlat.new()
 	panel_style.bg_color = Color(0.12, 0.12, 0.12, 0.98)
 	panel_style.border_width_left = 2
@@ -130,6 +177,8 @@ func _build(
 	var vbox := VBoxContainer.new()
 	vbox.add_theme_constant_override("separation", 12)
 	margin.add_child(vbox)
+	var hint_lbl: Label = null
+	var btn_row: HBoxContainer = null
 
 	# 標題列
 	var title_row := HBoxContainer.new()
@@ -158,7 +207,7 @@ func _build(
 	vbox.add_child(content)
 
 	if not is_confirm:
-		var hint_lbl := Label.new()
+		hint_lbl = Label.new()
 		hint_lbl.text = "點擊任意處關閉視窗"
 		hint_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 		hint_lbl.mouse_filter = Control.MOUSE_FILTER_IGNORE
@@ -167,21 +216,10 @@ func _build(
 		dialog_stack.add_child(hint_lbl)
 
 	if is_confirm:
-		var btn_row := HBoxContainer.new()
+		btn_row = HBoxContainer.new()
 		btn_row.alignment = BoxContainer.ALIGNMENT_CENTER
 		btn_row.add_theme_constant_override("separation", 16)
 		vbox.add_child(btn_row)
-
-		var ok_btn := Button.new()
-		ok_btn.text = ok_text
-		ok_btn.custom_minimum_size = Vector2(110.0, 44.0)
-		ok_btn.add_theme_font_size_override("font_size", _FONT_BTN)
-		ok_btn.pressed.connect(func() -> void:
-			canvas.queue_free()
-			if on_ok.is_valid():
-				on_ok.call()
-		)
-		btn_row.add_child(ok_btn)
 
 		var cancel_btn := Button.new()
 		cancel_btn.text = cancel_text
@@ -192,6 +230,29 @@ func _build(
 			if on_cancel.is_valid():
 				on_cancel.call()
 		)
+		var ok_btn := Button.new()
+		ok_btn.text = ok_text
+		ok_btn.custom_minimum_size = Vector2(110.0, 44.0)
+		ok_btn.add_theme_font_size_override("font_size", _FONT_BTN)
+		ok_btn.pressed.connect(func() -> void:
+			canvas.queue_free()
+			if on_ok.is_valid():
+				on_ok.call()
+		)
+		btn_row.add_child(ok_btn)
 		btn_row.add_child(cancel_btn)
 
+	var content_min := _get_content_min_size(content, content_width)
+	var title_min := title_row.get_combined_minimum_size()
+	var button_min := btn_row.get_combined_minimum_size() if is_confirm else Vector2.ZERO
+	var hint_min := hint_lbl.get_combined_minimum_size() if not is_confirm else Vector2.ZERO
+	var vertical_gap := 12.0
+	var body_height := title_min.y + content_min.y
+	if is_confirm:
+		body_height += vertical_gap + button_min.y
+	panel.custom_minimum_size = Vector2(
+		panel_width,
+		maxf(_PANEL_MIN_H, body_height + 32.0)
+	)
+	dialog_stack.custom_minimum_size = Vector2(panel.custom_minimum_size.x, panel.custom_minimum_size.y + hint_min.y + (10.0 if not is_confirm else 0.0))
 	return func() -> void: canvas.queue_free()

--- a/scripts/MailScene.gd
+++ b/scripts/MailScene.gd
@@ -1,7 +1,5 @@
 extends Control
 
-const BATTLE_SCENE_PATH := "res://scenes/BattleScene.tscn"
-
 var _summary_label: Label
 var _mail_list: ItemList
 var _detail_title: Label
@@ -11,10 +9,12 @@ var _attachment_box: VBoxContainer
 var _claim_btn: Button
 var _claim_all_btn: Button
 var _status_label: Label
+var _close_action: Callable = Callable()
 
 
 func _ready() -> void:
 	set_anchors_preset(Control.PRESET_FULL_RECT)
+	custom_minimum_size = Vector2(620, 900)
 	_build_ui()
 	_refresh_summary()
 	_populate_mail_list()
@@ -23,6 +23,10 @@ func _ready() -> void:
 		_on_mail_selected(0)
 	else:
 		_render_detail({})
+
+
+func set_close_action(action: Callable) -> void:
+	_close_action = action
 
 
 func _build_ui() -> void:
@@ -51,7 +55,10 @@ func _build_ui() -> void:
 	back_btn.text = "返回"
 	back_btn.custom_minimum_size = Vector2(92, 48)
 	back_btn.pressed.connect(func() -> void:
-		get_tree().change_scene_to_file(BATTLE_SCENE_PATH)
+		if _close_action.is_valid():
+			_close_action.call()
+		else:
+			SceneNavigator.return_to_battle()
 	)
 	header.add_child(back_btn)
 
@@ -304,7 +311,7 @@ func _render_reward_dialog(rewards: Variant, title: String) -> void:
 			])
 	if lines.is_empty():
 		lines.append("沒有可顯示的獎勵。")
-	DialogManager.show_info(title, "\n".join(lines))
+	DialogManager.show_info(title, "\n".join(lines), Callable(), "large")
 
 
 func _refresh_summary() -> void:

--- a/scripts/StartScene.gd
+++ b/scripts/StartScene.gd
@@ -1,6 +1,5 @@
 extends Control
 
-const BATTLE_SCENE_PATH := "res://scenes/BattleScene.tscn"
 const HERO_IMAGE := preload("res://assets/sprites/ui/start_scene_homey_v1.png")
 const TITLE_TEXT := "\u55b5\u55b5\u885d\u649e\u6d3e\u5c0d"
 const SUBTITLE_TEXT := "\u93df\u5c4e\u5b98\u4e5f\u60f3\u7576\u8c93"
@@ -773,7 +772,7 @@ func _update_loading_progress(value: float) -> void:
 func _start_game() -> void:
 	if not _input_ready:
 		return
-	get_tree().change_scene_to_file(BATTLE_SCENE_PATH)
+	SceneNavigator.enter_home_shell()
 
 
 func _input(event: InputEvent) -> void:

--- a/scripts/arenaScene/ArenaScene.gd
+++ b/scripts/arenaScene/ArenaScene.gd
@@ -61,7 +61,7 @@ func _build_ui() -> void:
 	var back_button := Button.new()
 	back_button.text = "返回"
 	back_button.custom_minimum_size = Vector2(100.0, 50.0)
-	back_button.pressed.connect(func() -> void: get_tree().change_scene_to_file("res://scenes/ActivityScene.tscn"))
+	back_button.pressed.connect(func() -> void: SceneNavigator.open_overlay_scene("res://scenes/ActivityScene.tscn"))
 	top_row.add_child(back_button)
 
 	var title := Label.new()

--- a/scripts/battle/arena_battle_scene.gd
+++ b/scripts/battle/arena_battle_scene.gd
@@ -371,7 +371,7 @@ func _start_battle() -> void:
 
 	if player_cats.is_empty() or enemy_cats.is_empty():
 		DialogManager.show_info("競技場", "隊伍資料不足，無法開始對戰。", func() -> void:
-			get_tree().change_scene_to_file("res://scenes/ArenaScene.tscn")
+			SceneNavigator.open_overlay_scene("res://scenes/ArenaScene.tscn")
 		)
 		return
 
@@ -399,7 +399,7 @@ func _handle_result(is_win: bool) -> void:
 		_settling = false
 		if not success or not (data is Dictionary):
 			DialogManager.show_info("競技場結算", str(error.get("message", "競技場結算失敗。")), func() -> void:
-				get_tree().change_scene_to_file("res://scenes/ArenaScene.tscn")
+				SceneNavigator.open_overlay_scene("res://scenes/ArenaScene.tscn")
 			)
 			return
 		var response: Dictionary = data
@@ -470,9 +470,9 @@ func _show_result_popup(response: Dictionary) -> void:
 		if event is InputEventMouseButton and event.pressed:
 			area.queue_free()
 			popup.queue_free()
-			get_tree().change_scene_to_file("res://scenes/ArenaScene.tscn")
+			SceneNavigator.open_overlay_scene("res://scenes/ArenaScene.tscn")
 	)
 
 
 func _on_retreat_pressed() -> void:
-	get_tree().change_scene_to_file("res://scenes/ArenaScene.tscn")
+	SceneNavigator.open_overlay_scene("res://scenes/ArenaScene.tscn")

--- a/scripts/battle/battle_scene.gd
+++ b/scripts/battle/battle_scene.gd
@@ -29,7 +29,7 @@ var _enemy_team: Node2D
 var _battle_manager: BattleManager
 
 # ── UI 節點 ───────────────────────────────────
-var _ui_layer: CanvasLayer
+var _ui_layer: Control
 var _timer_label: Label
 var _speed_1x: Button
 var _speed_2x: Button
@@ -115,7 +115,9 @@ func _build_battle_area() -> void:
 
 
 func _build_ui() -> void:
-	_ui_layer = CanvasLayer.new()
+	_ui_layer = Control.new()
+	_ui_layer.name = "BattleUiLayer"
+	_ui_layer.set_anchors_preset(Control.PRESET_FULL_RECT)
 	add_child(_ui_layer)
 
 	# 速度按鈕
@@ -508,7 +510,7 @@ func _apply_equipment_bonuses(data: CatData) -> void:
 
 
 func _on_nav_scooper() -> void:
-	get_tree().change_scene_to_file("res://scenes/ScooperScene.tscn")
+	SceneNavigator.open_overlay_scene("res://scenes/ScooperScene.tscn")
 
 
 ## 顯示貓砂盆互動視窗：掛機獎勵領取（完整分鐘）+ 屎堆鏟除
@@ -621,27 +623,36 @@ func _show_sandbox_dialog() -> void:
 
 
 func _on_nav_config() -> void:
-	get_tree().change_scene_to_file("res://scenes/ConfigScene.tscn")
+	SceneNavigator.open_overlay_scene("res://scenes/ConfigScene.tscn")
 
 
 func _on_nav_enhance() -> void:
-	get_tree().change_scene_to_file("res://scenes/EnhanceScene.tscn")
+	SceneNavigator.open_overlay_scene("res://scenes/EnhanceScene.tscn")
 
 
 func _on_nav_activity() -> void:
-	get_tree().change_scene_to_file("res://scenes/ActivityScene.tscn")
+	SceneNavigator.open_overlay_scene("res://scenes/ActivityScene.tscn")
 
 
 func _on_nav_shop() -> void:
-	get_tree().change_scene_to_file("res://scenes/ShopScene.tscn")
+	SceneNavigator.open_overlay_scene("res://scenes/ShopScene.tscn")
 
 
 func _on_nav_mail() -> void:
-	get_tree().change_scene_to_file("res://scenes/MailScene.tscn")
+	var mail_view: Control = load("res://scenes/MailScene.tscn").instantiate()
+	if mail_view.has_method("set_close_action"):
+		var close_dialog := [Callable()]
+		mail_view.set_close_action(func() -> void:
+			if close_dialog[0].is_valid():
+				close_dialog[0].call()
+		)
+		close_dialog[0] = DialogManager.show_info_node("郵件", mail_view, Callable(), "large")
+	else:
+		DialogManager.show_info_node("郵件", mail_view, Callable(), "large")
 
 func _open_chat() -> void:
 	var chat_view: Control = CHAT_SCENE.instantiate()
-	DialogManager.show_info_node("Chat", chat_view)
+	DialogManager.show_info_node("Chat", chat_view, Callable(), "large")
 
 
 func _refresh_chat_badge() -> void:

--- a/scripts/battle/dungeon_battle_scene.gd
+++ b/scripts/battle/dungeon_battle_scene.gd
@@ -378,7 +378,7 @@ func _on_battle_finished(result: String) -> void:
 	else:
 		_show_result_text("敗北", Color(1.0, 0.3, 0.3, 1.0), 310.0)
 		await get_tree().create_timer(1.0).timeout
-		get_tree().change_scene_to_file("res://scenes/DungeonScene.tscn")
+		SceneNavigator.open_overlay_scene("res://scenes/DungeonScene.tscn")
 
 
 func _handle_win() -> void:
@@ -403,7 +403,7 @@ func _on_complete_challenge(success: bool, data: Variant, error: Dictionary) -> 
 
 	var message := str(error.get("message", "挑戰結算失敗。"))
 	DialogManager.show_info("挑戰結算失敗", message, func():
-		get_tree().change_scene_to_file("res://scenes/DungeonScene.tscn")
+		SceneNavigator.open_overlay_scene("res://scenes/DungeonScene.tscn")
 	)
 
 
@@ -421,7 +421,7 @@ func _show_reward_popup(level: int, rewards: Dictionary) -> void:
 		lines.append("  鬍鬚碎片 ×%d" % int(rewards.get("whiskerShards", 0)))
 
 	DialogManager.show_info("挑戰完成", "\n".join(lines), func():
-		get_tree().change_scene_to_file("res://scenes/DungeonScene.tscn")
+		SceneNavigator.open_overlay_scene("res://scenes/DungeonScene.tscn")
 	)
 
 
@@ -433,4 +433,4 @@ func _show_result_text(text: String, color: Color, y: float) -> void:
 
 
 func _on_retreat_pressed() -> void:
-	get_tree().change_scene_to_file("res://scenes/DungeonScene.tscn")
+	SceneNavigator.open_overlay_scene("res://scenes/DungeonScene.tscn")

--- a/scripts/chat/ChatScene.gd
+++ b/scripts/chat/ChatScene.gd
@@ -15,7 +15,7 @@ var _load_more_button: Button
 
 
 func _ready() -> void:
-	custom_minimum_size = Vector2(620, 820)
+	custom_minimum_size = Vector2(620, 900)
 	_build_ui()
 	GameState.chat_connection_state_changed.connect(_on_connection_state_changed)
 	GameState.chat_messages_changed.connect(_on_messages_changed)

--- a/scripts/configs/ConfigScene.gd
+++ b/scripts/configs/ConfigScene.gd
@@ -496,4 +496,4 @@ func _on_back_pressed() -> void:
 	var boss_team: Dictionary = GameState.get_team("Boss")
 	var boss_members: Array = boss_team.get("members", [])
 	GameState.player_team = boss_members.map(func(m: Dictionary) -> int: return int(m.get("playerCatId", 0)))
-	get_tree().change_scene_to_file("res://scenes/BattleScene.tscn")
+	SceneNavigator.return_to_battle()

--- a/scripts/dungeon/DungeonScene.gd
+++ b/scripts/dungeon/DungeonScene.gd
@@ -72,4 +72,4 @@ func _get_local_dungeon_cfg(dungeon_key: String) -> Dictionary:
 
 
 func _on_back_pressed() -> void:
-	get_tree().change_scene_to_file("res://scenes/ActivityScene.tscn")
+	SceneNavigator.open_overlay_scene("res://scenes/ActivityScene.tscn")

--- a/scripts/enhance/EnhanceScene.gd
+++ b/scripts/enhance/EnhanceScene.gd
@@ -149,7 +149,7 @@ func _make_separator() -> HSeparator:
 
 
 func _on_back_pressed() -> void:
-	get_tree().change_scene_to_file("res://scenes/BattleScene.tscn")
+	SceneNavigator.return_to_battle()
 
 
 func _get_selected_player_cat_id() -> int:

--- a/scripts/gacha/GachaScene.gd
+++ b/scripts/gacha/GachaScene.gd
@@ -43,7 +43,7 @@ func _build_ui() -> void:
 	back_button.text = "返回"
 	back_button.custom_minimum_size = Vector2(100.0, 50.0)
 	back_button.pressed.connect(func() -> void:
-		get_tree().change_scene_to_file("res://scenes/ShopScene.tscn")
+		SceneNavigator.open_overlay_scene("res://scenes/ShopScene.tscn")
 	)
 	top_row.add_child(back_button)
 

--- a/scripts/navigation/HomeShellScene.gd
+++ b/scripts/navigation/HomeShellScene.gd
@@ -1,0 +1,53 @@
+extends Control
+
+const BATTLE_SCENE := preload("res://scenes/BattleScene.tscn")
+
+var _battle_scene: Node
+var _overlay_root: Control
+
+
+func _ready() -> void:
+	set_anchors_preset(Control.PRESET_FULL_RECT)
+	_build_shell()
+	SceneNavigator.register_home_shell(self)
+
+
+func _exit_tree() -> void:
+	SceneNavigator.unregister_home_shell(self)
+
+
+func show_overlay_scene(scene_path: String) -> void:
+	clear_overlay_scene()
+	if scene_path == "":
+		_overlay_root.mouse_filter = Control.MOUSE_FILTER_IGNORE
+		return
+
+	var packed_scene := load(scene_path) as PackedScene
+	if packed_scene == null:
+		push_error("HomeShellScene: failed to load overlay scene %s" % scene_path)
+		_overlay_root.mouse_filter = Control.MOUSE_FILTER_IGNORE
+		return
+
+	var overlay := packed_scene.instantiate()
+	_overlay_root.mouse_filter = Control.MOUSE_FILTER_STOP
+	_overlay_root.add_child(overlay)
+	if overlay is Control:
+		overlay.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+		overlay.set_deferred("size", get_viewport_rect().size)
+
+
+func clear_overlay_scene() -> void:
+	for child in _overlay_root.get_children():
+		child.queue_free()
+	_overlay_root.mouse_filter = Control.MOUSE_FILTER_IGNORE
+
+
+func _build_shell() -> void:
+	_battle_scene = BATTLE_SCENE.instantiate()
+	add_child(_battle_scene)
+
+	_overlay_root = Control.new()
+	_overlay_root.name = "OverlayRoot"
+	_overlay_root.set_anchors_preset(Control.PRESET_FULL_RECT)
+	_overlay_root.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	add_child(_overlay_root)

--- a/scripts/navigation/SceneNavigator.gd
+++ b/scripts/navigation/SceneNavigator.gd
@@ -1,0 +1,40 @@
+extends Node
+
+const HOME_SHELL_SCENE_PATH := "res://scenes/HomeShellScene.tscn"
+
+var _home_shell: Node = null
+var _pending_overlay_scene_path: String = ""
+
+
+func register_home_shell(shell: Node) -> void:
+	_home_shell = shell
+	if _pending_overlay_scene_path != "":
+		var pending_path := _pending_overlay_scene_path
+		_pending_overlay_scene_path = ""
+		_home_shell.call_deferred("show_overlay_scene", pending_path)
+
+
+func unregister_home_shell(shell: Node) -> void:
+	if _home_shell == shell:
+		_home_shell = null
+
+
+func enter_home_shell() -> void:
+	_pending_overlay_scene_path = ""
+	get_tree().change_scene_to_file(HOME_SHELL_SCENE_PATH)
+
+
+func open_overlay_scene(scene_path: String) -> void:
+	if _home_shell != null and is_instance_valid(_home_shell):
+		_home_shell.call_deferred("show_overlay_scene", scene_path)
+		return
+	_pending_overlay_scene_path = scene_path
+	get_tree().change_scene_to_file(HOME_SHELL_SCENE_PATH)
+
+
+func return_to_battle() -> void:
+	if _home_shell != null and is_instance_valid(_home_shell):
+		_home_shell.call_deferred("clear_overlay_scene")
+		return
+	_pending_overlay_scene_path = ""
+	get_tree().change_scene_to_file(HOME_SHELL_SCENE_PATH)

--- a/scripts/shop/ShopScene.gd
+++ b/scripts/shop/ShopScene.gd
@@ -147,8 +147,8 @@ func _on_back_pressed() -> void:
 	if _current_view != "menu":
 		_show_menu()
 		return
-	get_tree().change_scene_to_file("res://scenes/BattleScene.tscn")
+	SceneNavigator.return_to_battle()
 
 
 func _open_gacha_scene() -> void:
-	get_tree().change_scene_to_file("res://scenes/GachaScene.tscn")
+	SceneNavigator.open_overlay_scene("res://scenes/GachaScene.tscn")


### PR DESCRIPTION
## 摘要
- 新增 HomeShellScene 與 SceneNavigator，讓 BattleScene 在主畫面流程中常駐
- 將主畫面各子頁導覽改為 overlay/dialog 流程，避免直接 replace BattleScene
- 調整 DialogManager 支援 small/medium/large 寬度、依內容調整高度、確定按鈕固定在左側
- 將 Chat 與郵件改為 large dialog，並固定內容尺寸為 620x900

## 驗證
- 使用 Godot 4.6.2 console 啟動 HomeShellScene，確認專案可正常載入
- 針對鏟屎官、配置、強化 overlay 流程做實際載入檢查
- 驗證 Chat / 郵件 dialog 相關 parser error 已排除

## 關聯 Issue
Closes #97