### PR TITLE
fix:修正戰鬥場景清理貓砂盆對話框與局部同步流程

### DIFF
--- a/scripts/ApiClient.gd
+++ b/scripts/ApiClient.gd
@@ -64,6 +64,10 @@ func scoop_poop(count: int, callback: Callable) -> void:
 	_api_post("scooper/profile/scoop", {"count": count}, callback)
 
 
+func claim_idle_rewards(callback: Callable) -> void:
+	_api_post("scooper/profile/claim-idle", {}, callback)
+
+
 func get_equipment_list(callback: Callable) -> void:
 	_api_get("scooper/equipment", callback)
 

--- a/scripts/DialogManager.gd
+++ b/scripts/DialogManager.gd
@@ -116,6 +116,7 @@ func _build(
 	if content is Label or content is RichTextLabel:
 		content.custom_minimum_size.x = content_width
 	content.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	content.size_flags_vertical = 0
 
 	var canvas := CanvasLayer.new()
 	canvas.layer = 100
@@ -149,11 +150,13 @@ func _build(
 	dialog_stack.alignment = BoxContainer.ALIGNMENT_CENTER
 	dialog_stack.add_theme_constant_override("separation", 10)
 	dialog_stack.custom_minimum_size.x = panel_width
+	dialog_stack.size_flags_vertical = 0
 	center.add_child(dialog_stack)
 
 	# 主面板（吸收點擊，避免穿透到 overlay）
 	var panel := PanelContainer.new()
 	panel.custom_minimum_size = Vector2(panel_width, _PANEL_MIN_H)
+	panel.size_flags_vertical = 0
 	var panel_style := StyleBoxFlat.new()
 	panel_style.bg_color = Color(0.12, 0.12, 0.12, 0.98)
 	panel_style.border_width_left = 2
@@ -170,12 +173,14 @@ func _build(
 	dialog_stack.add_child(panel)
 
 	var margin := MarginContainer.new()
+	margin.size_flags_vertical = 0
 	for side: String in ["left", "right", "top", "bottom"]:
 		margin.add_theme_constant_override("margin_" + side, 16)
 	panel.add_child(margin)
 
 	var vbox := VBoxContainer.new()
 	vbox.add_theme_constant_override("separation", 12)
+	vbox.size_flags_vertical = 0
 	margin.add_child(vbox)
 	var hint_lbl: Label = null
 	var btn_row: HBoxContainer = null
@@ -183,6 +188,7 @@ func _build(
 	# 標題列
 	var title_row := HBoxContainer.new()
 	title_row.add_theme_constant_override("separation", 8)
+	title_row.size_flags_vertical = 0
 	vbox.add_child(title_row)
 
 	var title_lbl := Label.new()
@@ -254,5 +260,30 @@ func _build(
 		panel_width,
 		maxf(_PANEL_MIN_H, body_height + 32.0)
 	)
+	panel.size = panel.custom_minimum_size
 	dialog_stack.custom_minimum_size = Vector2(panel.custom_minimum_size.x, panel.custom_minimum_size.y + hint_min.y + (10.0 if not is_confirm else 0.0))
+	call_deferred("_fit_dialog_to_content", panel, margin, vbox, dialog_stack, hint_lbl, panel_width)
 	return func() -> void: canvas.queue_free()
+
+
+func _fit_dialog_to_content(
+		panel: PanelContainer,
+		margin: MarginContainer,
+		vbox: VBoxContainer,
+		dialog_stack: VBoxContainer,
+		hint_lbl: Label,
+		panel_width: float
+) -> void:
+	if not is_instance_valid(panel) or not is_instance_valid(margin) or not is_instance_valid(vbox) or not is_instance_valid(dialog_stack):
+		return
+
+	var body_height := vbox.get_combined_minimum_size().y
+	var panel_height := maxf(_PANEL_MIN_H, body_height + 32.0)
+	panel.custom_minimum_size = Vector2(panel_width, panel_height)
+	panel.size = panel.custom_minimum_size
+
+	var hint_height := 0.0
+	if is_instance_valid(hint_lbl):
+		hint_height = hint_lbl.get_combined_minimum_size().y + 10.0
+
+	dialog_stack.custom_minimum_size = Vector2(panel_width, panel_height + hint_height)

--- a/scripts/battle/battle_scene.gd
+++ b/scripts/battle/battle_scene.gd
@@ -527,7 +527,6 @@ func _show_sandbox_dialog() -> void:
 	# ── 掛機獎勵區 ────────────────────────────────────────
 	var rewards_section := VBoxContainer.new()
 	rewards_section.add_theme_constant_override("separation", 6)
-	rewards_section.visible = has_rewards
 
 	if has_rewards:
 		var h := complete_minutes / 60
@@ -552,12 +551,12 @@ func _show_sandbox_dialog() -> void:
 				lbl.add_theme_font_size_override("font_size", 18)
 				rewards_section.add_child(lbl)
 
-	vbox.add_child(rewards_section)
+	if has_rewards:
+		vbox.add_child(rewards_section)
 
 	# ── 鏟屎互動區 ────────────────────────────────────────
 	var scoop_section := VBoxContainer.new()
 	scoop_section.add_theme_constant_override("separation", 8)
-	scoop_section.visible = not has_rewards and GameState.player_data.poop_count > 0
 
 	var poop_count_lbl := Label.new()
 	poop_count_lbl.text = "待鏟屎堆：%d 個" % GameState.player_data.poop_count
@@ -575,22 +574,41 @@ func _show_sandbox_dialog() -> void:
 	scoop_btn.custom_minimum_size = Vector2(160.0, 52.0)
 	scoop_btn.disabled = GameState.player_data.poop_count <= 0
 	scoop_btn.pressed.connect(func() -> void:
-		var r := GameState.scoop_poop()
-		var remaining := GameState.player_data.poop_count
-		poop_count_lbl.text = "💩 待鏟屎堆：%d 個" % remaining
-		var parts := []
-		if r.get("exp", 0) > 0:
-			parts.append("EXP +%d" % r["exp"])
-		if r.get("memory_shards", 0) > 0:
-			parts.append("回憶碎片 +%d" % r["memory_shards"])
-		if r.get("whiskers", 0) > 0:
-			parts.append("鬍鬚 +%d" % r["whiskers"])
-		result_lbl.text = "（空手而歸）" if parts.is_empty() else "獲得：" + "、".join(parts)
-		scoop_btn.disabled = remaining <= 0
-		_refresh_sandbox_btn()
+		if scoop_btn.disabled:
+			return
+		scoop_btn.disabled = true
+		result_lbl.text = ""
+		ApiClient.scoop_poop(1, func(ok: bool, data: Variant, err: Dictionary) -> void:
+			if not ok:
+				result_lbl.text = str(err.get("message", "鏟屎失敗"))
+				scoop_btn.disabled = GameState.player_data.poop_count <= 0
+				return
+
+			var result: Dictionary = data if data is Dictionary else {}
+			var updated_profile: Variant = result.get("updatedProfile", {})
+			if updated_profile is Dictionary:
+				GameState.update_scooper_profile(updated_profile)
+
+			var remaining := GameState.player_data.poop_count
+			poop_count_lbl.text = "💩 待鏟屎堆：%d 個" % remaining
+			var parts: Array[String] = []
+			var exp_gained := int(result.get("expGained", 0))
+			if exp_gained > 0:
+				parts.append("EXP +%d" % exp_gained)
+			var memory_shards_gained := int(result.get("memoryShardsGained", 0))
+			if memory_shards_gained > 0:
+				parts.append("回憶碎片 +%d" % memory_shards_gained)
+			var whiskers_gained := int(result.get("WhiskersGained", result.get("whiskersGained", 0)))
+			if whiskers_gained > 0:
+				parts.append("鬍鬚 +%d" % whiskers_gained)
+			result_lbl.text = "（空手而歸）" if parts.is_empty() else "獲得：" + "、".join(parts)
+			scoop_btn.disabled = remaining <= 0
+			_refresh_sandbox_btn()
+		)
 	)
 	scoop_section.add_child(scoop_btn)
-	vbox.add_child(scoop_section)
+	if not has_rewards and GameState.player_data.poop_count > 0:
+		vbox.add_child(scoop_section)
 
 	# ── 領取按鈕 ───────────────────────────────────────────
 	var close_ref := [Callable()]
@@ -600,22 +618,32 @@ func _show_sandbox_dialog() -> void:
 		claim_btn.text = "領取獎勵"
 		claim_btn.custom_minimum_size = Vector2(200.0, 52.0)
 		claim_btn.pressed.connect(func() -> void:
-			var claimed := rewards.duplicate()
-			GameState.claim_idle_rewards()
-			close_ref[0].call()
-			_refresh_sandbox_btn()
-			var lines := []
-			for entry: Array in [
-				["💰 金幣",   "gold"],
-				["💩 屎堆",   "poop"],
-				["🍖 貓糧",   "cat_food"],
-				["💎 鑽石",   "diamonds"],
-				["🐱 鬍鬚",   "whiskers"],
-			]:
-				var val: int = claimed.get(entry[1], 0)
-				if val > 0:
-					lines.append("  %s  +%d" % [entry[0], val])
-			DialogManager.show_info("領取成功！", "\n".join(lines))
+			claim_btn.disabled = true
+			ApiClient.claim_idle_rewards(func(ok: bool, data: Variant, err: Dictionary) -> void:
+				claim_btn.disabled = false
+				if not ok:
+					DialogManager.show_info("領取失敗", str(err.get("message", "掛機獎勵領取失敗")))
+					return
+
+				var response: Dictionary = data if data is Dictionary else {}
+				GameState.apply_idle_claim_response(response)
+				close_ref[0].call()
+				_refresh_sandbox_btn()
+
+				var claimed: Dictionary = response.get("rewards", {})
+				var lines: Array[String] = []
+				for entry: Array in [
+					["💰 金幣",   "gold"],
+					["💩 屎堆",   "poop"],
+					["🍖 貓糧",   "cat_food"],
+					["💎 鑽石",   "diamonds"],
+					["🐱 鬍鬚",   "whiskers"],
+				]:
+					var val: int = int(claimed.get(entry[1], 0))
+					if val > 0:
+						lines.append("  %s  +%d" % [entry[0], val])
+				DialogManager.show_info("領取成功！", "\n".join(lines))
+			)
 		)
 		vbox.add_child(claim_btn)
 

--- a/scripts/gamestate/GameState.gd
+++ b/scripts/gamestate/GameState.gd
@@ -565,8 +565,17 @@ func get_skill_catalog_item(skill_id: String) -> Dictionary:
 
 ## 更新鏟屎官 profile 快取（記憶體 + 本地檔案）
 func update_scooper_profile(data: Dictionary) -> void:
-	scooper_profile_data = data
-	CacheIO.save_scooper("profile", data)
+	scooper_profile_data = data.duplicate(true)
+	CacheIO.save_scooper("profile", scooper_profile_data)
+	if player_data == null:
+		return
+	player_data.scooper_level = int(scooper_profile_data.get("scooperLevel", player_data.scooper_level))
+	player_data.scooper_exp = int(scooper_profile_data.get("scooperExp", player_data.scooper_exp))
+	player_data.gold = int(scooper_profile_data.get("gold", player_data.gold))
+	player_data.poop_count = int(scooper_profile_data.get("poopCount", player_data.poop_count))
+	player_data.memory_shards = int(scooper_profile_data.get("memoryShards", player_data.memory_shards))
+	player_data.whisker_shards = int(scooper_profile_data.get("whiskers", player_data.whisker_shards))
+	player_data.save()
 
 ## 更新裝備快取（記憶體 + 本地檔案）
 func update_scooper_equipment(data: Array) -> void:
@@ -638,6 +647,14 @@ func apply_wallet_snapshot(data: Dictionary) -> void:
 	player_data.poop_count = int(data.get("poopCount", player_data.poop_count))
 	player_data.memory_shards = int(data.get("memoryShards", player_data.memory_shards))
 	player_data.whisker_shards = int(data.get("whiskerShards", player_data.whisker_shards))
+	player_data.save()
+
+
+func apply_idle_claim_response(data: Dictionary) -> void:
+	var wallet_snapshot: Variant = data.get("walletSnapshot", {})
+	if wallet_snapshot is Dictionary:
+		apply_wallet_snapshot(wallet_snapshot)
+	player_data.last_quit_time = int(data.get("lastQuitTimeUnixSeconds", player_data.last_quit_time))
 	player_data.save()
 
 

--- a/scripts/scooper/ScooperScene.gd
+++ b/scripts/scooper/ScooperScene.gd
@@ -200,12 +200,7 @@ func _process(delta: float) -> void:
 
 
 func _apply_profile_to_player_data(profile: Dictionary) -> void:
-	GameState.player_data.scooper_level = int(profile.get("scooperLevel", GameState.player_data.scooper_level))
-	GameState.player_data.scooper_exp = int(profile.get("scooperExp", GameState.player_data.scooper_exp))
-	GameState.player_data.gold = int(profile.get("gold", GameState.player_data.gold))
-	GameState.player_data.poop_count = int(profile.get("poopCount", GameState.player_data.poop_count))
-	GameState.player_data.memory_shards = int(profile.get("memoryShards", GameState.player_data.memory_shards))
-	GameState.player_data.whisker_shards = int(profile.get("whiskers", GameState.player_data.whisker_shards))
+	GameState.update_scooper_profile(profile)
 	_refresh_resource_label()
 
 

--- a/scripts/scooper/scooper_tab_scooper.gd
+++ b/scripts/scooper/scooper_tab_scooper.gd
@@ -250,21 +250,19 @@ func _on_scoop_pressed(scene: Control) -> void:
 		var result: Dictionary = data if data is Dictionary else {}
 		var updated_profile: Variant = result.get("updatedProfile", {})
 		if updated_profile is Dictionary:
-			scene.GameState.update_scooper_profile(updated_profile)
 			scene._apply_profile_to_player_data(updated_profile)
 
 		if scene._scoop_result_label != null:
 			scene._scoop_result_label.text = _format_scoop_result(result)
 
 		scene._scoop_cooldown_remaining = scene.SCOOP_COOLDOWN
-		scene.refresh_from_bootstrap(func(refresh_ok: bool, _refresh_data: Variant, refresh_err: Dictionary) -> void:
-			if not refresh_ok:
-				var msg: String = refresh_err.get("message") if refresh_err.get("message") != null else "鏟屎官資料同步失敗"
-				if scene._scoop_result_label != null:
-					scene._scoop_result_label.text = msg
-				_refresh_scooper_profile_ui(scene)
-				_refresh_scoop_ui(scene)
+		scene.ApiClient.get_achievements(func(achievements_ok: bool, achievements_data: Variant, _achievements_err: Dictionary) -> void:
+			if achievements_ok and achievements_data is Array:
+				scene.GameState.update_scooper_achievement(achievements_data)
+				scene._refresh_tab_button_labels()
 		)
+		_refresh_scooper_profile_ui(scene)
+		_refresh_scoop_ui(scene)
 	)
 
 


### PR DESCRIPTION
## 摘要
- 修正戰鬥場景清理貓砂盆對話框高度計算，避免內容下方留下空白
- 將清理貓砂盆與掛機獎勵領取流程改為使用 API，同步必要狀態
- 鏟屎官頁面改為只更新必要資料與成就，不重抓完整 bootstrap

## 測試
- 無自動化測試（Godot client）

Closes #99