### PR TITLE
fix:統一前端按鈕語意樣式並修正商店購買面板

### DIFF
--- a/scripts/DialogManager.gd
+++ b/scripts/DialogManager.gd
@@ -266,7 +266,9 @@ func _build(
 	panel.size = panel.custom_minimum_size
 	dialog_stack.custom_minimum_size = Vector2(panel.custom_minimum_size.x, panel.custom_minimum_size.y + hint_min.y + (10.0 if not is_confirm else 0.0))
 	call_deferred("_fit_dialog_to_content", panel, margin, vbox, dialog_stack, hint_lbl, panel_width)
-	return func() -> void: canvas.queue_free()
+	return func() -> void:
+		if is_instance_valid(canvas):
+			canvas.queue_free()
 
 
 func _fit_dialog_to_content(

--- a/scripts/arenaScene/ArenaScene.gd
+++ b/scripts/arenaScene/ArenaScene.gd
@@ -171,7 +171,7 @@ func _build_ui() -> void:
 	team_help_button.custom_minimum_size = Vector2(38.0, 38.0)
 	team_help_button.pressed.connect(_show_team_panel_help)
 	season_row.add_child(team_help_button)
-	UiPalette.apply_button_kind(team_help_button, "rank")
+	UiPalette.apply_button_kind(team_help_button, "info")
 
 	var team_panel: PanelContainer = OverlaySceneChrome.make_card_panel()
 	_arena_section.add_child(team_panel)
@@ -690,20 +690,20 @@ func _get_opponent_action_text() -> String:
 
 
 func _apply_opponent_action_style(button: Button) -> void:
-	UiPalette.apply_button_kind(button, "rank" if Helpers.get_current_tickets(_overview) <= 0 else "primary")
+	UiPalette.apply_button_kind(button, "confirm")
 
 
 func _claim_rank_reward(rank_id: int) -> void:
 	ApiClient.claim_arena_rank_reward(rank_id, func(success: bool, data: Variant, error: Dictionary) -> void:
 		if not success or not (data is Dictionary):
-			_show_dialog(UiText.ARENA_REWARD_DIALOG_TITLE, Helpers.build_error_message(error))
+			ToastManager.error(UiText.ARENA_REWARD_DIALOG_TITLE, Helpers.build_error_message(error))
 			return
 		var response: Dictionary = data
 		var overview: Dictionary = response.get("overview", {})
 		if not overview.is_empty():
 			GameState.update_arena(overview)
 			_apply_overview(overview)
-		_show_dialog(UiText.ARENA_REWARD_DIALOG_TITLE, UiText.ARENA_REWARD_CLAIMED_FORMAT % [
+		ToastManager.success(UiText.ARENA_REWARD_DIALOG_TITLE, UiText.ARENA_REWARD_CLAIMED_FORMAT % [
 			str(response.get("rankName", UiText.ARENA_REWARD_UNKNOWN_RANK)),
 			Helpers.format_rewards(response.get("rewards", []))
 		])
@@ -753,7 +753,7 @@ func _purchase_tickets_confirmed() -> void:
 
 func _on_purchase_tickets_completed(success: bool, data: Variant, error: Dictionary) -> void:
 	if not success or not (data is Dictionary):
-		_show_dialog(UiText.ARENA_PURCHASE_DIALOG_TITLE, Helpers.build_error_message(error))
+		ToastManager.error(UiText.ARENA_PURCHASE_DIALOG_TITLE, Helpers.build_error_message(error))
 		return
 	var response: Dictionary = data
 	var overview: Dictionary = response.get("overview", {})
@@ -763,7 +763,7 @@ func _on_purchase_tickets_completed(success: bool, data: Variant, error: Diction
 			overview["opponents"] = preserved_opponents
 		GameState.update_arena(overview)
 		_apply_overview(overview)
-	_show_dialog(UiText.ARENA_PURCHASE_DIALOG_TITLE, UiText.ARENA_PURCHASE_SUCCESS_FORMAT % int(response.get("addedTickets", 0)))
+	ToastManager.success(UiText.ARENA_PURCHASE_DIALOG_TITLE, UiText.ARENA_PURCHASE_SUCCESS_FORMAT % int(response.get("addedTickets", 0)))
 
 
 func _on_back_pressed() -> void:

--- a/scripts/battle/battle_scene.gd
+++ b/scripts/battle/battle_scene.gd
@@ -1256,7 +1256,7 @@ func _show_sandbox_dialog() -> void:
 			ApiClient.claim_idle_rewards(func(ok: bool, data: Variant, err: Dictionary) -> void:
 				claim_btn.disabled = false
 				if not ok:
-					DialogManager.show_info(UiText.HOME_CLAIM_FAILED_TITLE, str(err.get("message", UiText.HOME_CLAIM_FAILED_MESSAGE)))
+					ToastManager.error(UiText.HOME_CLAIM_FAILED_TITLE, str(err.get("message", UiText.HOME_CLAIM_FAILED_MESSAGE)))
 					return
 
 				var response: Dictionary = data if data is Dictionary else {}

--- a/scripts/configs/ConfigScene.gd
+++ b/scripts/configs/ConfigScene.gd
@@ -5,7 +5,6 @@ const AssetResolver = preload("res://scripts/ui/asset_resolver.gd")
 const SceneSubmenuBar = preload("res://scripts/ui/scene_submenu_bar.gd")
 const CatRosterCard = preload("res://scripts/ui/cat_roster_card.gd")
 
-const ACTION_BUTTON_COLOR := Color(0.94, 0.77, 0.39, 1.0)
 const DANGER_BUTTON_COLOR := Color(0.94, 0.48, 0.42, 1.0)
 const MUTED_TEXT_COLOR := Color(0.90, 0.88, 0.82, 0.92)
 const DISABLED_TEXT_COLOR := Color(0.70, 0.70, 0.72, 0.92)
@@ -86,7 +85,7 @@ func _build_ui() -> void:
 	main_split.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	content_vbox.add_child(main_split)
 
-	var team_panel: PanelContainer = _make_card_panel()
+	var team_panel: PanelContainer = OverlaySceneChrome.make_card_panel()
 	team_panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	team_panel.size_flags_vertical = 0
 	main_split.add_child(team_panel)
@@ -118,10 +117,10 @@ func _build_ui() -> void:
 	_save_team_btn.custom_minimum_size = Vector2(0.0, 52.0)
 	_save_team_btn.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY_LG)
 	_save_team_btn.pressed.connect(_on_save_team_pressed)
-	UiPalette.apply_button_palette(_save_team_btn, ACTION_BUTTON_COLOR, Color(0.16, 0.11, 0.05, 1.0))
+	UiPalette.apply_button_kind(_save_team_btn, "confirm")
 	team_vbox.add_child(_save_team_btn)
 
-	var cats_panel: PanelContainer = _make_card_panel()
+	var cats_panel: PanelContainer = OverlaySceneChrome.make_card_panel()
 	cats_panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	cats_panel.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	cats_panel.size_flags_stretch_ratio = 1.05
@@ -326,7 +325,7 @@ func _refresh_team() -> void:
 
 func _make_team_slot_card(slot_index: int, member: Dictionary) -> PanelContainer:
 	var is_filled: bool = not member.is_empty()
-	var card: PanelContainer = _make_card_panel(OverlaySceneChrome.PANEL_BORDER if is_filled else SLOT_EMPTY_BORDER)
+	var card: PanelContainer = OverlaySceneChrome.make_card_panel(OverlaySceneChrome.PANEL_BORDER if is_filled else SLOT_EMPTY_BORDER)
 	card.custom_minimum_size = Vector2(0.0, 166.0)
 	card.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	var margin: MarginContainer = OverlaySceneChrome.make_content_margin(4)
@@ -744,7 +743,7 @@ func _update_save_section() -> void:
 	var dirty: bool = _is_current_team_dirty()
 	_save_team_btn.disabled = _api_in_flight or not dirty
 	if dirty and not _api_in_flight:
-		UiPalette.apply_button_palette(_save_team_btn, ACTION_BUTTON_COLOR, Color(0.16, 0.11, 0.05, 1.0))
+		UiPalette.apply_button_kind(_save_team_btn, "confirm")
 	else:
 		UiPalette.apply_button_palette(_save_team_btn, Color(0.24, 0.21, 0.18, 0.86), Color(0.72, 0.69, 0.64, 1.0))
 
@@ -771,7 +770,7 @@ func _on_save_team_pressed() -> void:
 	ApiClient.replace_team(_current_team_type, request_members, func(success: bool, data: Variant, error: Dictionary) -> void:
 		_api_in_flight = false
 		if not success:
-			DialogManager.show_info(UiText.CONFIG_SAVE_FAILED_TITLE, UiText.CONFIG_SAVE_FAILED_BODY_FORMAT % error.get("message", UiText.CONFIG_UNKNOWN_ERROR))
+			ToastManager.error(UiText.CONFIG_SAVE_FAILED_TITLE, str(error.get("message", UiText.CONFIG_UNKNOWN_ERROR)))
 			_refresh_team()
 			_refresh_cats_list()
 			return
@@ -786,6 +785,7 @@ func _on_save_team_pressed() -> void:
 
 		_refresh_team()
 		_refresh_cats_list()
+		ToastManager.success(UiText.CONFIG_SAVE_HINT_CLEAN)
 	)
 
 
@@ -842,12 +842,6 @@ func _show_skill_popup(cat_file_id: String) -> void:
 
 func _make_separator() -> HSeparator:
 	return HSeparator.new()
-
-
-func _make_card_panel(accent: Color = OverlaySceneChrome.CARD_BORDER) -> PanelContainer:
-	var panel: PanelContainer = PanelContainer.new()
-	panel.add_theme_stylebox_override("panel", OverlaySceneChrome.make_panel_style(OverlaySceneChrome.CARD_FILL, accent, 14))
-	return panel
 
 
 func _make_chip_style(fill: Color, border: Color, radius: int) -> StyleBoxFlat:

--- a/scripts/dungeon/DungeonSceneActions.gd
+++ b/scripts/dungeon/DungeonSceneActions.gd
@@ -16,7 +16,7 @@ static func on_dungeon_overview_completed(scene, success: bool, data: Variant, e
 		return
 
 	var message: String = str(error.get("message", UiText.DUNGEON_FETCH_FAILED_DEFAULT))
-	DialogManager.show_info(UiText.DUNGEON_FETCH_FAILED_TITLE, message)
+	ToastManager.error(UiText.DUNGEON_FETCH_FAILED_TITLE, message)
 	scene._rebuild_dungeon_panels()
 
 
@@ -38,7 +38,7 @@ static func on_dungeon_action_completed(scene, success: bool, data: Variant, err
 		return
 
 	var message: String = str(error.get("message", UiText.DUNGEON_ACTION_FAILED_DEFAULT))
-	DialogManager.show_info(UiText.DUNGEON_ACTION_FAILED_TITLE, message)
+	ToastManager.error(UiText.DUNGEON_ACTION_FAILED_TITLE, message)
 	scene._rebuild_dungeon_panels()
 
 
@@ -106,7 +106,7 @@ static func on_challenge_pressed(scene, dungeon_id: int) -> void:
 static func _prompt_ad_ticket(scene, dungeon: Dictionary) -> void:
 	var ad_count: int = int(dungeon.get("remainingAdTicketCount", 0))
 	if ad_count <= 0:
-		DialogManager.show_info(UiText.DUNGEON_ACTION_FAILED_TITLE, "\u4eca\u65e5\u88dc\u7968\u6b21\u6578\u5df2\u7528\u5b8c\u3002")
+		ToastManager.error(UiText.DUNGEON_ACTION_FAILED_TITLE, "\u4eca\u65e5\u88dc\u7968\u6b21\u6578\u5df2\u7528\u5b8c\u3002")
 		return
 
 	var on_confirm: Callable = func() -> void:
@@ -119,7 +119,7 @@ static func _prompt_ad_ticket(scene, dungeon: Dictionary) -> void:
 				scene._rebuild_dungeon_panels()
 				return
 			var message: String = str(error.get("message", UiText.DUNGEON_ACTION_FAILED_DEFAULT))
-			DialogManager.show_info(UiText.DUNGEON_ACTION_FAILED_TITLE, message)
+			ToastManager.error(UiText.DUNGEON_ACTION_FAILED_TITLE, message)
 			scene._rebuild_dungeon_panels()
 		)
 

--- a/scripts/dungeon/DungeonSceneUI.gd
+++ b/scripts/dungeon/DungeonSceneUI.gd
@@ -260,7 +260,7 @@ static func _build_dungeon_detail_panel(scene, dungeon: Dictionary) -> PanelCont
 		sweep_rewards,
 		REWARD_EMPTY_TEXT,
 		sweep_button,
-		"rank"
+		"confirm"
 	))
 
 	var challenge_rewards: Dictionary = _calculate_rewards(dungeon_key, local_cfg, next_floor)
@@ -278,7 +278,7 @@ static func _build_dungeon_detail_panel(scene, dungeon: Dictionary) -> PanelCont
 		challenge_rewards,
 		REWARD_EMPTY_TEXT,
 		challenge_button,
-		"primary"
+		"confirm"
 	))
 
 	scene._dungeon_panels[dungeon_id] = {

--- a/scripts/enhance/EnhanceSceneActions.gd
+++ b/scripts/enhance/EnhanceSceneActions.gd
@@ -49,7 +49,7 @@ static func on_enhance_action_completed(
 		return
 
 	var message := str(error.get("message", UiText.ENHANCE_ACTION_FAILED_DEFAULT))
-	DialogManager.show_info(UiText.ENHANCE_ACTION_FAILED_TITLE, message)
+	ToastManager.error(UiText.ENHANCE_ACTION_FAILED_TITLE, message)
 	scene._refresh_all_labels()
 
 
@@ -152,7 +152,7 @@ static func _run_special_point_operations(scene, player_cat_id: int, operations:
 			scene._action_inflight = false
 			scene._set_loading_overlay(false)
 			var message := str(error.get("message", UiText.ENHANCE_ACTION_FAILED_DEFAULT))
-			DialogManager.show_info(UiText.ENHANCE_ACTION_FAILED_TITLE, message)
+			ToastManager.error(UiText.ENHANCE_ACTION_FAILED_TITLE, message)
 			scene._refresh_all_labels()
 			return
 		var next_last_data: Dictionary = data if data is Dictionary else last_data

--- a/scripts/enhance/EnhanceSceneUI.gd
+++ b/scripts/enhance/EnhanceSceneUI.gd
@@ -360,8 +360,8 @@ static func rebuild_detail_panel(scene) -> void:
 	scene._food_max_btn.custom_minimum_size = Vector2(0.0, 46.0)
 	upgrade_row.add_child(scene._food_max_btn)
 
-	UiPalette.apply_button_kind(scene._food_upgrade_btn, "rank")
-	UiPalette.apply_button_kind(scene._food_max_btn, "rank")
+	UiPalette.apply_button_kind(scene._food_upgrade_btn, "confirm")
+	UiPalette.apply_button_kind(scene._food_max_btn, "confirm")
 
 	scene._detail_skill_tab = VBoxContainer.new()
 	scene._detail_skill_tab.size_flags_horizontal = Control.SIZE_EXPAND_FILL
@@ -417,7 +417,7 @@ static func rebuild_detail_panel(scene) -> void:
 	scene._rank_upgrade_btn.custom_minimum_size = Vector2(0.0, 46.0)
 	scene._rank_upgrade_btn.pressed.connect(scene._on_rank_upgrade_pressed)
 	scene._detail_rank_tab.add_child(scene._rank_upgrade_btn)
-	UiPalette.apply_button_kind(scene._rank_upgrade_btn, "rank")
+	UiPalette.apply_button_kind(scene._rank_upgrade_btn, "confirm")
 
 	Refresh.refresh_resource_label(scene)
 	Refresh.refresh_rank_labels(scene, player_cat)
@@ -617,9 +617,7 @@ static func _make_cat_card(scene, cat_id: String, player_cat: PlayerCatData, is_
 
 
 static func _make_card_panel(accent: Color = OverlaySceneChrome.CARD_BORDER) -> PanelContainer:
-	var panel := PanelContainer.new()
-	panel.add_theme_stylebox_override("panel", OverlaySceneChrome.make_panel_style(OverlaySceneChrome.CARD_FILL, accent, 14))
-	return panel
+	return OverlaySceneChrome.make_card_panel(accent)
 
 
 static func refresh_detail_tab_state(scene) -> void:

--- a/scripts/gacha/GachaScene.gd
+++ b/scripts/gacha/GachaScene.gd
@@ -78,7 +78,7 @@ func _build_ui() -> void:
 	_free_button.pressed.connect(func() -> void:
 		_request_pull(1, true)
 	)
-	UiPalette.apply_button_kind(_free_button, "rank")
+	UiPalette.apply_button_kind(_free_button, "confirm")
 	pull_box.add_child(_free_button)
 
 	var hint: Label = Label.new()
@@ -133,7 +133,7 @@ func refresh_from_bootstrap(show_error_dialog: bool = true) -> void:
 			_refresh_view()
 			return
 		if show_error_dialog:
-			DialogManager.show_info(UiText.GACHA_LOAD_FAILED_TITLE, str(error.get("message", UiText.GACHA_LOAD_FAILED_BODY)))
+			ToastManager.error(UiText.GACHA_LOAD_FAILED_TITLE, str(error.get("message", UiText.GACHA_LOAD_FAILED_BODY)))
 	)
 
 
@@ -377,7 +377,7 @@ func _on_pull_button_pressed(pull_count: int) -> void:
 
 func _on_pull_completed(success: bool, data: Variant, error: Dictionary) -> void:
 	if not success:
-		DialogManager.show_info(UiText.GACHA_PULL_FAILED_TITLE, str(error.get("message", UiText.GACHA_PULL_FAILED_BODY)))
+		ToastManager.error(UiText.GACHA_PULL_FAILED_TITLE, str(error.get("message", UiText.GACHA_PULL_FAILED_BODY)))
 		return
 	var payload: Dictionary = data if data is Dictionary else {}
 	var results_variant: Variant = payload.get("results", [])

--- a/scripts/scooper/ScooperScene.gd
+++ b/scripts/scooper/ScooperScene.gd
@@ -298,9 +298,8 @@ func _show_loading_in(container: VBoxContainer) -> void:
 
 
 func _make_card_panel(accent: Color = OverlaySceneChrome.CARD_BORDER) -> PanelContainer:
-	var panel: PanelContainer = PanelContainer.new()
+	var panel: PanelContainer = OverlaySceneChrome.make_card_panel(accent)
 	panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	panel.add_theme_stylebox_override("panel", OverlaySceneChrome.make_panel_style(OverlaySceneChrome.CARD_FILL, accent, 14))
 	return panel
 
 

--- a/scripts/scooper/scooper_tab_achievement.gd
+++ b/scripts/scooper/scooper_tab_achievement.gd
@@ -97,6 +97,7 @@ func _add_achievement_section(scene: Control, title_text: String, entries: Array
 		claim_all_btn.text = UiText.SCOOPER_ACHIEVEMENT_CLAIM_ALL
 		claim_all_btn.custom_minimum_size = Vector2(120.0, 40.0)
 		claim_all_btn.disabled = bool(scene._api_in_flight)
+		UiPalette.apply_button_kind(claim_all_btn, "confirm")
 		claim_all_btn.pressed.connect(func() -> void:
 			_claim_all_achievements(scene)
 		)
@@ -203,15 +204,18 @@ func _make_achievement_card(scene: Control, entry: Dictionary) -> Control:
 	if is_completed and not is_claimed:
 		action_btn.text = UiText.SCOOPER_ACHIEVEMENT_ACTION_CLAIM
 		action_btn.disabled = bool(scene._api_in_flight)
+		UiPalette.apply_button_kind(action_btn, "confirm")
 		action_btn.pressed.connect(func() -> void:
 			_claim_achievement(scene, achievement_id)
 		)
 	elif is_claimed:
 		action_btn.text = UiText.SCOOPER_ACHIEVEMENT_ACTION_CLAIMED
 		action_btn.disabled = true
+		UiPalette.apply_button_kind(action_btn, "neutral")
 	else:
 		action_btn.text = UiText.SCOOPER_ACHIEVEMENT_ACTION_PENDING
 		action_btn.disabled = true
+		UiPalette.apply_button_kind(action_btn, "neutral")
 
 	return panel
 

--- a/scripts/scooper/scooper_tab_memory.gd
+++ b/scripts/scooper/scooper_tab_memory.gd
@@ -146,6 +146,7 @@ func _make_memory_card(scene: Control, item: Dictionary) -> Control:
 	var action_btn: Button = Button.new()
 	action_btn.custom_minimum_size = Vector2(190.0, 42.0)
 	action_btn.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	UiPalette.apply_button_kind(action_btn, "confirm")
 	card.add_child(action_btn)
 
 	if unlocked:

--- a/scripts/scooper/scooper_tab_scooper.gd
+++ b/scripts/scooper/scooper_tab_scooper.gd
@@ -245,7 +245,7 @@ func _make_equip_card(scene: Control, item: Dictionary) -> Control:
 	var action_btn: Button = Button.new()
 	action_btn.custom_minimum_size = Vector2(0.0, 44.0)
 	action_btn.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	UiPalette.apply_button_kind(action_btn, "rank")
+	UiPalette.apply_button_kind(action_btn, "confirm")
 	action_row.add_child(action_btn)
 
 	if locked:

--- a/scripts/scooper/scooper_tab_treasure.gd
+++ b/scripts/scooper/scooper_tab_treasure.gd
@@ -25,6 +25,7 @@ func build(scene: Control) -> void:
 	var total_bonus_btn: Button = Button.new()
 	total_bonus_btn.text = UiText.SCOOPER_TREASURE_TOTAL_BONUS
 	total_bonus_btn.custom_minimum_size = Vector2(120.0, 40.0)
+	UiPalette.apply_button_kind(total_bonus_btn, "info")
 	total_bonus_btn.pressed.connect(func() -> void:
 		_show_total_bonus_dialog(scene)
 	)

--- a/scripts/shop/ShopBundleView.gd
+++ b/scripts/shop/ShopBundleView.gd
@@ -156,8 +156,10 @@ func _build_bundle_card(bundle: Dictionary) -> Control:
 	if bool(bundle.get("isSoldOut", false)):
 		button.text = "\u5df2\u552e\u5b8c"
 		button.disabled = true
+		UiPalette.apply_button_kind(button, "neutral")
 	else:
 		button.text = "\u8cfc\u8cb7"
+		UiPalette.apply_button_kind(button, "confirm")
 		button.pressed.connect(_confirm_purchase.bind(
 			int(bundle.get("bundleId", 0)),
 			str(bundle.get("displayName", "\u5546\u57ce\u79ae\u5305")),
@@ -182,7 +184,7 @@ func _on_category_selected(category_id: String) -> void:
 
 func _on_purchase_completed(success: bool, data: Variant, error: Dictionary) -> void:
 	if not success:
-		DialogManager.show_info("\u8cfc\u8cb7\u5931\u6557", _extract_error_message(error, "\u8cfc\u8cb7\u79ae\u5305\u5931\u6557\u3002"))
+		ToastManager.error("\u8cfc\u8cb7\u5931\u6557", _extract_error_message(error, "\u8cfc\u8cb7\u79ae\u5305\u5931\u6557\u3002"))
 		return
 	var payload: Dictionary = data if data is Dictionary else {}
 	emit_signal("request_refresh")
@@ -203,7 +205,7 @@ func _on_purchase_completed(success: bool, data: Variant, error: Dictionary) -> 
 				])
 	if reward_lines.is_empty():
 		reward_lines.append("\u734e\u52f5\u5df2\u767c\u9001\u5b8c\u6210\u3002")
-	DialogManager.show_info("\u8cfc\u8cb7\u6210\u529f", "\n".join(reward_lines))
+	ToastManager.success("\u8cfc\u8cb7\u6210\u529f", " / ".join(reward_lines))
 
 
 func _build_limit_text(bundle: Dictionary) -> String:

--- a/scripts/shop/ShopScene.gd
+++ b/scripts/shop/ShopScene.gd
@@ -110,7 +110,7 @@ func refresh_from_bootstrap(show_error_dialog: bool = true) -> void:
 			_refresh_content()
 			return
 		if show_error_dialog:
-			DialogManager.show_info(UiText.SHOP_LOAD_FAILED_TITLE, str(error.get("message", UiText.SHOP_LOAD_FAILED_BODY)))
+			ToastManager.error(UiText.SHOP_LOAD_FAILED_TITLE, str(error.get("message", UiText.SHOP_LOAD_FAILED_BODY)))
 	)
 
 
@@ -333,9 +333,9 @@ func _build_bundle_detail_card(bundle: Dictionary) -> Control:
 	action_button.text = _build_bundle_button_text(bundle)
 	if bool(bundle.get("isSoldOut", false)):
 		action_button.disabled = true
-		UiPalette.apply_button_palette(action_button, Color(0.23, 0.18, 0.18, 0.96), Color(0.82, 0.74, 0.70, 0.9))
+		UiPalette.apply_button_kind(action_button, "neutral")
 	else:
-		UiPalette.apply_button_kind(action_button, "primary")
+		UiPalette.apply_button_kind(action_button, "confirm")
 		action_button.pressed.connect(func() -> void:
 			_confirm_bundle_purchase(bundle)
 		)
@@ -466,7 +466,7 @@ func _build_arena_ticket_card() -> Control:
 		UiPalette.apply_button_kind(button, "primary")
 	else:
 		button.disabled = true
-		UiPalette.apply_button_palette(button, Color(0.23, 0.18, 0.18, 0.96), Color(0.82, 0.74, 0.70, 0.9))
+		UiPalette.apply_button_kind(button, "neutral")
 	action_row.add_child(button)
 
 	return panel
@@ -583,10 +583,14 @@ func _open_quantity_keypad(anchor: Control, initial_value: int, on_submit: Calla
 	grid.add_theme_constant_override("v_separation", 8)
 	content.add_child(grid)
 
-	var state := {"buffer": str(initial_value)}
+	var state := {"buffer": "" if initial_value <= 0 else str(initial_value)}
 	var close_dialog: Callable = Callable()
+	var ok_button: Button = null
 	var refresh_display := func() -> void:
 		display.text = state["buffer"] if str(state["buffer"]) != "" else "0"
+		var has_value: bool = str(state["buffer"]) != "" and int(str(state["buffer"])) > 0
+		if ok_button != null:
+			ok_button.disabled = not has_value
 
 	for key_label: String in ["1", "2", "3", "4", "5", "6", "7", "8", "9", "C", "0", "OK"]:
 		var button: Button = Button.new()
@@ -595,14 +599,21 @@ func _open_quantity_keypad(anchor: Control, initial_value: int, on_submit: Calla
 		button.custom_minimum_size = Vector2(0.0, 52.0)
 		button.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SUBHEADING)
 		if key_label == "OK":
+			ok_button = button
 			UiPalette.apply_button_kind(button, "primary")
+			button.disabled = true
+		elif key_label == "C":
+			UiPalette.apply_button_kind(button, "neutral")
 		grid.add_child(button)
 		button.pressed.connect(func() -> void:
 			match key_label:
 				"C":
 					state["buffer"] = ""
 				"OK":
-					var value: int = maxi(1, int(str(state["buffer"]) if str(state["buffer"]) != "" else "0"))
+					if str(state["buffer"]) == "" or int(str(state["buffer"])) <= 0:
+						refresh_display.call()
+						return
+					var value: int = int(str(state["buffer"]))
 					if on_submit.is_valid():
 						on_submit.call(value)
 					if close_dialog.is_valid():
@@ -634,10 +645,10 @@ func _open_quantity_keypad(anchor: Control, initial_value: int, on_submit: Calla
 func _purchase_trap_cages(quantity: int) -> void:
 	_api_client.purchase_trap_cages(quantity, func(success: bool, _data: Variant, error: Dictionary) -> void:
 		if not success:
-			DialogManager.show_info(UiText.SHOP_PURCHASE_FAILED_TITLE, str(error.get("message", UiText.SHOP_TRAP_CAGE_PURCHASE_FAILED_BODY)))
+			ToastManager.error(UiText.SHOP_PURCHASE_FAILED_TITLE, str(error.get("message", UiText.SHOP_TRAP_CAGE_PURCHASE_FAILED_BODY)))
 			return
 		refresh_from_bootstrap(false)
-		DialogManager.show_info(UiText.SHOP_PURCHASE_SUCCESS_TITLE, UiText.SHOP_TRAP_CAGE_PURCHASE_SUCCESS_BODY)
+		ToastManager.success(UiText.SHOP_PURCHASE_SUCCESS_TITLE, UiText.SHOP_TRAP_CAGE_PURCHASE_SUCCESS_BODY)
 	)
 
 
@@ -657,14 +668,14 @@ func _confirm_collision_coin_purchase(item: Dictionary) -> void:
 func _purchase_collision_coin(amount: int) -> void:
 	_api_client.purchase_trap_points(amount, func(success: bool, data: Variant, error: Dictionary) -> void:
 		if not success:
-			DialogManager.show_info(UiText.SHOP_PURCHASE_FAILED_TITLE, str(error.get("message", UiText.SHOP_COLLISION_COIN_PURCHASE_FAILED_BODY)))
+			ToastManager.error(UiText.SHOP_PURCHASE_FAILED_TITLE, str(error.get("message", UiText.SHOP_COLLISION_COIN_PURCHASE_FAILED_BODY)))
 			return
 		var payload: Dictionary = data if data is Dictionary else {}
 		var overview: Dictionary = payload.get("overview", {})
 		if not overview.is_empty():
 			GameState.update_shop(overview)
 		_refresh_content()
-		DialogManager.show_info(UiText.SHOP_PURCHASE_SUCCESS_TITLE, UiText.SHOP_COLLISION_COIN_PURCHASE_SUCCESS_BODY % amount)
+		ToastManager.success(UiText.SHOP_PURCHASE_SUCCESS_TITLE, UiText.SHOP_COLLISION_COIN_PURCHASE_SUCCESS_BODY % amount)
 	)
 
 
@@ -695,7 +706,7 @@ func _open_trap_cage_keypad_dialog() -> void:
 		return
 	_trap_cage_keypad_close = _open_quantity_keypad(
 		_trap_cage_quantity_button,
-		_trap_cage_quantity,
+		0,
 		Callable(self, "_set_trap_cage_quantity")
 	)
 
@@ -737,7 +748,7 @@ func _on_trap_cage_quantity_dialog_closed() -> void:
 func _purchase_arena_tickets() -> void:
 	_api_client.purchase_arena_tickets(func(success: bool, data: Variant, error: Dictionary) -> void:
 		if not success:
-			DialogManager.show_info(UiText.SHOP_PURCHASE_FAILED_TITLE, str(error.get("message", UiText.SHOP_ARENA_TICKET_PURCHASE_FAILED_BODY)))
+			ToastManager.error(UiText.SHOP_PURCHASE_FAILED_TITLE, str(error.get("message", UiText.SHOP_ARENA_TICKET_PURCHASE_FAILED_BODY)))
 			return
 		if data is Dictionary:
 			var response: Dictionary = data
@@ -745,6 +756,7 @@ func _purchase_arena_tickets() -> void:
 			if not overview.is_empty():
 				GameState.update_arena(overview)
 		refresh_from_bootstrap(false)
+		ToastManager.success(UiText.SHOP_PURCHASE_SUCCESS_TITLE, UiText.SHOP_ARENA_TICKET_TITLE)
 	)
 
 
@@ -773,7 +785,7 @@ func _on_bundle_purchase_completed(success: bool, data: Variant, error: Dictiona
 			)
 			return
 		_pending_bundle_purchase.clear()
-		DialogManager.show_info(UiText.SHOP_PURCHASE_FAILED_TITLE, str(error.get("message", UiText.SHOP_BUNDLE_PURCHASE_FAILED_BODY)))
+		ToastManager.error(UiText.SHOP_PURCHASE_FAILED_TITLE, str(error.get("message", UiText.SHOP_BUNDLE_PURCHASE_FAILED_BODY)))
 		return
 	var payload: Dictionary = data if data is Dictionary else {}
 	_pending_bundle_purchase.clear()
@@ -791,7 +803,7 @@ func _on_bundle_purchase_completed(success: bool, data: Variant, error: Dictiona
 				])
 	if reward_lines.is_empty():
 		reward_lines.append(UiText.SHOP_REWARD_SENT)
-	DialogManager.show_info(UiText.SHOP_PURCHASE_SUCCESS_TITLE, "\n".join(reward_lines))
+	ToastManager.success(UiText.SHOP_PURCHASE_SUCCESS_TITLE, " / ".join(reward_lines))
 
 
 func _should_redirect_to_collision_coin_store(error: Dictionary) -> bool:

--- a/scripts/shop/ShopTrapCageView.gd
+++ b/scripts/shop/ShopTrapCageView.gd
@@ -82,6 +82,7 @@ func _build_offer_card(offer: Dictionary) -> Control:
 	var button := Button.new()
 	button.text = "\u8cfc\u8cb7"
 	button.custom_minimum_size = Vector2(140.0, 48.0)
+	UiPalette.apply_button_kind(button, "confirm")
 	button.pressed.connect(_confirm_purchase.bind(count, cost))
 	row.add_child(button)
 
@@ -97,7 +98,7 @@ func _confirm_purchase(count: int, cost: int) -> void:
 
 func _on_purchase_completed(success: bool, data: Variant, error: Dictionary) -> void:
 	if not success:
-		DialogManager.show_info("\u8cfc\u8cb7\u5931\u6557", _extract_error_message(error, "\u8cfc\u8cb7\u8a98\u6355\u7c60\u5931\u6557\u3002"))
+		ToastManager.error("\u8cfc\u8cb7\u5931\u6557", _extract_error_message(error, "\u8cfc\u8cb7\u8a98\u6355\u7c60\u5931\u6557\u3002"))
 		return
 	emit_signal("request_refresh")
 	var owner := get_parent()
@@ -105,7 +106,7 @@ func _on_purchase_completed(success: bool, data: Variant, error: Dictionary) -> 
 		var scene := owner.get_parent()
 		if scene != null and scene.has_method("refresh_from_bootstrap"):
 			scene.refresh_from_bootstrap(false)
-	DialogManager.show_info("\u8cfc\u8cb7\u6210\u529f", "\u5df2\u6210\u529f\u8cfc\u8cb7\u8a98\u6355\u7c60\u3002")
+	ToastManager.success("\u8cfc\u8cb7\u6210\u529f", "\u5df2\u6210\u529f\u8cfc\u8cb7\u8a98\u6355\u7c60\u3002")
 
 
 func _extract_error_message(error: Dictionary, fallback: String) -> String:

--- a/scripts/ui/cat_roster_card.gd
+++ b/scripts/ui/cat_roster_card.gd
@@ -2,6 +2,7 @@ class_name CatRosterCard
 extends RefCounted
 
 const AssetResolver = preload("res://scripts/ui/asset_resolver.gd")
+const OverlaySceneChrome = preload("res://scripts/ui/overlay_scene_chrome.gd")
 const UiPalette = preload("res://scripts/ui/ui_palette.gd")
 
 
@@ -30,7 +31,7 @@ static func build(options: Dictionary) -> PanelContainer:
 	card.custom_minimum_size = Vector2(0.0, card_height)
 	card.add_theme_stylebox_override(
 		"panel",
-		_make_panel_style(
+		OverlaySceneChrome.make_panel_style(
 			selected_card_fill if is_selected else card_fill,
 			selected_card_border if is_selected else card_border,
 			int(options.get("card_radius", 14))
@@ -48,7 +49,7 @@ static func build(options: Dictionary) -> PanelContainer:
 	art_panel.custom_minimum_size = Vector2(0.0, float(options.get("art_height", 112.0)))
 	art_panel.add_theme_stylebox_override(
 		"panel",
-		_make_panel_style(
+		OverlaySceneChrome.make_panel_style(
 			selected_art_fill if is_selected else art_fill,
 			selected_art_border if is_selected else art_border,
 			int(options.get("art_radius", 12))
@@ -159,7 +160,7 @@ static func _make_meta_chip(text: String, is_selected: bool, options: Dictionary
 	chip.custom_minimum_size = Vector2(float(options.get("chip_min_width", 75.0)), 0.0)
 	chip.add_theme_stylebox_override(
 		"panel",
-		_make_panel_style(
+		OverlaySceneChrome.make_panel_style(
 			selected_chip_fill if is_selected else chip_fill,
 			selected_chip_border if is_selected else chip_border,
 			int(options.get("chip_radius", 12))
@@ -187,18 +188,3 @@ static func _make_content_margin(value: int) -> MarginContainer:
 	margin.add_theme_constant_override("margin_right", value)
 	margin.add_theme_constant_override("margin_bottom", value)
 	return margin
-
-
-static func _make_panel_style(fill: Color, border: Color, radius: int) -> StyleBoxFlat:
-	var style: StyleBoxFlat = StyleBoxFlat.new()
-	style.bg_color = fill
-	style.border_width_left = 2
-	style.border_width_right = 2
-	style.border_width_top = 2
-	style.border_width_bottom = 2
-	style.border_color = border
-	style.corner_radius_top_left = radius
-	style.corner_radius_top_right = radius
-	style.corner_radius_bottom_left = radius
-	style.corner_radius_bottom_right = radius
-	return style

--- a/scripts/ui/scene_submenu_bar.gd
+++ b/scripts/ui/scene_submenu_bar.gd
@@ -2,6 +2,7 @@ class_name SceneSubmenuBar
 extends RefCounted
 
 const SceneMenuTheme = preload("res://scripts/ui/scene_menu_theme.gd")
+const OverlaySceneChrome = preload("res://scripts/ui/overlay_scene_chrome.gd")
 
 static func build(host: Control, options: Dictionary) -> Dictionary:
 	var button_map: Dictionary = {}
@@ -28,7 +29,7 @@ static func build(host: Control, options: Dictionary) -> Dictionary:
 	back_panel.offset_top = float(options.get("top", -222.0))
 	back_panel.offset_right = back_right
 	back_panel.offset_bottom = float(options.get("bottom", -110.0))
-	back_panel.add_theme_stylebox_override("panel", _make_panel_style(panel_fill, panel_border, 16))
+	back_panel.add_theme_stylebox_override("panel", OverlaySceneChrome.make_panel_style(panel_fill, panel_border, 16))
 	host.add_child(back_panel)
 
 	var back_margin := _make_content_margin(int(options.get("margin", 12)))
@@ -52,7 +53,7 @@ static func build(host: Control, options: Dictionary) -> Dictionary:
 	dock_panel.offset_top = float(options.get("top", -222.0))
 	dock_panel.offset_right = right
 	dock_panel.offset_bottom = float(options.get("bottom", -110.0))
-	dock_panel.add_theme_stylebox_override("panel", _make_panel_style(panel_fill, panel_border, 16))
+	dock_panel.add_theme_stylebox_override("panel", OverlaySceneChrome.make_panel_style(panel_fill, panel_border, 16))
 	host.add_child(dock_panel)
 
 	var dock_margin := _make_content_margin(int(options.get("margin", 12)))
@@ -110,18 +111,3 @@ static func _make_content_margin(value: int) -> MarginContainer:
 	margin.add_theme_constant_override("margin_right", value)
 	margin.add_theme_constant_override("margin_bottom", value)
 	return margin
-
-
-static func _make_panel_style(fill: Color, border: Color, radius: int) -> StyleBoxFlat:
-	var style := StyleBoxFlat.new()
-	style.bg_color = fill
-	style.border_width_left = 2
-	style.border_width_right = 2
-	style.border_width_top = 2
-	style.border_width_bottom = 2
-	style.border_color = border
-	style.corner_radius_top_left = radius
-	style.corner_radius_top_right = radius
-	style.corner_radius_bottom_left = radius
-	style.corner_radius_bottom_right = radius
-	return style

--- a/scripts/ui/ui_palette.gd
+++ b/scripts/ui/ui_palette.gd
@@ -1,8 +1,11 @@
 class_name UiPalette
 extends RefCounted
 
-const BUTTON_PRIMARY_BG := Color(0.94, 0.77, 0.39, 1.0)
-const BUTTON_PRIMARY_FG := Color(0.16, 0.11, 0.05, 1.0)
+const BUTTON_PRIMARY_BG := Color(0.80, 0.70, 0.43, 0.98)
+const BUTTON_PRIMARY_FG := Color(0.22, 0.17, 0.10, 1.0)
+const BUTTON_DISABLED_BG := Color(0.28, 0.26, 0.24, 0.84)
+const BUTTON_DISABLED_BORDER := Color(0.41, 0.38, 0.35, 0.92)
+const BUTTON_DISABLED_FG := Color(0.67, 0.64, 0.60, 0.92)
 const BUTTON_SECONDARY_BG := Color(0.63, 0.46, 0.20, 0.96)
 const BUTTON_SECONDARY_FG := Color(0.98, 0.95, 0.88, 1.0)
 const BUTTON_RANK_BG := Color(0.30, 0.22, 0.10, 0.96)
@@ -104,15 +107,16 @@ static func apply_button_palette(button: Button, bg: Color, fg: Color) -> void:
 	pressed.bg_color = bg.darkened(0.08)
 
 	var disabled: StyleBoxFlat = normal.duplicate()
-	disabled.bg_color = bg.darkened(0.18)
-	disabled.border_color = bg.lightened(0.04)
+	disabled.bg_color = BUTTON_DISABLED_BG
+	disabled.border_color = BUTTON_DISABLED_BORDER
+	disabled.shadow_color = Color(0.0, 0.0, 0.0, 0.0)
 
 	button.add_theme_stylebox_override("normal", normal)
 	button.add_theme_stylebox_override("hover", hover)
 	button.add_theme_stylebox_override("pressed", pressed)
 	button.add_theme_stylebox_override("disabled", disabled)
 	button.add_theme_color_override("font_color", fg)
-	button.add_theme_color_override("font_disabled_color", fg.darkened(0.25))
+	button.add_theme_color_override("font_disabled_color", BUTTON_DISABLED_FG)
 
 
 static func style_rank_progress_bar(bar: ProgressBar) -> void:


### PR DESCRIPTION
## 變更摘要
- 統一多個場景的按鈕語意與共用 UI helper，讓主操作、資訊、選單與回滾操作維持一致
- 將適合的非阻塞結果通知改為 toast，減少不必要的 dialog 打斷
- 調整主操作色與 disabled 樣式，讓可操作與不可操作狀態更容易辨識
- 修正商店誘捕籠購買 keypad 的初始值、確認按鈕狀態與 dialog 關閉 callback

## 主要調整
- 改用共用 panel/card helper 收斂 scene submenu 與卡片樣式
- 將 Config、Dungeon、Enhance、Gacha、Shop、Arena、Scooper、Home battle 的結果提示收斂到 toast
- 依功能語意調整按鈕顏色：主操作、資訊、選單、回滾與 disabled 狀態
- 修正 Shop 誘捕籠購買時 keypad 預設顯示 0，且未輸入有效數值前不可按確定
- 修正 dialog close callable 在節點已釋放時的 null 錯誤

## 未納入
- 未追蹤的 home 圖檔素材未納入此次提交

Closes #128