### PR TITLE
fix:調整鏟屎與裝備升級互動流程

### DIFF
--- a/scripts/ApiClient.gd
+++ b/scripts/ApiClient.gd
@@ -56,28 +56,28 @@ func _process(delta: float) -> void:
 		_update_loading_label()
 
 
-func get_scooper_profile(callback: Callable) -> void:
-	_api_get("scooper/profile", callback)
+func get_scooper_profile(callback: Callable, track_loading: bool = true) -> void:
+	_api_get("scooper/profile", callback, track_loading)
 
 
-func scoop_poop(count: int, callback: Callable) -> void:
-	_api_post("scooper/profile/scoop", {"count": count}, callback)
+func scoop_poop(count: int, callback: Callable, track_loading: bool = true) -> void:
+	_api_post("scooper/profile/scoop", {"count": count}, callback, track_loading)
 
 
 func claim_idle_rewards(callback: Callable) -> void:
 	_api_post("scooper/profile/claim-idle", {}, callback)
 
 
-func get_equipment_list(callback: Callable) -> void:
-	_api_get("scooper/equipment", callback)
+func get_equipment_list(callback: Callable, track_loading: bool = true) -> void:
+	_api_get("scooper/equipment", callback, track_loading)
 
 
 func purchase_equipment(equipment_id: int, callback: Callable) -> void:
 	_api_post("scooper/equipment/purchase", {"equipmentId": equipment_id}, callback)
 
 
-func upgrade_equipment(equipment_id: int, callback: Callable) -> void:
-	_api_post("scooper/equipment/upgrade", {"equipmentId": equipment_id}, callback)
+func upgrade_equipment(equipment_id: int, callback: Callable, track_loading: bool = true) -> void:
+	_api_post("scooper/equipment/upgrade", {"equipmentId": equipment_id}, callback, track_loading)
 
 
 func repair_equipment(equipment_id: int, callback: Callable) -> void:
@@ -104,16 +104,16 @@ func get_treasures(callback: Callable) -> void:
 	_api_get("scooper/treasure", callback)
 
 
-func get_achievements(callback: Callable) -> void:
-	_api_get("scooper/achievement", callback)
+func get_achievements(callback: Callable, track_loading: bool = true) -> void:
+	_api_get("scooper/achievement", callback, track_loading)
 
 
 func claim_achievement(achievement_id: int, callback: Callable) -> void:
 	_api_post("scooper/achievement/claim", {"achievementId": achievement_id}, callback)
 
 
-func get_authenticated_bootstrap(callback: Callable) -> void:
-	_api_get("auth/bootstrap", callback)
+func get_authenticated_bootstrap(callback: Callable, track_loading: bool = true) -> void:
+	_api_get("auth/bootstrap", callback, track_loading)
 
 
 func get_mail_summary(callback: Callable) -> void:
@@ -268,12 +268,12 @@ func release_loading_overlay() -> void:
 	_release_loading_overlay()
 
 
-func _api_get(path: String, callback: Callable) -> void:
-	_enqueue_request(path, HTTPClient.METHOD_GET, {}, callback)
+func _api_get(path: String, callback: Callable, track_loading: bool = true) -> void:
+	_enqueue_request(path, HTTPClient.METHOD_GET, {}, callback, track_loading)
 
 
-func _api_post(path: String, body: Dictionary, callback: Callable) -> void:
-	_enqueue_request(path, HTTPClient.METHOD_POST, body, callback)
+func _api_post(path: String, body: Dictionary, callback: Callable, track_loading: bool = true) -> void:
+	_enqueue_request(path, HTTPClient.METHOD_POST, body, callback, track_loading)
 
 
 func _api_put(path: String, body: Dictionary, callback: Callable) -> void:

--- a/scripts/scooper/ScooperScene.gd
+++ b/scripts/scooper/ScooperScene.gd
@@ -22,6 +22,9 @@ var _scoop_cd_label: Label
 var _scoop_result_label: Label
 const SCOOP_COOLDOWN := 0.5
 var _scoop_cooldown_remaining := 0.0
+var _equipment_upgrade_cooldowns: Dictionary = {}
+var _equipment_upgrade_button_refs: Dictionary = {}
+var _equipment_upgrade_gain_map: Dictionary = {}
 var _ability_list: VBoxContainer
 var _equip_list: VBoxContainer  # 裝備列表容器，行動後重建
 var _memory_summary_label: Label
@@ -160,6 +163,7 @@ func _rebuild_tab_content() -> void:
 	_scoop_overlay = null
 	_scoop_cd_label = null
 	_scoop_result_label = null
+	_equipment_upgrade_button_refs.clear()
 	_ability_list = null
 	_equip_list  = null
 	_memory_summary_label = null

--- a/scripts/scooper/scooper_tab_scooper.gd
+++ b/scripts/scooper/scooper_tab_scooper.gd
@@ -3,14 +3,16 @@ extends RefCounted
 ## 鏟屎官 Tab — 個人資料、鏟屎、特殊能力、裝備列表
 
 
+func _scene_valid(scene: Control) -> bool:
+	return scene != null and is_instance_valid(scene)
+
+
 func build(scene: Control) -> void:
-	# 等級標題
 	scene._level_label = Label.new()
 	scene._level_label.add_theme_font_size_override("font_size", 32)
 	scene._level_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	scene._tab_content.add_child(scene._level_label)
 
-	# EXP 進度條 + 數字標籤（並排）
 	var exp_row := HBoxContainer.new()
 	exp_row.add_theme_constant_override("separation", 10)
 	scene._tab_content.add_child(exp_row)
@@ -57,7 +59,6 @@ func build(scene: Control) -> void:
 
 	scene._tab_content.add_child(scene._make_separator())
 
-	# ── 特殊能力 ──────────────────────────────────────
 	var ability_title := Label.new()
 	ability_title.text = "特殊能力"
 	ability_title.add_theme_font_size_override("font_size", 24)
@@ -73,7 +74,6 @@ func build(scene: Control) -> void:
 	scene._ability_list.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	ability_scroll.add_child(scene._ability_list)
 
-	# ── 裝備列表 ──────────────────────────────────
 	var equip_header := Label.new()
 	equip_header.text = "裝備"
 	equip_header.add_theme_font_size_override("font_size", 24)
@@ -90,15 +90,18 @@ func build(scene: Control) -> void:
 	scene._equip_list.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	scroll.add_child(scene._equip_list)
 
-	# 先用本地快取資料渲染，再拉 API 更新
 	_refresh_scooper_tab_from_local(scene)
 
 
 func process(scene: Control, delta: float) -> void:
-	if scene._scoop_cooldown_remaining <= 0.0:
-		return
-	scene._scoop_cooldown_remaining = maxf(0.0, scene._scoop_cooldown_remaining - delta)
-	_refresh_scoop_ui(scene)
+	var needs_refresh := false
+	if scene._scoop_cooldown_remaining > 0.0:
+		scene._scoop_cooldown_remaining = maxf(0.0, scene._scoop_cooldown_remaining - delta)
+		needs_refresh = true
+	if _tick_equipment_upgrade_cooldowns(scene, delta):
+		needs_refresh = true
+	if needs_refresh:
+		_refresh_scoop_ui(scene)
 
 
 func _refresh_scooper_tab_from_local(scene: Control) -> void:
@@ -109,36 +112,26 @@ func _refresh_scooper_tab_from_local(scene: Control) -> void:
 
 
 func _refresh_scooper_profile_ui(scene: Control) -> void:
+	if not _scene_valid(scene):
+		return
 	var profile: Dictionary = scene.GameState.scooper_profile_data
-	var level: int
-	var exp: int
-	var threshold: int
-
-	if not profile.is_empty():
-		level = int(profile.get("scooperLevel", 0))
-		exp = int(profile.get("scooperExp", 0))
-		threshold = int(profile.get("expThreshold", 1))
-	else:
-		level = scene.GameState.player_data.scooper_level
-		exp = scene.GameState.player_data.scooper_exp
-		threshold = (level + 1) * int(scene.GameState.idle_config.get("scooper_exp_per_level", 10))
+	var level: int = int(profile.get("scooperLevel", 0))
+	var exp: int = int(profile.get("scooperExp", 0))
+	var threshold: int = max(1, int(profile.get("expThreshold", 1)))
 
 	if scene._level_label != null:
 		scene._level_label.text = "鏟屎官 Lv.%d" % level
 
 	if scene._exp_bar != null:
 		scene._exp_bar.max_value = threshold
-		scene._exp_bar.value     = exp
+		scene._exp_bar.value = exp
 
 	if scene._exp_label != null:
 		scene._exp_label.text = "EXP %d / %d" % [exp, threshold]
 
 
-# ── 裝備列表 UI ────────────────────────────────────────────
-
-## 清空並重建裝備列表（購買 / 升級 / 修復 / 就醫後呼叫）
 func _rebuild_equip_list(scene: Control) -> void:
-	if scene._equip_list == null:
+	if not _scene_valid(scene) or scene._equip_list == null:
 		return
 	for child in scene._equip_list.get_children():
 		child.queue_free()
@@ -157,7 +150,7 @@ func _rebuild_equip_list(scene: Control) -> void:
 
 
 func _refresh_ability_ui(scene: Control) -> void:
-	if scene._ability_list == null:
+	if not _scene_valid(scene) or scene._ability_list == null:
 		return
 
 	for child in scene._ability_list.get_children():
@@ -175,6 +168,7 @@ func _refresh_ability_ui(scene: Control) -> void:
 	for item: Dictionary in owned:
 		scene._ability_list.add_child(_make_ability_card(scene, item))
 
+
 func _make_ability_card(scene: Control, item: Dictionary) -> Control:
 	var btn := Button.new()
 	btn.text = item.get("displayName") if item.get("displayName") != null else ""
@@ -188,6 +182,8 @@ func _make_ability_card(scene: Control, item: Dictionary) -> Control:
 
 
 func _show_ability_dialog(scene: Control, item: Dictionary) -> void:
+	if not _scene_valid(scene):
+		return
 	var lines: Array[String] = [
 		"效果：%s" % item.get("description", ""),
 	]
@@ -199,7 +195,7 @@ func _show_ability_dialog(scene: Control, item: Dictionary) -> void:
 
 
 func _refresh_scoop_ui(scene: Control) -> void:
-	if scene._scoop_button == null:
+	if not _scene_valid(scene) or scene._scoop_button == null:
 		return
 	var poop_count: int = scene.GameState.player_data.poop_count
 	var scoop_amount: int = _get_scoop_amount()
@@ -218,12 +214,101 @@ func _refresh_scoop_ui(scene: Control) -> void:
 			scene._scoop_overlay.position = Vector2(button_size.x * (1.0 - ratio), 0.0)
 			scene._scoop_overlay.size = Vector2(button_size.x * ratio, button_size.y)
 			scene._scoop_cd_label.visible = false
-			scene._scoop_cd_label.text = "%.1f" % scene._scoop_cooldown_remaining
 			scene._scoop_cd_label.position = Vector2.ZERO
 			scene._scoop_cd_label.size = button_size
 		else:
 			scene._scoop_overlay.visible = false
 			scene._scoop_cd_label.visible = false
+
+	_refresh_equipment_upgrade_button_states(scene)
+
+
+func _tick_equipment_upgrade_cooldowns(scene: Control, delta: float) -> bool:
+	if not _scene_valid(scene):
+		return false
+	var changed := false
+	var expired: Array[int] = []
+	for equip_id_variant: Variant in scene._equipment_upgrade_cooldowns.keys():
+		var equip_id := int(equip_id_variant)
+		var remaining := maxf(0.0, float(scene._equipment_upgrade_cooldowns[equip_id]) - delta)
+		if remaining <= 0.0:
+			expired.append(equip_id)
+		else:
+			scene._equipment_upgrade_cooldowns[equip_id] = remaining
+		_refresh_equipment_upgrade_button_state(scene, equip_id)
+		changed = true
+
+	for equip_id: int in expired:
+		scene._equipment_upgrade_cooldowns.erase(equip_id)
+		_refresh_equipment_upgrade_button_state(scene, equip_id)
+		changed = true
+
+	return changed
+
+
+func _refresh_equipment_upgrade_button_states(scene: Control) -> void:
+	if not _scene_valid(scene):
+		return
+	for equip_id_variant: Variant in scene._equipment_upgrade_button_refs.keys():
+		_refresh_equipment_upgrade_button_state(scene, int(equip_id_variant))
+
+
+func _register_equipment_upgrade_button(scene: Control, equip_id: int, button: Button) -> void:
+	var overlay := ColorRect.new()
+	overlay.color = Color(0.0, 0.0, 0.0, 0.45)
+	overlay.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	overlay.visible = false
+	button.add_child(overlay)
+
+	var cooldown_label := Label.new()
+	cooldown_label.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	cooldown_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	cooldown_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	cooldown_label.add_theme_font_size_override("font_size", 16)
+	cooldown_label.visible = false
+	button.add_child(cooldown_label)
+
+	scene._equipment_upgrade_button_refs[equip_id] = {
+		"button": button,
+		"overlay": overlay,
+		"label": cooldown_label,
+		"base_disabled": button.disabled,
+	}
+	_refresh_equipment_upgrade_button_state(scene, equip_id)
+
+
+func _refresh_equipment_upgrade_button_state(scene: Control, equip_id: int) -> void:
+	if not _scene_valid(scene):
+		return
+	var entry: Variant = scene._equipment_upgrade_button_refs.get(equip_id, null)
+	if not entry is Dictionary:
+		return
+
+	var entry_dict: Dictionary = entry
+	var button := entry_dict.get("button") as Button
+	var overlay := entry_dict.get("overlay") as ColorRect
+	var cooldown_label := entry_dict.get("label") as Label
+	if button == null or overlay == null or cooldown_label == null:
+		return
+
+	var remaining := float(scene._equipment_upgrade_cooldowns.get(equip_id, 0.0))
+	var cooling_down := remaining > 0.0
+	button.disabled = bool(entry_dict.get("base_disabled", false)) or cooling_down or scene._api_in_flight
+
+	if cooling_down:
+		var button_size := button.size
+		if button_size.x <= 0.0 or button_size.y <= 0.0:
+			button_size = button.custom_minimum_size
+		var ratio := clampf(remaining / scene.SCOOP_COOLDOWN, 0.0, 1.0)
+		overlay.visible = true
+		overlay.position = Vector2(button_size.x * (1.0 - ratio), 0.0)
+		overlay.size = Vector2(button_size.x * ratio, button_size.y)
+		cooldown_label.visible = false
+		cooldown_label.position = Vector2.ZERO
+		cooldown_label.size = button_size
+	else:
+		overlay.visible = false
+		cooldown_label.visible = false
 
 
 func _get_scoop_amount() -> int:
@@ -231,17 +316,22 @@ func _get_scoop_amount() -> int:
 
 
 func _on_scoop_pressed(scene: Control) -> void:
+	if not _scene_valid(scene):
+		return
 	if scene._scoop_cooldown_remaining > 0.0 or scene.GameState.player_data.poop_count <= 0 or scene._api_in_flight:
 		return
 
 	var scoop_count := mini(scene.GameState.player_data.poop_count, _get_scoop_amount())
+	scene._scoop_cooldown_remaining = scene.SCOOP_COOLDOWN
 	scene._api_in_flight = true
 	_refresh_scoop_ui(scene)
 
 	scene.ApiClient.scoop_poop(scoop_count, func(ok: bool, data: Variant, err: Dictionary) -> void:
-		scene._api_in_flight = false
+		if not _scene_valid(scene):
+			return
 		if not ok:
-			var msg: String = err.get("message") if err.get("message") != null else "鏟屎失敗"
+			scene._api_in_flight = false
+			var msg: String = str(err.get("message", "鏟屎失敗"))
 			if scene._scoop_result_label != null:
 				scene._scoop_result_label.text = msg
 			_refresh_scoop_ui(scene)
@@ -255,15 +345,17 @@ func _on_scoop_pressed(scene: Control) -> void:
 		if scene._scoop_result_label != null:
 			scene._scoop_result_label.text = _format_scoop_result(result)
 
-		scene._scoop_cooldown_remaining = scene.SCOOP_COOLDOWN
 		scene.ApiClient.get_achievements(func(achievements_ok: bool, achievements_data: Variant, _achievements_err: Dictionary) -> void:
+			if not _scene_valid(scene):
+				return
 			if achievements_ok and achievements_data is Array:
 				scene.GameState.update_scooper_achievement(achievements_data)
 				scene._refresh_tab_button_labels()
-		)
-		_refresh_scooper_profile_ui(scene)
-		_refresh_scoop_ui(scene)
-	)
+			scene._api_in_flight = false
+			_refresh_scooper_profile_ui(scene)
+			_refresh_scoop_ui(scene)
+		, false)
+	, false)
 
 
 func _format_scoop_result(result: Dictionary) -> String:
@@ -281,19 +373,18 @@ func _format_scoop_result(result: Dictionary) -> String:
 
 
 func _make_equip_card(scene: Control, item: Dictionary) -> Control:
-	var equip_id: int     = int(item.get("equipmentId", 0))
-	var name_str: String  = item.get("displayName") if item.get("displayName") != null else ""
-	var unlock_lv: int    = int(item.get("unlockLevel", 1))
-	var owned: bool       = bool(item.get("isOwned", false))
-	var level: int        = int(item.get("level", 0))
-	var exp_val: int      = int(item.get("currentExp", 0))
-	var broken: bool      = bool(item.get("isBroken", false))
+	var equip_id: int = int(item.get("equipmentId", 0))
+	var name_str: String = item.get("displayName") if item.get("displayName") != null else ""
+	var unlock_lv: int = int(item.get("unlockLevel", 1))
+	var owned: bool = bool(item.get("isOwned", false))
+	var level: int = int(item.get("level", 0))
+	var exp_val: int = int(item.get("currentExp", 0))
+	var broken: bool = bool(item.get("isBroken", false))
 	var sick_cat_name: String = item.get("sickCatName") if item.get("sickCatName") != null else ""
-	var scooper_lv: int   = int(item.get("scooperLevel", scene.GameState.player_data.scooper_level))
-	var exp_per_lv: int   = int(item.get("expPerLevel", 10))
-	var locked: bool      = not owned and scooper_lv < unlock_lv
+	var scooper_lv: int = int(item.get("scooperLevel", scene.GameState.player_data.scooper_level))
+	var exp_per_lv: int = int(item.get("expPerLevel", 10))
+	var locked: bool = not owned and scooper_lv < unlock_lv
 
-	# 背景容器
 	var card := VBoxContainer.new()
 	card.add_theme_constant_override("separation", 4)
 	var card_bg := ColorRect.new()
@@ -301,7 +392,6 @@ func _make_equip_card(scene: Control, item: Dictionary) -> Control:
 	card_bg.custom_minimum_size = Vector2(0.0, 4.0)
 	card.add_child(card_bg)
 
-	# ── 標題行：名稱 + 等級 ──
 	var header_row := HBoxContainer.new()
 	card.add_child(header_row)
 
@@ -328,7 +418,6 @@ func _make_equip_card(scene: Control, item: Dictionary) -> Control:
 		lv_lbl.add_theme_color_override("font_color", Color(0.7, 0.9, 1.0, 1.0))
 		header_row.add_child(lv_lbl)
 
-	# ── 說明行：加成描述 / 鎖定提示 / 狀態 ──
 	var desc_lbl := Label.new()
 	desc_lbl.add_theme_font_size_override("font_size", 16)
 	desc_lbl.add_theme_color_override("font_color", Color(0.7, 0.7, 0.7, 1.0))
@@ -339,21 +428,21 @@ func _make_equip_card(scene: Control, item: Dictionary) -> Control:
 	elif sick_cat_name != "":
 		desc_lbl.text = "🐱 %s 生病中，無法升級　%s" % [sick_cat_name, _bonus_desc(item, level)]
 	elif owned:
-		var exp_str: String = "  EXP %d / %d" % [exp_val, exp_per_lv] if level < scooper_lv else "  已滿等"
+		var exp_gain: int = int(scene._equipment_upgrade_gain_map.get(equip_id, 0))
+		var gain_suffix := " (+%d)" % exp_gain if exp_gain > 0 else ""
+		var exp_str: String = "  EXP %d / %d%s" % [exp_val, exp_per_lv, gain_suffix] if level < scooper_lv else "  已滿等%s" % gain_suffix
 		desc_lbl.text = _bonus_desc(item, level) + exp_str
 	else:
 		desc_lbl.text = "%s　購買後解鎖" % _bonus_desc(item, 1)
 	card.add_child(desc_lbl)
 
-	# ── 操作按鈕行 ──
 	var btn_row := HBoxContainer.new()
 	btn_row.add_theme_constant_override("separation", 8)
 	card.add_child(btn_row)
 
 	if locked:
-		pass  # 無按鈕
+		pass
 	elif not owned:
-		# 購買按鈕
 		var buy_btn := Button.new()
 		buy_btn.text = "購買 %d 💰" % int(item.get("purchaseCost", 0))
 		buy_btn.custom_minimum_size = Vector2(160.0, 42.0)
@@ -364,7 +453,6 @@ func _make_equip_card(scene: Control, item: Dictionary) -> Control:
 		btn_row.add_child(buy_btn)
 	else:
 		if broken:
-			# 修復按鈕
 			var repair_btn := Button.new()
 			repair_btn.text = "修復 %d 💰" % int(item.get("repairCost", 0))
 			repair_btn.custom_minimum_size = Vector2(160.0, 42.0)
@@ -375,7 +463,6 @@ func _make_equip_card(scene: Control, item: Dictionary) -> Control:
 			btn_row.add_child(repair_btn)
 		else:
 			if sick_cat_name != "":
-				# 就醫按鈕
 				var heal_btn := Button.new()
 				heal_btn.text = "就醫 %d 💰" % int(item.get("treatCost", 0))
 				heal_btn.custom_minimum_size = Vector2(160.0, 42.0)
@@ -385,7 +472,6 @@ func _make_equip_card(scene: Control, item: Dictionary) -> Control:
 				)
 				btn_row.add_child(heal_btn)
 
-			# 升級按鈕（生病時 disabled）
 			var up_btn := Button.new()
 			up_btn.text = "升級 %d 💰" % int(item.get("upgradeCost", 0))
 			up_btn.custom_minimum_size = Vector2(160.0, 42.0)
@@ -394,17 +480,25 @@ func _make_equip_card(scene: Control, item: Dictionary) -> Control:
 			up_btn.pressed.connect(func() -> void:
 				_do_equipment_action(scene, "upgrade", equip_id)
 			)
+			_register_equipment_upgrade_button(scene, equip_id, up_btn)
 			btn_row.add_child(up_btn)
 
-	# 分隔線
 	card.add_child(scene._make_separator())
 	return card
 
 
 func _do_equipment_action(scene: Control, action: String, equip_id: int) -> void:
+	if not _scene_valid(scene):
+		return
 	if scene._api_in_flight:
 		return
+
+	if action == "upgrade":
+		scene._equipment_upgrade_cooldowns[equip_id] = scene.SCOOP_COOLDOWN
+		scene._equipment_upgrade_gain_map.erase(equip_id)
+
 	scene._api_in_flight = true
+	_refresh_equipment_upgrade_button_states(scene)
 
 	var action_labels: Dictionary = {
 		"purchase": "購買",
@@ -415,64 +509,124 @@ func _do_equipment_action(scene: Control, action: String, equip_id: int) -> void
 	var label: String = action_labels.get(action, action)
 
 	var callback := func(ok: bool, data: Variant, err: Dictionary) -> void:
-		scene._api_in_flight = false
+		if not _scene_valid(scene):
+			return
 		if not ok:
+			scene._api_in_flight = false
+			_refresh_equipment_upgrade_button_states(scene)
 			scene.DialogManager.show_info("%s失敗" % label, str(err.get("message", "操作失敗")))
 			return
 
 		var result: Dictionary = data if data is Dictionary else {}
-
-		# 升級時顯示結果摘要
 		if action == "upgrade":
-			var msg_parts: Array = []
 			var gained: int = int(result.get("expGained", 0))
 			if gained > 0:
-				msg_parts.append("獲得 EXP +%d" % gained)
-			if bool(result.get("leveledUp", false)):
-				msg_parts.append("裝備升級！")
-			if bool(result.get("broken", false)):
-				msg_parts.append("⚠ 裝備損壞了！")
-			if result.get("sickCatId", null) != null:
-				msg_parts.append("🤒 有貓咪生病了！")
-			if not msg_parts.is_empty():
-				scene.DialogManager.show_info("升級結果", "\n".join(msg_parts))
+				scene._equipment_upgrade_gain_map[equip_id] = gained
+			else:
+				scene._equipment_upgrade_gain_map.erase(equip_id)
 
-		# 重新拉取更新後的裝備列表與profile
-		_refresh_resource_after_action(scene)
+		_refresh_resource_after_action(scene, action == "upgrade", func() -> void:
+			if not _scene_valid(scene):
+				return
+			scene._api_in_flight = false
+			_refresh_equipment_upgrade_button_states(scene)
+		)
 
 	match action:
 		"purchase":
 			scene.ApiClient.purchase_equipment(equip_id, callback)
 		"upgrade":
-			scene.ApiClient.upgrade_equipment(equip_id, callback)
+			scene.ApiClient.upgrade_equipment(equip_id, callback, false)
 		"repair":
 			scene.ApiClient.repair_equipment(equip_id, callback)
 		"treat":
 			scene.ApiClient.treat_equipment(equip_id, callback)
 
 
-func _refresh_resource_after_action(scene: Control) -> void:
-	scene.refresh_from_bootstrap(func(ok: bool, _data: Variant, err: Dictionary) -> void:
-		if not ok:
-			scene.DialogManager.show_info("同步失敗", str(err.get("message", "鏟屎官資料同步失敗")))
-	)
+func _refresh_resource_after_action(scene: Control, refresh_upgrade_data: bool = false, on_completed: Callable = Callable()) -> void:
+	if not _scene_valid(scene):
+		return
+	if not refresh_upgrade_data:
+		scene.refresh_from_bootstrap(func(ok: bool, _data: Variant, err: Dictionary) -> void:
+			if not _scene_valid(scene):
+				return
+			if not ok:
+				scene.DialogManager.show_info("同步失敗", str(err.get("message", "鏟屎官資料同步失敗")))
+			if not on_completed.is_null():
+				on_completed.call()
+		)
+		return
+
+	var request_state := {
+		"remaining": 3,
+		"ok": true,
+		"err": {},
+	}
+
+	var finish_request := func(request_ok: bool, request_err: Dictionary) -> void:
+		if not _scene_valid(scene):
+			return
+		if not request_ok and bool(request_state["ok"]):
+			request_state["ok"] = false
+			request_state["err"] = request_err
+		request_state["remaining"] = int(request_state["remaining"]) - 1
+		if int(request_state["remaining"]) > 0:
+			return
+
+		scene._refresh_resource_label()
+		_refresh_scooper_profile_ui(scene)
+		scene._refresh_tab_button_labels()
+		_rebuild_equip_list(scene)
+		_refresh_scoop_ui(scene)
+
+		if not bool(request_state["ok"]):
+			var sync_err: Dictionary = request_state["err"]
+			scene.DialogManager.show_info("同步失敗", str(sync_err.get("message", "鏟屎官資料同步失敗")))
+		if not on_completed.is_null():
+			on_completed.call()
+
+	scene.ApiClient.get_scooper_profile(func(ok: bool, data: Variant, err: Dictionary) -> void:
+		if not _scene_valid(scene):
+			return
+		if ok and data is Dictionary:
+			scene.GameState.update_scooper_profile(data)
+		finish_request.call(ok, err)
+	, false)
+
+	scene.ApiClient.get_equipment_list(func(ok: bool, data: Variant, err: Dictionary) -> void:
+		if not _scene_valid(scene):
+			return
+		if ok and data is Array:
+			scene.GameState.update_scooper_equipment(data)
+		finish_request.call(ok, err)
+	, false)
+
+	scene.ApiClient.get_achievements(func(ok: bool, data: Variant, err: Dictionary) -> void:
+		if not _scene_valid(scene):
+			return
+		if ok and data is Array:
+			scene.GameState.update_scooper_achievement(data)
+		finish_request.call(ok, err)
+	, false)
 
 
-## 產生加成描述文字，level=0 時顯示「每級 +X%」
 func _bonus_desc(item: Dictionary, level: int) -> String:
-	var stat: String   = item.get("bonusStat") if item.get("bonusStat") != null else ""
+	var stat: String = item.get("bonusStat") if item.get("bonusStat") != null else ""
 	var target: String = item.get("bonusTarget") if item.get("bonusTarget") != null else "All"
-	var per_lv: float  = float(item.get("bonusPerLevel", 0.0))
+	var per_lv: float = float(item.get("bonusPerLevel", 0.0))
 
 	var target_str: String = "全隊" if target.to_lower() == "all" else "%s系" % target
 	var stat_str: String
 	match stat:
-		"atk_percent", "AtkPercent":     stat_str = "ATK"
-		"def_percent", "DefPercent":     stat_str = "DEF"
-		"max_hp_percent", "MaxHpPercent": stat_str = "HP"
-		_:                               stat_str = stat
+		"atk_percent", "AtkPercent":
+			stat_str = "ATK"
+		"def_percent", "DefPercent":
+			stat_str = "DEF"
+		"max_hp_percent", "MaxHpPercent":
+			stat_str = "HP"
+		_:
+			stat_str = stat
 
 	if level <= 0:
 		return "%s %s +%.1f%%/級" % [target_str, stat_str, per_lv * 100.0]
-	else:
-		return "%s %s +%.1f%%" % [target_str, stat_str, per_lv * level * 100.0]
+	return "%s %s +%.1f%%" % [target_str, stat_str, per_lv * level * 100.0]


### PR DESCRIPTION
## 變更摘要
- 移除鏟屎與裝備升級流程中的 loading overlay
- 裝備升級改為直接顯示在裝備列中的 EXP 增量
- 補上裝備升級按鈕 0.5 秒冷卻遮罩與重新啟用時機控制
- 加入場景失效時的 callback 保護，避免切頁後寫回失效節點

## 測試說明
- 尚未在本機以 Godot CLI 執行自動驗證
- 需手動確認鏟屎與裝備升級按鈕在冷卻與 API 完成前不會提前啟用

Closes #101