### PR TITLE
[codex] Add settings center, lineup scene, and local audio config

### DIFF
--- a/docs/gdd/08_ui.md
+++ b/docs/gdd/08_ui.md
@@ -2,15 +2,20 @@
 
 ## 主畫面
 
-顯示戰鬥場地，底部導覽列：
+首頁顯示常駐戰鬥場景，底部導覽列如下：
 
 | 按鈕 | 功能 |
-|------|------|
+| --- | --- |
 | 鏟屎官 | 鏟屎官資訊、能力、裝備與收藏畫面 |
-| 編隊 | 貓咪配置畫面 |
+| 編隊 | 開啟 `LineupScene`，進行貓咪隊伍配置與延遲設定 |
 | 強化 | 強化貓咪 |
 | 活動 | 活動 / 競技場等入口 |
 | 商店 | 購買道具 / 誘捕籠 |
+
+首頁左上角為新的個人資訊入口：
+
+- 顯示目前頭像與暱稱
+- 點擊後開啟 `ConfigScene` 設定中心
 
 ### 主畫面戰鬥 HUD
 
@@ -19,18 +24,75 @@
 - `全部` 模式會展開為雙排，完整顯示我方 5 隻與敵方 5 隻的頭像、血量條、冷卻條與冷卻倒數。
 - 技能格僅顯示角色頭像、HP、冷卻資訊與死亡遮罩，不顯示技能名稱文字。
 - `清理貓砂盆 HH:MM:SS` 與 `加速` 兩顆按鈕位於技能欄標頭列，清理貓砂盆在左、加速在右。
+- 左上角頭像 / 名稱區塊會隨 `GameState.player_profile_changed` 即時刷新。
+- 資源列會隨 `GameState.player_wallet_changed` 即時刷新。
 
 ### 【2026/04/05】UI 顯示統一調整
+
 - 所有顯示貓咪名稱的地方（如強化頁、競技場、隊伍列表等）皆統一顯示為「名稱LvX」格式，Lv 由玩家資料決定。
-- 顯示格式集中由 CatRegistry.get_cat_display_name_with_lv 控制，方便日後維護。
+- 顯示格式集中由 `CatRegistry.get_cat_display_name_with_lv` 控制，方便日後維護。
 
-## 配置畫面
+## 設定中心
 
-- 拖曳貓咪至上場位置，決定站位順序
-- 長按縮圖：查看技能與冷卻時間
+設定中心由首頁左上角頭像入口開啟，使用 `OverlaySceneChrome` 的 overlay 風格，分成三區：
+
+### 角色資料
+
+- 預設頭像
+- 暱稱
+- 角色名稱
+- 自介
+- 生日
+- 性別
+- 地區
+
+互動規則：
+
+- 表單編輯後才啟用儲存按鈕
+- 儲存成功顯示 success toast
+- 成功後立即更新首頁左上角頭像與名稱
+
+### 帳號資料
+
+- 顯示帳號與 `Player UID`
+- 顯示 `Google` / `Apple` 綁定狀態
+- OAuth 本期只做狀態展示，不會進入真正授權流程
+- 內建兌換碼輸入框與 `兌換` 按鈕
+
+互動規則：
+
+- 已綁定 provider 顯示 `已綁定`
+- 未綁定顯示 `即將開放`
+- 兌換碼成功後顯示獎勵 Dialog，再顯示 success toast
+- 兌換碼失敗時只顯示 error toast，不更新本地錢包
+
+### 遊戲設定
+
+- `總音量`
+- `背景音樂`
+- `音效`
+
+每一列都包含：
+
+- slider
+- 百分比文字
+- 靜音 checkbox
+
+規則：
+
+- 音量與靜音設定只保存在本機 `user://client_settings.json`
+- 調整後立即套用到 `Master` / `BGM` / `SFX` audio bus
+
+## 編隊畫面
+
+編隊畫面由底部導覽列 `編隊` 進入，實作場景為 `LineupScene`。
+
+- 加入 / 移除貓咪，決定站位與隊伍內容
+- 點擊延遲按鈕可循環調整 `initialDelaySeconds`
+- 長按貓咪縮圖可查看技能與冷卻時間
 - 貓咪圖示右上角顯示品階：`+1`、`+2`...
-- 已加入隊伍的貓咪按鈕會自動變為 disabled，無法重複加入同一隻貓咪。
-- 最大上場數、隊伍限制等皆由 JSON 設定檔決定，UI 會自動反映設定。
+- 已加入隊伍的貓咪不會重複加入同一隊
+- 最大上場數、各場景隊伍限制由 JSON / bootstrap 設定決定，UI 會自動反映
 
 ## 商店頁面
 
@@ -38,213 +100,162 @@
 
 ## 全域 UI 元件系統
 
-> 開發新功能時，以下規範為判斷「該用哪個元件」的唯一依據。
+> 開發新功能時，以下規範是判斷「該用哪個元件」的主要依據。
 > 程式碼層級細節（API 參數、顏色常數）請參考 `docs/ui_component_spec.md`。
 
 ---
 
-### 按鈕系統（UiPalette）
+## 按鈕系統（UiPalette）
 
 所有按鈕樣式統一由 `UiPalette.apply_button_kind(button, kind)` 套用。
 
-#### 按鈕種類與使用情境
+| 種類（語意別名） | 種類（顏色別名） | 外觀 | 什麼時候用 |
+| --- | --- | --- | --- |
+| `confirm` | `primary` | 金黃色 | 玩家主要目的動作：確認購買、出戰、抽卡、儲存 |
+| `cancel` | `secondary` | 棕褐色 | 放棄本次操作：取消、返回上一步 |
+| `neutral` | `rank` | 深棕色 | 不消費資源的中性動作：切換面板、查看排行、免費抽 |
+| `info` | `info` | 深灰色 | 純說明、無明確操作方向：規則說明、`?` 按鈕 |
+| `destruct` | `danger` | 深紅色 | 不可逆危險操作：重置、清除、解散 |
+| `remove` | `minus` | 深灰小型 | 數量減少：`－` |
+| `add` | `plus` | 橫幅棕小型 | 數量增加：`＋` |
 
-| 種類（語意別名） | 種類（顏色別名） | 外觀 | **什麼時候用** |
-|----------------|----------------|------|--------------|
-| `confirm` | `primary` | 金黃色 | 玩家的**主要目的動作**：確認購買、出戰、抽卡、儲存隊伍 |
-| `cancel` | `secondary` | 棕褐色 | **放棄此次操作**：取消、返回上一步 |
-| `neutral` | `rank` | 深棕色 | **不消費資源的中性動作**：切換面板、查看排名資訊、免費抽（尚有次數） |
-| `info` | `info` | 深灰色 | **純說明、無明確操作方向**：顯示規則說明（? 按鈕） |
-| `destruct` | `danger` | 深紅色 | **不可逆的危險操作**：重置、清除、解散（需搭配 Confirm Dialog） |
-| `remove` | `minus` | 深灰小型 | **數量減少**：－ 按鈕 |
-| `add` | `plus` | 橄欖棕小型 | **數量增加**：＋ 按鈕、加技能點 |
+判斷原則：
 
-#### 判斷原則
-
-1. **一個操作流程只能有一個 `confirm` 按鈕**，代表「做這件事」的最終動作。
-2. `destruct` 按鈕必須搭配 Confirm Dialog，讓玩家二次確認，不可直接執行。
-3. 資源不足時（門票 / 餘額不足）的按鈕改用 `neutral`，讓玩家感知「目前無法行動」而不是「有行動可做」。
-4. 不要用自訂顏色建立按鈕，現有 7 種已涵蓋所有情境；如有新的不適合的情境，應討論後新增至 `UiPalette`。
+1. 一個操作流程只應有一個主要 `confirm` 按鈕。
+2. `destruct` 必須搭配 Confirm Dialog。
+3. 資源不足時按鈕改用 `neutral`，讓玩家知道目前不能做。
+4. 不要自行硬寫新顏色，除非先擴充 `UiPalette`。
 
 ---
 
-## 全域對話框（Dialog）規範
+## 全域對話框（Dialog）
 
 ### 資訊方框（Info Dialog）
-- 僅顯示右上角「✕」按鈕
+
+- 只顯示右上角關閉按鈕
 - 可點擊方框外任意處關閉
-- 不顯示其他按鈕（如「確定」等）
-- 方框下方顯示白色提示文字：「點擊任意處關閉視窗」
+- 不顯示其他操作按鈕
 - 用於單純提示、說明、資訊展示
 
 ### 二次確認方框（Confirm Dialog）
-- 僅顯示「確定」與「取消」兩個按鈕
-- 不能點擊方框外任意處關閉（必須按按鈕才可關閉）
-- 用於需要玩家明確選擇的操作（如刪除、消耗資源等）
 
-### 實作原則
-- 兩種方框行為由 DialogManager 統一管理，避免重複程式碼，方便維護與擴充。
-- 所有彈窗請依此規範設計，確保 UI/UX 一致性。
+- 只顯示 `確認` 與 `取消`
+- 不能點方框外直接關閉
+- 用於資源消耗、刪除、重置等需要明確決策的行為
 
-### Dialog 使用情境
+### 使用情境
 
 | 情境 | 種類 |
-|------|------|
-| 顯示排名加成、技能說明 | Info Dialog |
+| --- | --- |
+| 顯示排行加成、技能說明 | Info Dialog |
 | 顯示規則說明 | Info Dialog |
-| API 載入失敗（無法繼續操作） | Info Dialog |
-| 購買確認（消費貨幣） | Confirm Dialog |
-| 重置、清除、刪除操作 | Confirm Dialog |
-| 解散、放棄等不可逆操作 | Confirm Dialog |
+| API 載入失敗且無法繼續操作 | Info Dialog |
+| 購買確認 | Confirm Dialog |
+| 重置、清除、刪除 | Confirm Dialog |
 
-> 輕量操作反饋（購買成功、操作完成）請使用 **Toast 通知**，不要用 Dialog。
+> 輕量操作反饋（儲存成功、兌換成功等）請優先使用 Toast，而不是 Dialog。
 
 ---
 
 ## 全域 Toast 通知（ToastManager）
 
-Toast 是**非阻斷式**的輕量通知，玩家不需要任何操作即可自動消失（3 秒）。
-
-### 三種 Toast 類型
+Toast 是非阻斷式的輕量通知，3 秒後自動消失。
 
 | 類型 | 顏色 | 圖示 | 使用情境 |
-|------|------|------|---------|
-| `success` | 綠色 | ✓ | 操作**成功**的反饋 |
-| `error` | 紅色 | ✕ | **非阻斷性錯誤**，玩家可繼續操作 |
-| `hint` | 黃色 | ！ | **提示、限制說明**，告知玩家狀態 |
+| --- | --- | --- | --- |
+| `success` | 綠色 | `✓` | 操作成功 |
+| `error` | 紅色 | `✕` | 非阻斷性錯誤，玩家仍可繼續操作 |
+| `hint` | 黃色 | `！` | 提示、限制說明 |
 
-### Toast 使用情境
+常見情境：
 
-| 情境 | 類型 |
-|------|------|
-| 購買成功 | `success` |
-| 領取獎勵成功 | `success` |
-| 設定儲存成功 | `success` |
-| 道具使用成功 | `success` |
-| API 請求逾時（可重試） | `error` |
-| 網路錯誤（不影響主流程） | `error` |
-| 今日購買上限已達 | `hint` |
-| 免費抽卡已重置 | `hint` |
-| 冷卻中，尚無法操作 | `hint` |
-| 功能尚未開放 | `hint` |
-
-### Dialog vs Toast 判斷流程
-
-```
-玩家執行操作後...
-  └─ 操作是否需要玩家做選擇？
-       ├─ 是 → Confirm Dialog（確認 / 取消）
-       └─ 否 → 操作是否成功？
-                ├─ 成功 → Toast success
-                └─ 失敗 → 玩家還能繼續操作嗎？
-                           ├─ 能 → Toast error
-                           └─ 不能（必須解決才能繼續）→ Info Dialog
-```
+- 購買成功 -> `success`
+- 領取獎勵成功 -> `success`
+- 設定儲存成功 -> `success`
+- 兌換碼成功 -> `success`
+- API 請求逾時 -> `error`
+- 網路錯誤但不影響主流程 -> `error`
+- 功能尚未開放 -> `hint`
+- 今日上限已達 -> `hint`
 
 ---
 
-## 導覽列與選單（何時用哪種）
+## 導覽列與選單
 
 ### 主導覽列（底部 Dock）
 
-**使用時機**：場景內有 **2 個以上的主要分頁**，且分頁內容性質平行。
+使用時機：場景內有兩個以上主要分頁，且內容性質平行。
 
 範例：
+
+- 首頁主功能入口
 - 扭蛋：永久池 / 限定池
 - 副本：掃蕩 / 挑戰
 
-實作：透過 `OverlaySceneChrome.build()` 的 `dock_items` 參數，或 `SceneSubmenuBar.build()`。
-
 ### 側邊欄子選單（Secondary Submenu）
 
-**使用時機**：場景內有**垂直的分類列表**，左側選單、右側內容。
+使用時機：場景內有垂直分類列表，左側選單、右側內容。
 
 範例：
-- 商店：超值禮包 / 衝撞幣 / 鑽石商店（左側群組，右側卡片）
 
-實作：`SceneSecondarySubmenu.build()`。
+- 商店：超值禮包 / 衝撞幣 / 鑽石商店
 
-### 二次確認對話框
+### overlay 導覽規則
 
-**使用時機**：玩家的操作有**不可逆後果**（消費貨幣、重置資料）或需要二次確認。
-
-實作：`DialogManager.show_confirm()`。
-
-### 隨意點選取消的視窗（Info Dialog）
-
-**使用時機**：顯示說明、讀取結果或錯誤通知，玩家點任意處即可關閉。
-
-實作：`DialogManager.show_info()`。
+- `SceneNavigator` 用於首頁 overlay 類場景切換。
+- `ConfigScene` 是設定中心 overlay。
+- `LineupScene` 是編隊 overlay。
+- 深層戰鬥或活動流程仍可用 `change_scene_to_file(...)` 離開首頁 shell。
 
 ---
 
 ## 面板與卡片樣式
 
-所有場景的面板和卡片請統一呼叫 `OverlaySceneChrome` 的靜態方法建立，不要在各場景自行定義 `_make_panel_style()`。
+所有場景的面板與卡片請統一使用 `OverlaySceneChrome` 建立，不要在各場景自行做 `_make_panel_style()`。
 
 | 元件 | 使用時機 | 建立方式 |
-|------|---------|---------|
-| 主面板 | 場景主要內容區域 | `OverlaySceneChrome.make_panel_style(PANEL_FILL, PANEL_BORDER, 18)` |
-| 卡片 | 列表項目、個別物品展示 | `OverlaySceneChrome.make_card_panel()` |
+| --- | --- | --- |
+| 主面板 | 場景主要內容區域 | `OverlaySceneChrome.make_panel_style(...)` |
+| 卡片 | 列表項目、物品展示 | `OverlaySceneChrome.make_card_panel()` |
 | 自訂卡片 | 稀有度邊框、強調色 | `OverlaySceneChrome.make_card_panel(accent_color, fill, radius)` |
 
 ---
 
-## 字型大小系統（UiPalette）
+## 字體大小系統（UiPalette）
 
-所有文字大小請使用 `UiPalette` 的常數，禁止在程式碼裡直接寫數字。修改常數即可一次更新全遊戲同一層級的所有文字。
+所有文字大小請優先使用 `UiPalette` 常數。
 
 | 常數 | 大小 | 使用情境 |
-|------|------|---------|
-| `UiPalette.FONT_SIZE_DISPLAY` | 34 | 超大展示數字（戰力值、大型倒數計時） |
-| `UiPalette.FONT_SIZE_HEADING` | 28 | 場景主標題、大型標頭 |
-| `UiPalette.FONT_SIZE_TITLE` | 24 | 次要標頭、對話框標題 |
-| `UiPalette.FONT_SIZE_SUBHEADING` | 22 | 分頁標籤、副標題 |
-| `UiPalette.FONT_SIZE_BODY_LG` | 20 | 主要按鈕文字、稍大說明 |
-| `UiPalette.FONT_SIZE_BODY` | 18 | 主要內文、一般按鈕（最常用） |
-| `UiPalette.FONT_SIZE_LABEL` | 16 | 標籤、次要說明文字 |
-| `UiPalette.FONT_SIZE_SMALL` | 14 | 附屬資訊、chip 文字 |
-| `UiPalette.FONT_SIZE_TINY` | 12 | 角標、最小資訊文字 |
-
-若有特定場景需要微調（如 17px 的卡片描述文字），可保留為一次性魔法數字，不強制對應至上表。
+| --- | --- | --- |
+| `FONT_SIZE_DISPLAY` | 34 | 超大展示數字、主視覺標題 |
+| `FONT_SIZE_HEADING` | 28 | 場景主標題 |
+| `FONT_SIZE_TITLE` | 24 | 次要標頭、Dialog 標題 |
+| `FONT_SIZE_SUBHEADING` | 22 | 分頁標籤 |
+| `FONT_SIZE_BODY_LG` | 20 | 主要按鈕文字 |
+| `FONT_SIZE_BODY` | 18 | 主要內文 |
+| `FONT_SIZE_LABEL` | 16 | 標籤與次要說明 |
+| `FONT_SIZE_SMALL` | 14 | 附屬資訊 |
+| `FONT_SIZE_TINY` | 12 | 角標與最小資訊 |
 
 ---
 
 ## 徽章 / 紅點系統（BadgeOverlay）
 
-在按鈕或其他 Control 節點的右上角顯示紅點或數字徽章，用來提示玩家有未讀訊息、新內容或待處理事項。
+在按鈕或其他 Control 的右上角顯示紅點或數字徽章，提示玩家有未讀資訊或待處理事項。
 
 ### API
 
 ```gdscript
-# 紅點（無數字，例如：有新活動、有新郵件）
 BadgeOverlay.add_dot(button)
-
-# 數字徽章（例如：未讀郵件 5 封）
-BadgeOverlay.add_count(button, 5)        # 顯示「5」
-BadgeOverlay.add_count(button, 120)      # 超過 99 顯示「99+」
-
-# 移除徽章（例如：玩家已讀取完畢）
+BadgeOverlay.add_count(button, 5)
 BadgeOverlay.remove(button)
 ```
 
-### 使用情境
-
-| 情境 | 類型 |
-|------|------|
-| 有新郵件未讀 | `add_count(button, unread_count)` |
-| 商店有新商品上架 | `add_dot(button)` |
-| 好友申請待處理 | `add_count(button, count)` |
-| 活動有限時任務可完成 | `add_dot(button)` |
-| 強化有貓咪可升等 | `add_dot(button)` |
-| 已讀取、已處理 | `remove(button)` |
-
 ### 規則
 
-- 數字超過 99 自動顯示 `99+`，不需要呼叫端自行判斷。
-- 重複呼叫 `add_dot` / `add_count` 會自動更新，不會疊加多個紅點。
-- `count <= 0` 時呼叫 `add_count` 等同呼叫 `remove`，自動清除。
-- 不需要 Autoload，`BadgeOverlay` 為 `class_name` 全域可用。
+- 數字超過 99 自動顯示 `99+`
+- 重複呼叫會自動更新，不會疊多個紅點
+- `count <= 0` 視同移除
 
 ---
 
@@ -252,18 +263,19 @@ BadgeOverlay.remove(button)
 
 ### 共用 Loading Overlay 視覺規則
 
-- Client 端共用 API loading overlay 的配色需對齊 StartScene 讀取區塊。
-- 不直接複製 StartScene 程式碼，但共用 overlay 需採用相同視覺語言：
-  - 外層遮罩：偏棕色半透明遮罩。
-  - 中央內容：米白卡片底、咖啡色外框。
-  - 載入文字：棕色字體。
-  - Spinner / 點點：StartScene 同系綠色。
+- 配色需對齊 `StartScene`：
+  - 外層遮罩：偏棕色半透明遮罩
+  - 中央內容：米白卡片底、咖啡色外框
+  - 文字：棕色字體
+  - Spinner / 點點：沿用 StartScene 綠色系
 
-### 共用 Loading Overlay 行為規則
+### 行為規則
 
-- 共用 loading overlay 用於 API request 追蹤，不綁定單一場景。
-- 視覺樣式統一，但不應改動 StartScene 既有流程與場景內專用讀取動畫。
-- 任何後續調整共用 loading overlay 時，需確認其配色仍與 StartScene 維持同系風格。
+- 共用 loading overlay 用於 API request 追蹤，不綁定單一場景
+- 不應改動 `StartScene` 原本的專用載入動畫
+
+---
+
 ## 2026-04-15 Shop UI Update
 
 ### 超值禮包三層結構
@@ -274,21 +286,20 @@ BadgeOverlay.remove(button)
 
 ### 超值禮包資料來源
 
-- `shopOverview.categories`：上方主分類
-- `shopOverview.bundleGroups`：左側次級子選單群組
-- `shopOverview.bundles`：實際禮包卡片
+- `shopOverview.categories`
+- `shopOverview.bundleGroups`
+- `shopOverview.bundles`
 
 ### 超值禮包顯示規則
 
 - 左側次級子選單顯示禮包群組中文名稱
-- 點入群組後，右側可顯示同群組的多張禮包卡片
+- 點入群組後，右側顯示同群組多張禮包卡片
 - 每張卡片維持圖片、描述、價格、剩餘可購買次數與獎勵內容
 
 ### 衝撞幣規則
 
 - 衝撞幣是透過實體消費換得的付費消耗品
-- 衝撞幣可以購買超值禮包，也可延伸購買地下城券、鑽石等高價值消耗品
-- 鑽石商店內的鑽石消耗型商品，仍可維持獨立流程，不與衝撞幣禮包混用
+- 可購買超值禮包，也可延伸購買地下城券、鑽石等高價值消耗品
 - 商店頁上方資源列需同時顯示鑽石、衝撞幣、誘捕籠
-- 衝撞幣商品卡的主要按鈕文案使用 `NT33`、`NT170` 這類價格格式
+- 衝撞幣商品卡主要按鈕文案使用 `NT33`、`NT170` 這類價格格式
 - 點擊衝撞幣商品後，先跳出二次確認方框；目前確認後會直接發送衝撞幣，後續再接正式金流

--- a/docs/gdd/11_account.md
+++ b/docs/gdd/11_account.md
@@ -1,24 +1,104 @@
 # 帳號系統
 
 | 項目 | 說明 |
-|------|------|
+| --- | --- |
 | MVP 登入方式 | 帳號密碼登入 |
-| MVP 註冊方式 | 名稱 + 帳號 + 密碼 + 二次驗證密碼 |
+| MVP 註冊方式 | 暱稱 + 帳號 + 密碼 + 二次驗證密碼 |
 | 登入入口 | `StartScene` |
-| 驗證規則 | 帳號不可重複、密碼至少 8 碼、註冊時需再次輸入相同密碼 |
-| 註冊成功後 | 直接取得 access token / refresh token，視同已登入 |
+| 角色資料入口 | 首頁左上角頭像 / 名稱區塊，開啟 `ConfigScene` 設定中心 |
+| OAuth 狀態展示 | 設定中心顯示 Google / Apple 綁定狀態，但本期不做真正授權流程 |
+| 登出入口 | 目前仍保留在 `StartScene` 的 session 按鈕 |
 
 ## StartScene 流程
 
 1. 預設顯示帳號與密碼欄位。
 2. 畫面提供 `登入` 與 `註冊` 兩個按鈕。
 3. 按下 `登入` 時，前端呼叫 `/api/auth/login` 驗證帳號密碼。
-4. 按下 `註冊` 後切換成註冊模式，補顯示名稱與再次輸入密碼欄位。
+4. 按下 `註冊` 後切換成註冊模式，補顯示暱稱與再次輸入密碼欄位。
 5. 註冊模式送出時，前端呼叫 `/api/auth/register` 建立帳號。
-6. 成功後先保存 token 與 API base URL，接著呼叫 `/api/auth/bootstrap` 取得玩家核心資料。
-7. bootstrap 成功後，把登入 session 與玩家核心資料寫入 `user://` 本地存檔，再進入遊戲主流程。
+6. 成功後先保存 token 與 API base URL，接著呼叫 `/api/auth/bootstrap` 取得玩家啟動快照。
+7. bootstrap 成功後，`GameState.apply_player_bootstrap(...)` 會把登入 session、玩家資料、隊伍快取、商店 / 扭蛋 / 鏟屎官資料與設定中心需要的角色資料寫進 `user://`。
 8. Client 重啟時若本地仍有 session，會先嘗試自動恢復登入；若 access token 過期，會用 refresh token 更新後再重新抓 bootstrap。
-9. 玩家從 `ConfigScene` 登出時，Client 會優先呼叫 `/api/auth/revoke` 撤銷目前 refresh token；若 access token 已過期，會先 refresh 再 revoke，最後清除本地 `user://auth_session.json` 與玩家存檔。
+9. 玩家若從 `StartScene` 登出，Client 會優先呼叫 `/api/auth/revoke` 撤銷目前 refresh token；若 access token 已過期，會先 refresh 再 revoke，最後清除本機登入狀態與玩家快取。
+
+## Bootstrap / Settings Contract
+
+`GET /api/auth/bootstrap` 目前除了既有核心資料外，也會帶回設定中心首頁所需欄位：
+
+- `account`
+- `displayName`
+- `playerName`
+- `avatarId`
+- `bio`
+- `birthday`
+- `genderType`
+- `region`
+- `linkedProviders`
+- `playerPublicId`
+
+Client 行為：
+
+- 進入遊戲主流程後，首頁 HUD 直接使用 bootstrap 寫入的 `GameState.player_data`。
+- 開啟 `ConfigScene` 時，先用本地快取立即繪製，再額外呼叫 `GET /api/profile/me` 拉最新資料。
+- 玩家在設定中心按下儲存時，client 送 `PUT /api/profile/me`，成功後立即覆蓋 `GameState.player_data`，並刷新首頁左上角頭像與名稱。
+
+## 設定中心相關 API
+
+### `GET /api/profile/me`
+
+用途：
+
+- 取得最新角色資料與帳號綁定狀態。
+
+重要欄位：
+
+- `displayName`
+- `playerName`
+- `avatarId`
+- `bio`
+- `birthday`
+- `genderType`
+- `region`
+- `account`
+- `playerPublicId`
+- `linkedProviders`
+
+### `PUT /api/profile/me`
+
+用途：
+
+- 更新設定中心的角色資料。
+
+目前 client 會送出的欄位：
+
+- `displayName`
+- `playerName`
+- `avatarId`
+- `bio`
+- `birthday`
+- `genderType`
+- `region`
+
+### `POST /api/redeem-codes/redeem`
+
+用途：
+
+- 設定中心帳號區塊的兌換碼功能。
+
+成功後 client 會：
+
+- 套用 `walletSnapshot` 到 `GameState`
+- 清空輸入框
+- 顯示獎勵 Dialog
+- 額外顯示成功 Toast
+
+## OAuth 狀態展示規則
+
+- 設定中心只顯示 `Google` 與 `Apple` 兩張 provider 卡片。
+- 狀態來源是 `linkedProviders`，不是 client 端自行推測。
+- 若 provider 已存在於 `linkedProviders`，顯示 `已綁定`。
+- 若不存在，顯示 `即將開放`，按鈕保持 disabled。
+- 本期不做真正的 OAuth 授權、callback、token 換發與帳號綁定寫入。
 
 ## Runtime API 設定
 

--- a/docs/gdd/15_config_data_architecture.md
+++ b/docs/gdd/15_config_data_architecture.md
@@ -1,196 +1,271 @@
-# 15. Config Data Architecture
+# 15. Settings And Lineup Data Architecture
 
-> Last updated: 2026-04-13
+> Last updated: 2026-04-17
 
-本文件記錄 `ConfigScene` 改為後端 API 驅動後的資料來源、前端 draft 行為、送出流程，以及與主戰鬥 / 競技場的同步規則。
+本文記錄 2026-04 後 `ConfigScene` 拆分完成後的實際資料流：
+
+- `ConfigScene`：真正的設定中心
+- `LineupScene`：原本的編隊 / 延遲設定頁
+
+這份文件同時說明角色資料、帳號區塊、兌換碼、本機音量設定，以及舊編隊功能如何延續到 `LineupScene`。
 
 ---
 
 ## 1. Local Cache
 
-Bootstrap 會把 Config 相關資料寫入 `user://config/`，`ConfigScene` 開啟時先讀 `GameState` 已載入的快取資料：
+目前設定中心與編隊相關的本機檔案如下：
 
 | 路徑 | 內容 | 資料來源 |
 | --- | --- | --- |
 | `user://config/player_cats.json` | 玩家持有貓咪清單，包含 `playerCatId`、`catCatalogId`、`displayName`、`catFoodLevel`、`rank`、`isOwned` | `/api/auth/bootstrap` |
-| `user://config/teams.json` | 四種隊伍的最新已確認設定，包含 `teamType`、`members[]` | `/api/auth/bootstrap` 與 Config API 成功回應 |
+| `user://config/teams.json` | 已確認的四種隊伍設定，包含 `teamType`、`members[]` | `/api/auth/bootstrap` 與 `PUT /api/config/teams/{teamType}` |
+| `user://client_settings.json` | 本機音量與靜音設定 | `ClientSettings` singleton |
+
+`user://client_settings.json` 固定結構：
+
+```json
+{
+  "masterVolume": 1.0,
+  "bgmVolume": 0.72,
+  "sfxVolume": 0.9,
+  "masterMuted": false,
+  "bgmMuted": false,
+  "sfxMuted": false
+}
+```
 
 ---
 
-## 2. Runtime State
+## 2. Runtime State Ownership
 
-`GameState` 是 Config 相關資料的前端單一來源：
+### 2.1 `GameState`
+
+`GameState` 是設定中心與編隊相關資料的主要來源：
 
 | 欄位 / 方法 | 說明 |
 | --- | --- |
-| `player_cats_data: Array` | 玩家持有貓咪快取 |
-| `teams_data: Dictionary` | 隊伍快取，key 為 `Boss` / `Dungeon` / `ArenaAttack` / `ArenaDefense` |
-| `get_team(team_type)` | 取得指定隊伍資料 |
-| `get_config_owned_cats()` | 取得 `isOwned = true` 的貓咪 |
-| `update_player_teams(data)` | 更新隊伍快取並寫回 `user://config/teams.json` |
-| `apply_active_team_from_config(teamType)` | 依指定隊伍重建目前戰鬥使用的 `player_team` 與 `skill_delays` |
-| `player_team: Array` | 目前戰鬥場景會實際上場的 `playerCatId` 清單 |
+| `player_data.display_name` | 暱稱 |
+| `player_data.player_name` | 角色名稱 |
+| `player_data.avatar_id` | 設定中心選取的頭像 id |
+| `player_data.bio` | 自介 |
+| `player_data.birthday` | 生日字串 |
+| `player_data.gender_type` | 性別 enum 名稱字串 |
+| `player_data.region` | 地區 |
+| `player_data.linked_providers` | 已綁定 provider 名稱清單 |
+| `teams_data` | 已確認隊伍快取，key 為 `Boss` / `Dungeon` / `ArenaAttack` / `ArenaDefense` |
+| `get_team(team_type)` | 取得指定隊伍 |
+| `get_config_owned_cats()` | 取得 `isOwned = true` 的貓咪清單 |
+| `apply_profile_response(data)` | 套用 `profile/me` 回應並同步更新 `player_data` |
+| `apply_wallet_snapshot(data)` | 套用兌換碼成功後的最新錢包快照 |
+| `apply_active_team_from_config(teamType)` | 依指定隊伍重建目前戰鬥使用中的 `player_team` 與 `skill_delays` |
+| `player_profile_changed` | 設定中心儲存成功後發送，首頁 HUD 會跟著刷新 |
+| `player_wallet_changed` | 兌換碼發獎後發送，首頁資源列會跟著刷新 |
+
+### 2.2 `ClientSettings`
+
+`ClientSettings` 是獨立 singleton，專門管理本機音量設定：
+
+| 方法 | 說明 |
+| --- | --- |
+| `get_settings()` | 取得完整本機設定 |
+| `set_volume(busKey, value)` | 更新 `master` / `bgm` / `sfx` 音量 |
+| `set_muted(busKey, muted)` | 更新靜音狀態 |
+| `settings_changed` | 設定變更時發送 |
+
+`ClientSettings` 會在 `_ready()`：
+
+1. 讀取 `user://client_settings.json`
+2. 呼叫 `UiAudio.ensure_audio_buses()`
+3. 把設定套用到 `Master` / `BGM` / `SFX` bus
 
 ---
 
-## 3. ConfigScene Draft Flow
+## 3. ConfigScene Data Flow
 
-`ConfigScene` 不會在每次加入 / 移除 / 調整延遲時立刻送 API。
+### 3.1 Open Flow
 
-### 3.1 Draft State
+- 首頁 `BattleScene` 左上角頭像 / 名稱區塊可點擊，開啟 `ConfigScene` overlay。
+- `ConfigScene` 開啟後先用 `GameState.player_data` 組出本地快照，立即畫出表單內容。
+- 接著呼叫 `ApiClient.get_profile_me()` 對 `GET /api/profile/me` 做同步。
+- 若 API 失敗，畫面保留本地快取並用 Toast 提示「設定資料使用快取」。
 
-- 每個頁籤 `boss / dungeon / arena_attack / arena_defense` 都有自己的本地 draft。
-- 加入貓咪、移除貓咪、調整延遲，都只會先修改 draft 並標記 dirty。
-- 使用者按下 `套用隊伍變更` 時，才會把目前頁籤的 draft 整組送出。
+### 3.2 Profile Form
 
-### 3.2 Slot Behavior
+設定中心角色資料區塊包含：
 
-- draft 內的 `members` 會保留固定槽位概念。
-- 移除中間槽位時，不會讓後面的貓自動補位。
-- 新加入貓咪時，會優先補到第一個空槽。
-- `slotNo` 由前端明確傳給後端，前後端都以 `slotNo` 當成唯一槽位依據。
+- 預設頭像
+- 暱稱
+- 角色名稱
+- 自介
+- 生日
+- 性別
+- 地區
 
-### 3.3 Save Result
+Client 驗證規則：
 
-- API 成功回傳後，`ConfigScene._apply_team_update()` 會更新 `GameState.teams_data`。
-- `GameState._save_config_cache("teams", ...)` 會同步寫回 `user://config/teams.json`。
-- 若此次儲存的是 `Boss` 隊伍，會再同步更新目前首頁戰鬥用的 `player_team` 與 `skill_delays`。
+- `displayName` 不可空白
+- `playerName` 不可空白
+- `bio` 最多 140 字
+- `birthday` 若有填寫，格式需為 `YYYY-MM-DD`
 
----
+儲存流程：
 
-## 4. Config API
+1. 使用者編輯表單後會標記 `_profile_dirty = true`
+2. 按下 `儲存角色資料`
+3. `ApiClient.update_profile_me(payload)` 呼叫 `PUT /api/profile/me`
+4. 成功後 `GameState.apply_profile_response(profile)`
+5. `ConfigScene` 重新套用回傳資料並清掉 dirty state
+6. `BattleScene` 透過 `player_profile_changed` 立即刷新左上角頭像與名稱
 
-目前 `ConfigScene` 使用的隊伍 API 如下：
+### 3.3 Account / OAuth Section
 
-| 功能 | API | Client 呼叫 | 說明 |
-| --- | --- | --- | --- |
-| 取得所有隊伍 | `GET /api/config/teams` | `ApiClient.get_teams()` | 取得四種隊伍的最新已確認設定 |
-| 整組覆蓋隊伍 | `PUT /api/config/teams/{teamType}` | `ApiClient.replace_team(type, members)` | 以目前頁籤 draft 覆蓋 server 隊伍內容 |
+帳號資料區塊顯示：
 
-### 4.1 teamType Mapping
+- `account`
+- `playerPublicId`
+- `linkedProviders`
 
-| Scene key | Route value | Backend enum |
-| --- | --- | --- |
-| `boss` | `boss` | `Boss` |
-| `dungeon` | `dungeon` | `Dungeon` |
-| `arena_attack` | `arena_attack` | `ArenaAttack` |
-| `arena_defense` | `arena_defense` | `ArenaDefense` |
+目前 provider 卡片固定為：
 
-### 4.2 PUT Request Shape
+- `Google`
+- `Apple`
 
-```json
-{
-  "members": [
-    {
-      "slotNo": 0,
-      "playerCatId": 42,
-      "initialDelaySeconds": 0.0
-    },
-    {
-      "slotNo": 4,
-      "playerCatId": 99,
-      "initialDelaySeconds": 2.0
-    }
-  ]
-}
-```
+規則：
 
-### 4.3 Validation Rules
+- 若 provider 在 `linkedProviders` 內，顯示 `已綁定`
+- 否則顯示 `即將開放`
+- 按鈕維持 disabled，本期不啟動真正授權流程
 
-- 每隊最多 5 隻貓。
-- `slotNo` 必須介於 0 到 4，且同一隊內不可重複。
-- 同一隻貓不可在同一隊內重複出現。
-- 所有 `playerCatId` 必須屬於當前玩家且為 `isOwned = true`。
-- `initialDelaySeconds` 不可為負數。
-- 四種隊伍 `Boss / Dungeon / ArenaAttack / ArenaDefense` 都允許設定 `initialDelaySeconds`。
-- 前端可透過缺少某些 `slotNo` 來保留空槽，例如只送出 `slotNo = 0` 與 `slotNo = 4` 代表中間槽位留空。
+### 3.4 Redeem Code Flow
 
----
+設定中心帳號區塊內建兌換碼輸入：
 
-## 5. Bootstrap Response Shape
+1. 玩家輸入 code 後按下 `兌換`
+2. `ApiClient.redeem_code(code)` 呼叫 `POST /api/redeem-codes/redeem`
+3. 成功時取出 `walletSnapshot` 並呼叫 `GameState.apply_wallet_snapshot(...)`
+4. 顯示獎勵列表 Dialog
+5. 額外顯示成功 Toast
 
-`GET /api/auth/bootstrap` 會回傳 `playerTeams`：
+失敗時：
 
-```json
-{
-  "playerTeams": [
-    {
-      "teamType": "Boss",
-      "members": [
-        {
-          "slotNo": 0,
-          "playerCatId": 42,
-          "catCatalogId": 3,
-          "catDisplayName": "黑貓",
-          "catFoodLevel": 5,
-          "rank": 2,
-          "initialDelaySeconds": 0.0
-        }
-      ]
-    },
-    { "teamType": "Dungeon", "members": [] },
-    { "teamType": "ArenaAttack", "members": [] },
-    { "teamType": "ArenaDefense", "members": [] }
-  ]
-}
-```
+- 顯示錯誤 Toast
+- 不修改本地錢包
+
+### 3.5 Audio Settings Flow
+
+設定中心遊戲設定區塊目前只處理本機音量：
+
+- `總音量`
+- `背景音樂`
+- `音效`
+
+每列都包含：
+
+- slider
+- 百分比文字
+- 靜音 checkbox
+
+資料流：
+
+1. 開啟設定中心時，從 `ClientSettings.get_settings()` 讀值
+2. 調整 slider 時，呼叫 `ClientSettings.set_volume(busKey, value)`
+3. 切換靜音時，呼叫 `ClientSettings.set_muted(busKey, pressed)`
+4. `ClientSettings` 立即寫回 `user://client_settings.json`
+5. `UiAudio.apply_settings(...)` 立即更新 `Master` / `BGM` / `SFX`
 
 ---
 
-## 6. Runtime Sync Rules
+## 4. LineupScene Draft Flow
 
-- `GameState.apply_active_team_from_config(teamType)` 會依 `slotNo` 重建目前戰鬥要使用的 `player_team` 與 `skill_delays`。
-- Bootstrap / 本地快取載入完成後，首頁預設會套用 `Boss` 隊伍。
-- `ConfigScene` 儲存 `Boss` 隊伍後，若 `BattleScene` 仍常駐於 `HomeShellScene`，會直接呼叫 `BattleScene.restart_with_latest_team()`，不用等待勝負結算才重新讀隊伍。
-- `ConfigScene` 儲存 `ArenaAttack` / `ArenaDefense` 後，會更新快取，但不會主動重啟任何競技場戰鬥。
-- `ArenaScene` 進入競技場攻擊戰前，會優先套用 `ArenaAttack`；若未設定才 fallback 到 `Boss`。延遲也會一起透過 `GameState.apply_active_team_from_config(...)` 載入。
-- `ArenaDefense` 目前也允許設定並儲存延遲，但 client 端沒有單獨的本地防守戰鬥入口；它主要是提供後端與對戰流程使用的隊伍設定資料。
+舊版 `ConfigScene` 的隊伍設定功能已搬到 `LineupScene`。
+
+### 4.1 Current Tabs
+
+`LineupScene` 目前維持四種隊伍頁籤：
+
+- `boss`
+- `dungeon`
+- `arena_attack`
+- `arena_defense`
+
+### 4.2 Draft State
+
+- 每個頁籤都有自己的本地 draft。
+- 加入貓咪、移除貓咪、調整 `initialDelaySeconds`，都只會先改本地 draft。
+- 使用者按下儲存後，才會把當前頁籤送往 `PUT /api/config/teams/{teamType}`。
+
+### 4.3 Slot Rules
+
+- draft 以固定 `slotNo` 為主，不做自動壓縮。
+- 移除中間槽位時，後面成員不會自動前移。
+- 新加入的貓咪會補到第一個空槽。
+- `slotNo` 仍是前後端共同的正式站位欄位。
+
+### 4.4 Save Result
+
+- API 成功後，`LineupScene` 會更新 `GameState.teams_data` 與 `user://config/teams.json`。
+- 若儲存的是 `Boss` 隊伍，會同步 `GameState.apply_active_team_from_config("Boss")`。
+- 若首頁 `BattleScene` 仍掛在 `HomeShellScene` 底下，會直接重新套用最新主隊伍，讓首頁戰鬥立即反映新編隊。
 
 ---
 
-## 7. Related Files
+## 5. Related Files
 
 | 路徑 | 職責 |
 | --- | --- |
-| `MeowPartyDashClient/scripts/configs/ConfigScene.gd` | Config UI、draft 狀態、確認送出 |
-| `MeowPartyDashClient/scripts/ApiClient.gd` | `get_teams`、`replace_team` |
-| `MeowPartyDashClient/scripts/gamestate/GameState.gd` | Config 快取與當前戰鬥隊伍同步 |
-| `MeowPartyDashClient/scripts/battle/battle_scene.gd` | Boss 隊伍儲存後的首頁戰鬥重啟 |
-| `MeowPartyDashClient/scripts/arenaScene/ArenaScene.gd` | 競技場攻擊戰前套用有效隊伍 |
-| `MeowPartyDashAPI/Controllers/ConfigController.cs` | Config API 路由入口 |
-| `MeowPartyDashAPI/MeowPartyDashAPI.Application/Services/Config/ConfigService.cs` | 隊伍驗證、整組覆蓋、slot 保留 |
+| `MeowPartyDashClient/scripts/configs/ConfigScene.gd` | 設定中心 UI、角色資料、帳號區塊、兌換碼、本機音量 |
+| `MeowPartyDashClient/scripts/lineup/LineupScene.gd` | 編隊 UI、draft 狀態、隊伍儲存 |
+| `MeowPartyDashClient/scripts/lineup/LineupConstants.gd` | 編隊頁常數與 type mapping |
+| `MeowPartyDashClient/scripts/gamestate/GameState.gd` | 角色資料、錢包快照、隊伍快取、首頁同步 |
+| `MeowPartyDashClient/scripts/gamestate/ClientSettings.gd` | 本機音量設定存取與套用 |
+| `MeowPartyDashClient/scripts/ui/UiAudio.gd` | `Master` / `BGM` / `SFX` bus 與播放入口 |
+| `MeowPartyDashClient/scripts/ApiClient.gd` | `get_profile_me`、`update_profile_me`、`redeem_code`、`replace_team` |
+| `MeowPartyDashClient/scripts/battle/battle_scene.gd` | 左上角設定入口、首頁 HUD 即時刷新、BGM 播放 |
+| `MeowPartyDashAPI/Controllers/ProfileController.cs` | `GET/PUT /api/profile/me` |
+| `MeowPartyDashAPI/Controllers/RedeemCodesController.cs` | `POST /api/redeem-codes/redeem` |
+| `MeowPartyDashAPI/Controllers/ConfigController.cs` | `PUT /api/config/teams/{teamType}` |
 
 ---
 
-## 8. Sequence Summary
+## 6. Sequence Summary
 
 ```text
 Bootstrap
   -> /api/auth/bootstrap
   -> GameState.apply_player_bootstrap()
+  -> player_data now contains displayName / playerName / avatarId / bio / birthday / genderType / region / linkedProviders
   -> user://config/player_cats.json
   -> user://config/teams.json
-  -> GameState.apply_active_team_from_config("Boss")
+  -> Boss team applied to home battle
 
 ConfigScene open
-  -> read GameState.player_cats_data / teams_data
-  -> build per-tab draft from cached team
+  -> build from GameState.player_data local snapshot
+  -> GET /api/profile/me
+  -> GameState.apply_profile_response()
+  -> refresh form
 
-User edits team
-  -> local draft only
-  -> dirty state = true
+Profile save
+  -> validate local form
+  -> PUT /api/profile/me
+  -> GameState.apply_profile_response()
+  -> player_profile_changed
+  -> BattleScene refresh HUD
 
-User presses 套用隊伍變更
-  -> ApiClient.replace_team()
+Redeem code
+  -> POST /api/redeem-codes/redeem
+  -> GameState.apply_wallet_snapshot()
+  -> player_wallet_changed
+  -> reward dialog + success toast
+
+Audio change
+  -> ClientSettings.set_volume / set_muted
+  -> save user://client_settings.json
+  -> UiAudio.apply_settings()
+
+LineupScene save
+  -> edit local draft only
   -> PUT /api/config/teams/{teamType}
-  -> TeamResponse
   -> GameState.teams_data update
   -> save user://config/teams.json
-  -> if Boss: GameState.apply_active_team_from_config("Boss")
-  -> if BattleScene is mounted: BattleScene.restart_with_latest_team()
-
-ArenaScene challenge
-  -> resolve effective team type (ArenaAttack first, Boss fallback)
-  -> GameState.apply_active_team_from_config(teamType)
-  -> change_scene_to_file(ArenaBattleScene)
+  -> if Boss: apply_active_team_from_config("Boss")
 ```

--- a/docs/gdd/18_frontend_architecture.md
+++ b/docs/gdd/18_frontend_architecture.md
@@ -1,9 +1,9 @@
 # 18. Frontend Architecture
 
-> Last updated: 2026-04-11
+> Last updated: 2026-04-17
 > Audience: AI agents and engineers modifying `MeowPartyDashClient`
 
-This document describes the current frontend architecture of `MeowPartyDashClient` so an AI agent can quickly find the correct edit location, understand data flow, and avoid breaking existing project conventions.
+This document describes the current frontend architecture of `MeowPartyDashClient` so an agent can quickly find the correct edit location, understand data flow, and avoid reintroducing the old `ConfigScene = team config` assumption.
 
 ---
 
@@ -12,13 +12,11 @@ This document describes the current frontend architecture of `MeowPartyDashClien
 - Frontend project path: `MeowPartyDashClient/`
 - Engine: Godot 4.6
 - Primary language: GDScript
-- .NET project exists for Godot integration, but current gameplay/frontend logic is implemented in GDScript
 - Main entry scene: `res://scenes/StartScene.tscn`
 - Home shell scene: `res://scenes/HomeShellScene.tscn`
-- Theme resource: `res://resources/default_theme.tres`
 - Runtime viewport baseline: `720 x 1280`
 
-Important rule: most gameplay and UI surfaces are generated directly in GDScript at runtime instead of being heavily authored in `.tscn` files. In many cases, the `.tscn` file is only a root node plus a script attachment.
+Important rule: many UI surfaces are built directly in GDScript at runtime. A `.tscn` file is often only a root node plus a script attachment.
 
 ---
 
@@ -36,7 +34,8 @@ Defined in `project.godot`:
   - `ChatRealtimeClient = res://scripts/chat/ChatRealtimeClient.gd`
   - `SceneNavigator = res://scripts/navigation/SceneNavigator.gd`
   - `UiAudio = res://scripts/ui/UiAudio.gd`
-  - `ToastManager = res://scripts/ui/ToastManager.gd` — non-blocking toast notifications (success / error / hint)
+  - `ClientSettings = res://scripts/gamestate/ClientSettings.gd`
+  - `ToastManager = res://scripts/ui/ToastManager.gd`
 
 ### 2.2 Start Flow
 
@@ -46,12 +45,12 @@ Primary startup logic lives in:
 
 Responsibilities:
 
-- build the login/register/start UI in code
+- build the login / register / restore-session UI in code
 - resolve runtime API base URL from config files
 - load or create local device id
 - restore persisted auth session from `GameState`
 - run authenticated bootstrap if a valid session exists
-- transition into the main gameplay flow after login/bootstrap
+- transition into the home gameplay flow after login / bootstrap
 
 Project rule from `AGENTS.md`: preserve the established visual identity of `StartScene` unless the task explicitly requires changing it.
 
@@ -63,31 +62,30 @@ Project rule from `AGENTS.md`: preserve the established visual identity of `Star
 
 - `scenes/`
 
-Contains top-level scene entry files such as:
+Current important top-level scenes:
 
 - `StartScene.tscn`
 - `HomeShellScene.tscn`
 - `BattleScene.tscn`
+- `ConfigScene.tscn` — real settings center
+- `LineupScene.tscn` — team composition and delay setup
+- `EnhanceScene.tscn`
 - `ActivityScene.tscn`
 - `DungeonScene.tscn`
 - `ArenaScene.tscn`
 - `ArenaBattleScene.tscn`
-- `ConfigScene.tscn`
-- `EnhanceScene.tscn`
 - `GachaScene.tscn`
 - `ShopScene.tscn`
 - `ScooperScene.tscn`
 - `LevelScene.tscn`
 
-These usually serve as entry wrappers for a paired script.
-
 ### 3.2 Frontend Scripts
 
 - `scripts/`
 
-Main codebase for client behavior. Key subfolders:
+Main subfolders:
 
-- `scripts/gamestate/`: app-wide state, persistence, cache helpers
+- `scripts/gamestate/`: global state, persistence, cache helpers, `ClientSettings`
 - `scripts/battle/`: battle runtime, simulator, manager, battle scenes
 - `scripts/arenaScene/`: arena UI shell and helpers
 - `scripts/dungeon/`: dungeon UI split into shell, UI builder, and action handlers
@@ -95,12 +93,13 @@ Main codebase for client behavior. Key subfolders:
 - `scripts/gacha/`: gacha flow and result panel
 - `scripts/shop/`: shop menu and subviews
 - `scripts/scooper/`: scooper scene and per-tab logic
-- `scripts/configs/`: config/team setup scene
-- `scripts/data/`: frontend-side data models and data adapters
+- `scripts/configs/`: settings center scene
+- `scripts/lineup/`: team setup scene and lineup constants
+- `scripts/data/`: frontend-side data models and adapters
 - `scripts/cats/`: cat runtime classes and type-specific behavior
 - `scripts/managers/`: registries for cats and skills
 - `scripts/systems/`: local systems such as idle, arena rank, gacha, special ability
-- `scripts/ui/`: reusable UI helpers such as inertial scrolling
+- `scripts/ui/`: reusable UI helpers
 
 ### 3.3 Static Assets
 
@@ -108,9 +107,9 @@ Main codebase for client behavior. Key subfolders:
 
 Current structure:
 
-- `assets/fonts/`: fonts
-- `assets/audio/`: audio
-- `assets/sprites/ui/`: UI visuals, backgrounds, icons, poses
+- `assets/fonts/`
+- `assets/audio/`
+- `assets/sprites/ui/`
 
 ### 3.4 Static Data and Runtime Samples
 
@@ -118,39 +117,41 @@ Current structure:
 
 Current structure:
 
-- `data/default/`: static default config JSON
-- `data/default/cats/`: cat definitions in JSON
-- `data/default/skills/`: active/passive skill definitions in JSON
-- `data/arena/`: arena seed/test data
-- `data/saves/`: local sample or persisted save-oriented data inside repo
+- `data/default/`
+- `data/default/cats/`
+- `data/default/skills/`
+- `data/arena/`
+- `data/saves/`
 
 ### 3.5 Config and Docs
 
 - `config/`: runtime config templates
-- `docs/gdd/`: game and architecture documents for implementation reference
+- `docs/gdd/`: game and architecture documents
 
 ---
 
 ## 4. Architectural Layers
 
-The frontend is easiest to reason about as five layers:
+The frontend is easiest to reason about as six layers:
 
 1. Scene shell layer
-2. Feature UI/action helper layer
+2. Feature UI / action helper layer
 3. Service layer
-4. State and cache layer
-5. Static data layer
+4. Runtime state layer
+5. Local device settings layer
+6. Static data layer
 
 ### 4.1 Scene Shell Layer
 
 Representative files:
 
 - `scripts/StartScene.gd`
-- `scripts/ActivityScene.gd`
-- `scripts/LevelScene.gd`
+- `scripts/battle/battle_scene.gd`
+- `scripts/configs/ConfigScene.gd`
+- `scripts/lineup/LineupScene.gd`
+- `scripts/arenaScene/ArenaScene.gd`
 - `scripts/dungeon/DungeonScene.gd`
 - `scripts/enhance/EnhanceScene.gd`
-- `scripts/arenaScene/ArenaScene.gd`
 - `scripts/shop/ShopScene.gd`
 - `scripts/gacha/GachaScene.gd`
 
@@ -159,7 +160,7 @@ Typical responsibilities:
 - build top-level UI
 - wire button navigation
 - call feature actions
-- read already-loaded state from `GameState`
+- read shared state from `GameState`
 - trigger API refresh if needed
 
 ### 4.2 Feature Helper Layer
@@ -174,14 +175,12 @@ Examples:
 - `scripts/enhance/EnhanceSceneRefresh.gd`
 - `scripts/enhance/EnhanceSceneActions.gd`
 - `scripts/arenaScene/arena_scene_helpers.gd`
-- `scripts/arenaScene/arena_scene_reward_popup.gd`
 
 Pattern:
 
-- `Scene.gd` acts as the shell/controller
+- `Scene.gd` acts as the shell / controller
 - `*UI.gd` builds and refreshes UI
 - `*Actions.gd` performs API-triggered actions and handles result callbacks
-- helper files format labels, reward popups, or feature-specific transforms
 
 ### 4.3 Service Layer
 
@@ -191,51 +190,55 @@ Primary service:
 
 Responsibilities:
 
-- owns a small `HTTPRequest` pool
-- queues requests when all slots are busy
+- owns the HTTP request pool
 - applies bearer token headers
 - parses API envelopes
-- handles `401` by refreshing with refresh token and retrying
-- exposes feature-specific convenience methods instead of forcing scenes to build URLs manually
+- handles `401` by refreshing and retrying
+- exposes feature-specific methods such as:
+  - `get_profile_me(...)`
+  - `update_profile_me(...)`
+  - `redeem_code(...)`
+  - `replace_team(...)`
 
-The rest of the frontend should prefer calling `ApiClient` convenience methods, not constructing ad hoc HTTP logic in scene scripts.
+Scenes should prefer `ApiClient` convenience methods, not hand-built HTTP code.
 
-### 4.4 State and Cache Layer
+### 4.4 Runtime State Layer
 
 Primary state owner:
 
 - `scripts/gamestate/GameState.gd`
 
-Supporting helpers:
-
-- `scripts/gamestate/GameStateCacheIO.gd`
-- `scripts/gamestate/GameStateFileUtils.gd`
-- `scripts/gamestate/GameStateBossStage.gd`
-
 Responsibilities:
 
 - owns auth session and API base URL
 - applies bootstrap payloads
-- stores current player-facing state
+- stores player-facing runtime state
 - persists cache files under `user://`
 - exposes accessors used by scenes
-- keeps feature overviews in memory after API refresh
+- emits update signals when player profile or wallet changes
 
-### 4.5 Static Data Layer
+### 4.5 Local Device Settings Layer
+
+Primary owner:
+
+- `scripts/gamestate/ClientSettings.gd`
+
+Responsibilities:
+
+- loads and saves `user://client_settings.json`
+- manages `masterVolume`, `bgmVolume`, `sfxVolume`
+- manages `masterMuted`, `bgmMuted`, `sfxMuted`
+- applies changes through `UiAudio.apply_settings(...)`
+
+This data is device-local and intentionally does not go through backend persistence.
+
+### 4.6 Static Data Layer
 
 Primary static loader:
 
 - `scripts/data/static_game_data.gd`
 
-This layer provides local default configuration such as:
-
-- cat definitions
-- active/passive skill definitions
-- dungeon config
-- arena config
-- idle config
-
-Use this layer when data is part of shipped client defaults, not player-specific live state.
+Use this layer when data is shipped client defaults, not player-specific live state.
 
 ---
 
@@ -245,58 +248,56 @@ Use this layer when data is part of shipped client defaults, not player-specific
 
 `GameState` is the main source of truth for runtime state that must survive scene changes.
 
-Examples of state currently owned there:
+Examples:
 
 - auth session
 - `player_data`
+- player profile fields used by settings center
 - player cat and enhance data
-- team config data
+- confirmed team config data
 - dungeon overview
 - arena overview
 - gacha overview
 - shop overview
-- scooper catalog data
-- scooper live data
+- scooper catalog and live data
 
-If a feature needs to be read by multiple scenes or must survive scene transitions, it usually belongs in `GameState`.
+### 5.2 Device-Local Ownership
 
-### 5.2 Scene-Local Ownership
+`ClientSettings` owns values that should persist on the device but should not sync to backend.
 
-Scene-local transient state should stay in the scene script when it is only used for temporary UI behavior.
+Examples:
+
+- master volume
+- BGM volume
+- SFX volume
+- muted flags
+
+### 5.3 Scene-Local Ownership
+
+Keep transient widget state in the scene when only that screen needs it.
 
 Examples:
 
 - selected tab
-- currently expanded panel
-- draft edits before save
 - request-in-flight flags
-- cooldown timers
+- lineup draft edits
+- selected avatar card while form is dirty
 
-Do not put temporary widget state into `GameState` unless multiple scenes depend on it.
+Do not put one-screen-only widget state into `GameState` unless multiple scenes depend on it.
 
 ---
 
 ## 6. Data Sources and Persistence
 
-Frontend data comes from four places:
+Frontend data comes from five places:
 
-1. hardcoded/static config in script
+1. hardcoded / script defaults
 2. JSON files under `res://data/default/`
 3. API responses
-4. cached/persisted runtime files under `user://`
+4. cached runtime files under `user://`
+5. device-local settings under `user://client_settings.json`
 
-### 6.1 Static Config
-
-Loaded through `StaticGameData` and repo JSON/config files.
-
-Common sources:
-
-- `scripts/data/static_game_data.gd`
-- `data/default/*.json`
-- `data/default/cats/*.json`
-- `data/default/skills/**/*.json`
-
-### 6.2 Auth and Runtime Config
+### 6.1 Auth and Runtime Config
 
 Key files:
 
@@ -306,25 +307,23 @@ Key files:
   - `res://config/runtime_config.json`
   - `res://config/runtime_config.local.json`
 
-Rule: CI-generated runtime config and local override config are environment-specific. Do not hardcode production URLs into random scene scripts.
+### 6.2 Persistent `user://` Storage
 
-### 6.3 Persistent `user://` Storage
-
-Important persisted paths used by frontend architecture:
+Important paths:
 
 - `user://auth_session.json`
 - `user://device_id.txt`
 - `user://catalog/*.json`
-- `user://config/*.json`
+- `user://config/player_cats.json`
+- `user://config/teams.json`
 - `user://player_data/scooper/*.json`
+- `user://client_settings.json`
 
-Player-specific runtime persistence should flow through `PlayerData`, per-cat save files, and `GameState` cache files under `user://`. Arena and dungeon overview state should not read from repo-local save JSON.
+Project rule: persistent runtime data must use `user://`, not `res://`.
 
-Project rule: persistent local runtime data must use `user://`, not `res://`.
+### 6.3 API Envelope Shape
 
-### 6.4 API Envelope Shape
-
-`ApiClient.gd` expects JSON responses shaped like:
+`ApiClient.gd` expects:
 
 ```json
 {
@@ -334,7 +333,7 @@ Project rule: persistent local runtime data must use `user://`, not `res://`.
 }
 ```
 
-Scenes and action handlers should work with the `data` payload delivered by `ApiClient`, not raw HTTP body parsing.
+Scenes should work with the `data` payload delivered by `ApiClient`, not raw HTTP body parsing.
 
 ---
 
@@ -342,72 +341,85 @@ Scenes and action handlers should work with the `data` payload delivered by `Api
 
 ### 7.1 Bootstrap Flow
 
-Normal authenticated startup:
-
-1. `StartScene.gd` resolves API base URL and device/session state
+1. `StartScene.gd` resolves API base URL and device / session state
 2. auth succeeds or persisted session is restored
-3. bootstrap API returns player snapshot plus feature overviews/catalogs
+3. bootstrap API returns player snapshot plus feature overviews
 4. `GameState.apply_player_bootstrap(data)` writes runtime state
 5. `GameState` persists relevant cache files under `user://`
 6. later scenes read from `GameState` first and refresh from API only when needed
 
-### 7.2 Scene Refresh Flow
+Bootstrap now includes the startup copy of settings-center fields:
 
-Typical feature refresh path:
+- `displayName`
+- `playerName`
+- `avatarId`
+- `bio`
+- `birthday`
+- `genderType`
+- `region`
+- `linkedProviders`
 
-1. scene opens
-2. scene reads cached `GameState` state
-3. if state is missing or stale, scene calls `ApiClient`
-4. callback updates `GameState`
-5. scene rebuilds or refreshes UI from updated `GameState`
+### 7.2 Settings Center Flow
 
-This is the dominant frontend pattern.
+1. user clicks the top-left profile block in `BattleScene`
+2. `ConfigScene` opens and renders from local `GameState.player_data`
+3. `ConfigScene` calls `ApiClient.get_profile_me(...)`
+4. response flows through `GameState.apply_profile_response(...)`
+5. save uses `ApiClient.update_profile_me(...)`
+6. success emits `player_profile_changed` and refreshes the home HUD
 
-### 7.3 Mutating Action Flow
+### 7.3 Redeem Code Flow
 
-Typical action path:
+1. user enters a code in `ConfigScene`
+2. `ApiClient.redeem_code(...)` calls backend
+3. success returns `walletSnapshot` and `grantedRewards`
+4. `GameState.apply_wallet_snapshot(...)` updates resources
+5. `player_wallet_changed` refreshes the home resource UI
 
-1. user presses button
-2. scene or `*Actions.gd` calls `ApiClient`
-3. server returns updated overview or changed entities
-4. callback writes response into `GameState`
-5. UI refreshes from `GameState`
+### 7.4 Local Audio Settings Flow
 
-Do not manually patch many labels from raw response if the feature already has a `GameState.update_*()` path. Prefer updating shared state first, then re-rendering.
+1. `ClientSettings` loads `user://client_settings.json`
+2. `UiAudio.ensure_audio_buses()` guarantees `Master`, `BGM`, `SFX`
+3. slider / mute changes call `ClientSettings.set_volume(...)` or `set_muted(...)`
+4. `UiAudio.apply_settings(...)` applies changes immediately
+
+### 7.5 Lineup Save Flow
+
+1. `LineupScene` edits only local draft state
+2. save calls `ApiClient.replace_team(...)`
+3. response updates `GameState.teams_data`
+4. cache writes back to `user://config/teams.json`
+5. saving the `Boss` lineup re-applies the home battle team immediately
 
 ---
 
 ## 8. Navigation Map
 
-Current high-level navigation uses `HomeShellScene` for the main home loop, plus direct `get_tree().change_scene_to_file(...)` for dedicated flows.
-
-Common flow:
+Current high-level navigation:
 
 - `StartScene` -> `HomeShellScene`
 - `HomeShellScene` keeps `BattleScene` mounted in the background
+- `BattleScene` top-left profile block opens `ConfigScene`
 - `BattleScene` bottom nav opens home overlays through `SceneNavigator`:
   - `ScooperScene`
-  - `ConfigScene`
+  - `LineupScene`
   - `EnhanceScene`
   - `ActivityScene`
   - `ShopScene`
   - `MailScene`
-- `ActivityScene` can open `DungeonScene` and `ArenaScene` as deeper home overlays
-- `ShopScene` can open `GachaScene` as another home overlay
-- `ActivityScene` opens:
+- `ActivityScene` can open deeper activity routes such as:
   - `DungeonScene`
   - `ArenaScene`
+- `ShopScene` can open `GachaScene`
 - battle-specific routes also open:
   - `ArenaBattleScene`
   - `DungeonBattleScene`
 
-`SceneNavigator` coordinates the home overlays, while dedicated battle/activity routes still change scenes directly when leaving the home shell.
+`SceneNavigator` coordinates home overlays, while dedicated battle / activity routes still change scenes directly when leaving the home shell.
 
 ---
 
 ## 9. Feature Ownership Map
-
-Use this section to find the correct edit surface quickly.
 
 ### 9.1 Auth / Startup
 
@@ -416,75 +428,80 @@ Use this section to find the correct edit surface quickly.
 - `scripts/gamestate/GameState.gd`
 - `config/runtime_config*.json`
 
-### 9.2 Core Battle
+### 9.2 Core Battle / Home HUD
 
 - `scripts/battle/battle_scene.gd`
 - `scripts/battle/battle_manager.gd`
 - `scripts/battle/battle_simulator.gd`
-- `scripts/battle/battle_event.gd`
-- `scripts/cats/`
-- `scripts/systems/special_ability_system.gd`
+- `scripts/ui/asset_resolver.gd`
+- `scripts/ui/UiAudio.gd`
 
-Current behavior notes:
+Current notes:
 
 - `BattleScene` is the persistent home battle surface mounted under `HomeShellScene`.
-- `BattleScene.restart_with_latest_team()` is the public hook used when a Boss team save should immediately restart the home battle with the newest confirmed team and delay settings.
-- `BattleManager` must treat cached `CatNode` references defensively because the home battle can now restart while old nodes are being freed.
+- It now owns the top-left settings entry and home BGM playback.
+- It listens to `player_profile_changed` and `player_wallet_changed`.
 
-### 9.3 Team Config
+### 9.3 Settings Center
 
 - `scripts/configs/ConfigScene.gd`
-- `scripts/configs/ConfigConstants.gd`
+- `scripts/ApiClient.gd`
+- `scripts/gamestate/GameState.gd`
+- `scripts/gamestate/ClientSettings.gd`
+- `scripts/ui/UiAudio.gd`
+- related docs:
+  - `docs/gdd/08_ui.md`
+  - `docs/gdd/11_account.md`
+  - `docs/gdd/15_config_data_architecture.md`
+
+Current notes:
+
+- `ConfigScene` is now the real settings center.
+- It owns profile editing, account / linked-provider display, redeem code UI, and local audio settings.
+- OAuth is currently status-only: `Google` and `Apple` cards are visible but disabled when unbound.
+
+### 9.4 Team Lineup
+
+- `scripts/lineup/LineupScene.gd`
+- `scripts/lineup/LineupConstants.gd`
 - `scripts/gamestate/GameState.gd`
 - related doc: `docs/gdd/15_config_data_architecture.md`
 
-Current behavior notes:
+Current notes:
 
-- `ConfigScene` keeps a per-tab draft for `boss`, `dungeon`, `arena_attack`, and `arena_defense`.
-- Team members are slot-based. Removing a member leaves an empty slot instead of compacting later members forward.
-- All four team types now allow editing `initialDelaySeconds`.
-- Saving the Boss tab updates `GameState` and immediately restarts the mounted home `BattleScene`.
+- This is the old team-config feature moved out of `ConfigScene`.
+- It keeps per-tab draft state for `boss`, `dungeon`, `arena_attack`, and `arena_defense`.
+- Team members remain slot-based and are not compacted automatically.
 
-### 9.4 Enhance
+### 9.5 Enhance
 
 - `scripts/enhance/EnhanceScene.gd`
 - `scripts/enhance/EnhanceSceneUI.gd`
 - `scripts/enhance/EnhanceSceneRefresh.gd`
 - `scripts/enhance/EnhanceSceneActions.gd`
 
-### 9.5 Dungeon
+### 9.6 Dungeon
 
 - `scripts/dungeon/DungeonScene.gd`
 - `scripts/dungeon/DungeonSceneUI.gd`
 - `scripts/dungeon/DungeonSceneActions.gd`
 - `scripts/gamestate/GameState.gd`
-- related doc: `docs/gdd/16_dungeon_data_architecture.md`
 
-### 9.6 Arena
+### 9.7 Arena
 
 - `scripts/arenaScene/ArenaScene.gd`
 - `scripts/arenaScene/arena_scene_helpers.gd`
-- `scripts/arenaScene/arena_scene_reward_popup.gd`
 - `scripts/battle/arena_battle_scene.gd`
 - `scripts/gamestate/GameState.gd`
-- related doc: `docs/gdd/17_arena_data_architecture.md`
 
-Current behavior notes:
-
-- Arena overview still comes from `/api/arena`, not from bootstrap.
-- Arena attack battle startup resolves an effective team type in this order: `ArenaAttack`, then `Boss` fallback.
-- Before opening `ArenaBattleScene`, `ArenaScene` applies the chosen confirmed team through `GameState.apply_active_team_from_config(...)` so arena attacks use the saved delay settings.
-- `ArenaDefense` delay is stored through the Config/API contract even though the client does not currently have a local defense battle entrypoint.
-
-### 9.7 Scooper
+### 9.8 Scooper
 
 - `scripts/ScooperScene.gd`
 - `scripts/scooper/`
 - `scripts/ApiClient.gd`
 - `scripts/gamestate/GameState.gd`
-- related doc: `docs/gdd/14_scooper_data_architecture.md`
 
-### 9.8 Gacha / Shop
+### 9.9 Gacha / Shop
 
 - `scripts/gacha/GachaScene.gd`
 - `scripts/gacha/GachaResultPanel.gd`
@@ -497,66 +514,45 @@ Current behavior notes:
 
 ## 10. Current Frontend Conventions
 
-These conventions are important when AI agents make changes.
-
 ### 10.1 Build UI in Script First
 
-Many screens are code-built. Before assuming a `.tscn` contains the UI tree, inspect the paired `.gd` file.
+Before assuming a `.tscn` contains the UI tree, inspect the paired `.gd` file.
 
-### 10.2 Prefer Small Feature Splits
+### 10.2 Prefer Existing Scene Boundaries
 
-When a screen becomes large, the existing pattern is to split into:
-
-- shell scene script
-- UI builder helpers
-- refresh helpers
-- action handlers
-
-Prefer following that pattern instead of introducing a new architecture style for one screen only.
-
-### 10.3 Use Autoloads for Shared Services
-
-Common shared dependencies should go through:
-
-- `GameState` — runtime state and persistence
-- `ApiClient` — all HTTP requests
-- `DialogManager` — blocking dialogs (info and confirm)
-- `ToastManager` — non-blocking ephemeral notifications
-- `UiAudio` — button click and UI sounds
-
-Do not create duplicate global state containers for the same concern.
-
-### 10.7 UI Component Rules
-
-All UI styling must use the shared helpers. Do not re-implement them inline.
-
-**Buttons** — always call `UiPalette.apply_button_kind(button, kind)`. Accepted kinds: `confirm`, `cancel`, `neutral`, `info`, `destruct`, `remove`, `add` (semantic aliases) or their color equivalents `primary`, `secondary`, `rank`, `danger`, `minus`, `plus`.
-
-**Panels and cards** — always call `OverlaySceneChrome.make_panel_style(...)` or `OverlaySceneChrome.make_card_panel(...)`. Do not define a local `_make_panel_style()` function.
-
-**Non-blocking feedback** — use `ToastManager.success/error/hint(message)`. Reserve `DialogManager` for cases where the player must actively choose or acknowledge before continuing.
-
-**Rarity colors** — use `GameConstants.get_rarity_color_from_string(rarity_type)` or `GameConstants.get_rarity_color(GameConstants.Rarity.LEGENDARY)`. Do not hardcode rarity colors inline.
-
-Full usage rules and situation guides: `docs/gdd/08_ui.md` and `docs/ui_component_spec.md`.
-
-### 10.4 Persist Through `GameState`
-
-If API data needs to survive scene changes, add or update a `GameState.update_*()` style path and persist via `GameStateCacheIO` if applicable.
-
-### 10.5 Keep Feature-Specific State Local
-
-Do not pollute `GameState` with one-screen-only toggles, scroll positions, or draft widget flags.
-
-### 10.6 Respect Existing Scene Boundaries
+Follow the project’s current splits instead of inventing a new pattern for one feature.
 
 Examples:
 
-- `EnhanceScene` is already split into UI, refresh, and actions
-- `DungeonScene` is already split into UI and actions
-- `ArenaScene` keeps helper formatting in a separate helper file
+- `ConfigScene` owns settings-center logic
+- `LineupScene` owns lineup draft logic
+- `EnhanceScene` is already split into UI / refresh / actions
+- `DungeonScene` is already split into UI / actions
 
-Extend the existing boundary before inventing another one.
+### 10.3 Use Autoloads For Shared Services
+
+Shared dependencies should go through:
+
+- `GameState`
+- `ApiClient`
+- `DialogManager`
+- `ToastManager`
+- `UiAudio`
+- `ClientSettings`
+
+### 10.4 Persist Through Shared Owners
+
+- API-backed cross-scene state -> `GameState`
+- device-local audio settings -> `ClientSettings`
+
+### 10.5 UI Component Rules
+
+Do not re-implement shared UI styling inline.
+
+- Buttons -> `UiPalette.apply_button_kind(...)`
+- Panels / cards -> `OverlaySceneChrome.make_panel_style(...)` or `make_card_panel(...)`
+- Non-blocking feedback -> `ToastManager`
+- Blocking choices / acknowledgements -> `DialogManager`
 
 ---
 
@@ -567,45 +563,44 @@ Extend the existing boundary before inventing another one.
 Check in this order:
 
 1. scene shell file
-2. related `*Actions.gd` or helper file
+2. related helper / action file
 3. `ApiClient.gd`
-4. `GameState.gd`
-5. related `docs/gdd/*_architecture.md`
+4. `GameState.gd` or `ClientSettings.gd`
+5. related `docs/gdd/*.md`
 
 ### 11.2 If You Need To Add A New Persisted API Feature
 
 Expected work usually includes:
 
 1. add `ApiClient` convenience method
-2. add `GameState` state fields and update method
-3. add cache save/load if the data should persist locally
-4. update scene/action files to read from `GameState`
-5. update architecture docs if the data flow becomes durable
+2. add `GameState` update method and state fields
+3. add cache save / load if needed
+4. update the scene to read from shared state
+5. update architecture docs
 
-### 11.3 If You Need To Change Visual Layout
+### 11.3 If You Need To Add A New Device-Local Setting
 
-Check whether the screen is:
+Expected work usually includes:
 
-- mostly code-built in `.gd`
-- partially composed from helper files
-- constrained by an existing visual identity such as `StartScene`
-
-### 11.4 If You Need To Change Navigation
-
-Search for `change_scene_to_file` in the related scene scripts. Navigation is decentralized.
+1. add key to `ClientSettings.DEFAULT_SETTINGS`
+2. normalize / save / load it in `ClientSettings`
+3. apply it through the relevant runtime subsystem
+4. expose it in the correct settings-center section
+5. update docs
 
 ---
 
 ## 12. Paths AI Should Inspect First
 
-When an AI agent needs orientation, inspect these files first:
+When orientation is needed, inspect these files first:
 
 - `project.godot`
 - `AGENTS.md`
 - `scripts/StartScene.gd`
 - `scripts/ApiClient.gd`
 - `scripts/gamestate/GameState.gd`
-- `scripts/gamestate/GameStateCacheIO.gd`
+- `scripts/gamestate/ClientSettings.gd`
+- `scripts/ui/UiAudio.gd`
 - `scripts/data/static_game_data.gd`
 
 Then inspect the feature-specific scene and helper folder.
@@ -616,20 +611,21 @@ Then inspect the feature-specific scene and helper folder.
 
 - Do not assume `.tscn` files fully describe the UI
 - Do not store persistent runtime data in `res://`
-- Do not bypass `ApiClient` with random per-scene HTTP implementations unless there is a strong architectural reason
-- Do not duplicate global state that already belongs to `GameState`
+- Do not bypass `ApiClient` with ad hoc per-scene HTTP code
+- Do not duplicate state already owned by `GameState` or `ClientSettings`
+- Do not reintroduce the old assumption that `ConfigScene` means team setup
 - Do not rewrite `StartScene` visual identity unless explicitly requested
-- Do not move frontend logic into C# unless the task explicitly requires changing the technology boundary
 
 ---
 
 ## 14. Related Documents
 
-- `docs/gdd/08_ui.md` — UI component usage rules and situation guides
-- `docs/ui_component_spec.md` — code-level API reference for all UI helpers
+- `docs/gdd/08_ui.md`
+- `docs/gdd/11_account.md`
 - `docs/gdd/14_scooper_data_architecture.md`
 - `docs/gdd/15_config_data_architecture.md`
 - `docs/gdd/16_dungeon_data_architecture.md`
 - `docs/gdd/17_arena_data_architecture.md`
+- `docs/ui_component_spec.md`
 
-This document should be updated whenever the client introduces a new durable frontend subsystem, a new global singleton, or a materially different data flow pattern.
+Update this document whenever the client introduces a new durable subsystem, a new singleton, or a materially different data flow pattern.

--- a/project.godot
+++ b/project.godot
@@ -24,6 +24,7 @@ ApiClient="*res://scripts/ApiClient.gd"
 ChatRealtimeClient="*res://scripts/chat/ChatRealtimeClient.gd"
 SceneNavigator="*res://scripts/navigation/SceneNavigator.gd"
 UiAudio="*res://scripts/ui/UiAudio.gd"
+ClientSettings="*res://scripts/gamestate/ClientSettings.gd"
 ToastManager="*res://scripts/ui/ToastManager.gd"
 
 [display]

--- a/scenes/LineupScene.tscn
+++ b/scenes/LineupScene.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/lineup/LineupScene.gd" id="1"]
+
+[node name="LineupScene" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource("1")

--- a/scripts/ApiClient.gd
+++ b/scripts/ApiClient.gd
@@ -144,6 +144,18 @@ func get_authenticated_bootstrap(callback: Callable) -> void:
 	_api_get("auth/bootstrap", callback)
 
 
+func get_profile_me(callback: Callable) -> void:
+	_api_get("profile/me", callback)
+
+
+func update_profile_me(payload: Dictionary, callback: Callable) -> void:
+	_api_put("profile/me", payload, callback)
+
+
+func redeem_code(code: String, callback: Callable) -> void:
+	_api_post("redeem-codes/redeem", {"code": code}, callback)
+
+
 func get_mail_summary(callback: Callable) -> void:
 	_api_get("mail/summary", callback)
 

--- a/scripts/battle/battle_manager.gd
+++ b/scripts/battle/battle_manager.gd
@@ -263,13 +263,7 @@ func _play_audio_sfx(stream: AudioStream, volume_db: float, pitch_scale: float) 
 		return
 	if not _should_play_battle_audio():
 		return
-	var player: AudioStreamPlayer = AudioStreamPlayer.new()
-	player.stream = stream
-	player.volume_db = volume_db
-	player.pitch_scale = pitch_scale
-	add_child(player)
-	player.finished.connect(player.queue_free)
-	player.play()
+	UiAudio.play_sfx(stream, volume_db, pitch_scale)
 
 
 func _should_play_battle_audio() -> bool:

--- a/scripts/battle/battle_scene.gd
+++ b/scripts/battle/battle_scene.gd
@@ -10,6 +10,7 @@ const RESOURCE_GOLD_TEXTURE := preload("res://assets/sprites/ui/rewards/gold.png
 const RESOURCE_DIAMOND_TEXTURE := preload("res://assets/sprites/ui/rewards/diamonds.png")
 const RESOURCE_POOP_TEXTURE := preload("res://assets/sprites/ui/rewards/poop_count.png")
 const PROFILE_AVATAR_TEXTURE := preload("res://assets/sprites/ui/character_refs/black_cat/black_cat_icon_v1.png")
+const HOME_BGM_STREAM := preload("res://assets/audio/sfx/ui/mainmenu_scene.mp3")
 const REWARD_DEFAULT_SFX := preload("res://assets/audio/sfx/rewards/ui_reward_float_default.mp3")
 const REWARD_SFX_BY_KEY := {
 	"gold": preload("res://assets/audio/sfx/rewards/reward_gold.mp3"),
@@ -157,7 +158,14 @@ var _free_speed_boost_used: bool = false
 
 func _ready() -> void:
 	add_to_group("battle_scene")
+	GameState.player_profile_changed.connect(func() -> void:
+		_refresh_ui()
+	)
+	GameState.player_wallet_changed.connect(func() -> void:
+		_refresh_ui()
+	)
 	_build_scene()
+	UiAudio.play_bgm(HOME_BGM_STREAM)
 	_start_battle()
 	# Update the idle button text every second.
 	var sandbox_timer := Timer.new()
@@ -265,11 +273,22 @@ func _build_ui() -> void:
 	_ui_layer.add_child(top_bar_root)
 
 	_top_avatar_rect = top_bar_root.get_node("Avatar") as TextureRect
-	_top_avatar_rect.texture = PROFILE_AVATAR_TEXTURE
+	_top_avatar_rect.texture = AssetResolver.resolve_profile_avatar(GameState.get_profile_avatar_id())
+	if _top_avatar_rect.texture == null:
+		_top_avatar_rect.texture = PROFILE_AVATAR_TEXTURE
 	var avatar_circle_material := ShaderMaterial.new()
 	avatar_circle_material.shader = Shader.new()
 	avatar_circle_material.shader.code = "shader_type canvas_item;\nvoid fragment(){\n\tvec2 uv = UV - vec2(0.5);\n\tif (length(uv) > 0.5) {\n\t\tdiscard;\n\t}\n\tCOLOR = texture(TEXTURE, UV) * COLOR;\n}\n"
 	_top_avatar_rect.material = avatar_circle_material
+	var profile_entry_button := Button.new()
+	profile_entry_button.flat = true
+	profile_entry_button.focus_mode = Control.FOCUS_NONE
+	profile_entry_button.position = Vector2(0.0, 14.0)
+	profile_entry_button.size = Vector2(180.0, 170.0)
+	profile_entry_button.modulate = Color(1.0, 1.0, 1.0, 0.01)
+	profile_entry_button.pressed.connect(UiAudio.play_ui_click)
+	profile_entry_button.pressed.connect(_open_settings_scene)
+	top_bar_root.add_child(profile_entry_button)
 	_profile_name_label = top_bar_root.get_node("NameLabel") as Label
 	_profile_level_label = top_bar_root.get_node("LevelLabel") as Label
 	_top_exp_bar = top_bar_root.get_node("TopExpBar") as ProgressBar
@@ -533,7 +552,7 @@ func _build_ui() -> void:
 
 	var nav_items: Array = [
 		[UiText.NAV_SCOOPER, "res://scenes/ScooperScene.tscn", _on_nav_scooper],
-		[UiText.NAV_CONFIG, "res://scenes/ConfigScene.tscn", _on_nav_config],
+		[UiText.NAV_CONFIG, "res://scenes/LineupScene.tscn", _on_nav_config],
 		[UiText.NAV_ENHANCE, "res://scenes/EnhanceScene.tscn", _on_nav_enhance],
 		[UiText.NAV_ACTIVITY, "res://scenes/ActivityScene.tscn", _on_nav_activity],
 		[UiText.NAV_SHOP, "res://scenes/ShopScene.tscn", _on_nav_shop],
@@ -1064,11 +1083,7 @@ func _play_reward_float_sfx(reward_key: String) -> void:
 	var stream: AudioStream = REWARD_SFX_BY_KEY.get(reward_key, REWARD_DEFAULT_SFX)
 	if stream == null:
 		return
-	var player := AudioStreamPlayer.new()
-	player.stream = stream
-	add_child(player)
-	player.finished.connect(player.queue_free)
-	player.play()
+	UiAudio.play_sfx(stream)
 
 
 func _set_speed(mult: float, active_btn: Button) -> void:
@@ -1172,14 +1187,12 @@ func _refresh_ui() -> void:
 	if _stage_task_label != null:
 		_stage_task_label.text = UiText.HOME_DAILY_TASK
 	if _profile_name_label != null:
-		var profile_name := GameState.player_data.display_name.strip_edges()
-		if profile_name.is_empty():
-			profile_name = GameState.player_data.player_name.strip_edges()
-		if profile_name.is_empty():
-			profile_name = "Scooper"
-		_profile_name_label.text = profile_name
+		_profile_name_label.text = GameState.get_profile_display_name()
 	if _profile_level_label != null:
 		_profile_level_label.text = str(GameState.player_data.scooper_level)
+	if _top_avatar_rect != null:
+		var avatar_texture: Texture2D = AssetResolver.resolve_profile_avatar(GameState.get_profile_avatar_id())
+		_top_avatar_rect.texture = avatar_texture if avatar_texture != null else PROFILE_AVATAR_TEXTURE
 	if _top_exp_bar != null and _top_progress_value_label != null:
 		var top_profile: Dictionary = GameState.scooper_profile_data
 		var top_level: int
@@ -1768,6 +1781,10 @@ func _show_sandbox_dialog() -> void:
 
 
 func _on_nav_config() -> void:
+	_toggle_overlay_scene("res://scenes/LineupScene.tscn")
+
+
+func _open_settings_scene() -> void:
 	_toggle_overlay_scene("res://scenes/ConfigScene.tscn")
 
 

--- a/scripts/configs/ConfigScene.gd
+++ b/scripts/configs/ConfigScene.gd
@@ -1,890 +1,746 @@
 extends Control
 
-const Constants = preload("res://scripts/configs/ConfigConstants.gd")
 const AssetResolver = preload("res://scripts/ui/asset_resolver.gd")
-const SceneSubmenuBar = preload("res://scripts/ui/scene_submenu_bar.gd")
-const CatRosterCard = preload("res://scripts/ui/cat_roster_card.gd")
 
-const DANGER_BUTTON_COLOR := Color(0.94, 0.48, 0.42, 1.0)
 const MUTED_TEXT_COLOR := Color(0.90, 0.88, 0.82, 0.92)
-const DISABLED_TEXT_COLOR := Color(0.70, 0.70, 0.72, 0.92)
-const EMPTY_SLOT_TEXT_COLOR := Color(0.75, 0.70, 0.62, 0.9)
-const SLOT_IMAGE_BG := Color(0.24, 0.20, 0.16, 0.96)
-const SLOT_IMAGE_BORDER := Color(0.98, 0.84, 0.54, 0.95)
-const SLOT_DELAY_BG := Color(0.18, 0.12, 0.08, 0.94)
-const SLOT_HOLD_SECONDS := 0.4
-const SLOT_EMPTY_FILL := Color(0.20, 0.18, 0.16, 0.88)
-const SLOT_EMPTY_BORDER := Color(0.62, 0.54, 0.40, 0.78)
-const SLOT_NAME_COLOR := Color(0.98, 0.95, 0.88, 1.0)
-const SLOT_META_COLOR := Color(0.88, 0.80, 0.67, 0.92)
-const SLOT_REMOVE_BG := Color(0.56, 0.18, 0.18, 0.96)
-const CAT_CARD_HOLD_SECONDS := 2.0
+const SECTION_HINT_COLOR := Color(0.84, 0.80, 0.72, 0.88)
+const FIELD_BG := Color(0.14, 0.12, 0.11, 0.98)
+const FIELD_BORDER := Color(0.42, 0.36, 0.26, 0.96)
+const SELECTED_BORDER := Color(0.92, 0.79, 0.44, 1.0)
+const UNSELECTED_BORDER := Color(0.42, 0.36, 0.26, 0.96)
+const GENDER_OPTIONS := [
+	{"label": "未指定", "value": "Unspecified"},
+	{"label": "男性", "value": "Male"},
+	{"label": "女性", "value": "Female"},
+	{"label": "非二元", "value": "NonBinary"},
+	{"label": "不透露", "value": "PreferNotToSay"},
+]
 
-var _current_team_type: String = "boss"
-var _api_in_flight: bool = false
+var _profile_dirty: bool = false
+var _profile_loading: bool = false
+var _profile_saving: bool = false
+var _redeem_in_flight: bool = false
+var _applying_profile_form: bool = false
+var _selected_avatar_id: String = AssetResolver.DEFAULT_PROFILE_AVATAR_ID
 
-var _team_type_btns: Dictionary = {}
-var _page_title: Label
-var _team_summary_label: Label
-var _team_container: GridContainer
-var _cats_title: Label
-var _cats_sort_btns: Dictionary = {}
-var _cats_scroll: ScrollContainer
-var _cats_container: GridContainer
-var _save_team_btn: Button
-var _cats_scroller: InertialScroller
-
-var _team_drafts: Dictionary = {}
-var _team_dirty: Dictionary = {}
-var _cats_sort_mode: String = "level"
+var _avatar_preview: TextureRect
+var _avatar_name_label: Label
+var _avatar_buttons: Dictionary = {}
+var _display_name_input: LineEdit
+var _player_name_input: LineEdit
+var _bio_input: TextEdit
+var _birthday_input: LineEdit
+var _gender_option: OptionButton
+var _region_input: LineEdit
+var _save_profile_button: Button
+var _save_profile_hint_label: Label
+var _account_value_label: LineEdit
+var _player_uid_value_label: LineEdit
+var _provider_status_labels: Dictionary = {}
+var _redeem_input: LineEdit
+var _redeem_button: Button
+var _audio_value_labels: Dictionary = {}
+var _audio_sliders: Dictionary = {}
+var _audio_mute_boxes: Dictionary = {}
 
 
 func _ready() -> void:
 	_build_ui()
+	_apply_profile_data(_build_local_profile_snapshot())
+	_apply_audio_settings()
+	_load_profile_from_api()
 
 
 func _build_ui() -> void:
-	var bg: Control = AssetResolver.make_fullscreen_background("config")
-	add_child(bg)
-
-	var dim: ColorRect = ColorRect.new()
-	dim.color = Color(0.04, 0.03, 0.05, 0.34)
-	dim.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	add_child(dim)
-
-	var content_panel: PanelContainer = PanelContainer.new()
-	content_panel.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	content_panel.offset_left = 20.0
-	content_panel.offset_top = OverlaySceneChrome.CONTENT_TOP_GAP
-	content_panel.offset_right = -20.0
-	content_panel.offset_bottom = -(OverlaySceneChrome.HOME_MAIN_NAV_H + OverlaySceneChrome.BOTTOM_DOCK_H + 12.0)
-	content_panel.add_theme_stylebox_override("panel", OverlaySceneChrome.make_panel_style(OverlaySceneChrome.PANEL_FILL, OverlaySceneChrome.PANEL_BORDER, 18))
-	add_child(content_panel)
-
-	var content_margin: MarginContainer = OverlaySceneChrome.make_content_margin(18)
-	content_panel.add_child(content_margin)
-
-	var content_vbox: VBoxContainer = VBoxContainer.new()
-	content_vbox.add_theme_constant_override("separation", 14)
-	content_margin.add_child(content_vbox)
-
-	_page_title = Label.new()
-	_page_title.text = UiText.CONFIG_PAGE_TITLE
-	_page_title.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_DISPLAY)
-	content_vbox.add_child(_page_title)
-
-	var page_desc: Label = Label.new()
-	page_desc.text = UiText.CONFIG_PAGE_DESC
-	page_desc.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	page_desc.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY)
-	page_desc.add_theme_color_override("font_color", MUTED_TEXT_COLOR)
-	content_vbox.add_child(page_desc)
-
-	var main_split: VBoxContainer = VBoxContainer.new()
-	main_split.add_theme_constant_override("separation", 12)
-	main_split.size_flags_vertical = Control.SIZE_EXPAND_FILL
-	content_vbox.add_child(main_split)
-
-	var team_panel: PanelContainer = OverlaySceneChrome.make_card_panel()
-	team_panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	team_panel.size_flags_vertical = 0
-	main_split.add_child(team_panel)
-
-	var team_margin: MarginContainer = OverlaySceneChrome.make_content_margin(14)
-	team_panel.add_child(team_margin)
-
-	var team_vbox: VBoxContainer = VBoxContainer.new()
-	team_vbox.add_theme_constant_override("separation", 10)
-	team_vbox.size_flags_vertical = 0
-	team_margin.add_child(team_vbox)
-
-	_team_summary_label = Label.new()
-	_team_summary_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	_team_summary_label.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
-	_team_summary_label.add_theme_color_override("font_color", MUTED_TEXT_COLOR)
-	_team_summary_label.visible = false
-	team_vbox.add_child(_team_summary_label)
-
-	_team_container = GridContainer.new()
-	_team_container.columns = 5
-	_team_container.add_theme_constant_override("separation", 6)
-	_team_container.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	_team_container.size_flags_vertical = 0
-	team_vbox.add_child(_team_container)
-
-	_save_team_btn = Button.new()
-	_save_team_btn.text = UiText.CONFIG_SAVE_BUTTON
-	_save_team_btn.custom_minimum_size = Vector2(0.0, 52.0)
-	_save_team_btn.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY_LG)
-	_save_team_btn.pressed.connect(_on_save_team_pressed)
-	UiPalette.apply_button_kind(_save_team_btn, "confirm")
-	team_vbox.add_child(_save_team_btn)
-
-	var cats_panel: PanelContainer = OverlaySceneChrome.make_card_panel()
-	cats_panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	cats_panel.size_flags_vertical = Control.SIZE_EXPAND_FILL
-	cats_panel.size_flags_stretch_ratio = 1.05
-	main_split.add_child(cats_panel)
-
-	var cats_margin: MarginContainer = OverlaySceneChrome.make_content_margin(14)
-	cats_panel.add_child(cats_margin)
-
-	var cats_vbox: VBoxContainer = VBoxContainer.new()
-	cats_vbox.add_theme_constant_override("separation", 10)
-	cats_margin.add_child(cats_vbox)
-
-	var cats_header: HBoxContainer = HBoxContainer.new()
-	cats_header.add_theme_constant_override("separation", 8)
-	cats_vbox.add_child(cats_header)
-
-	_cats_title = Label.new()
-	_cats_title.text = UiText.CONFIG_OWNED_CATS_TITLE
-	_cats_title.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_HEADING)
-	_cats_title.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	cats_header.add_child(_cats_title)
-
-	var sort_row: HBoxContainer = HBoxContainer.new()
-	sort_row.add_theme_constant_override("separation", 6)
-	cats_header.add_child(sort_row)
-
-	for sort_key: String in ["level", "rank"]:
-		var sort_btn: Button = Button.new()
-		sort_btn.text = UiText.CONFIG_SORT_LEVEL if sort_key == "level" else UiText.CONFIG_SORT_RANK
-		sort_btn.custom_minimum_size = Vector2(64.0, 28.0)
-		sort_btn.add_theme_font_size_override("font_size", 13)
-		sort_btn.pressed.connect(func() -> void:
-			_set_cats_sort_mode(sort_key)
-		)
-		sort_row.add_child(sort_btn)
-		_cats_sort_btns[sort_key] = sort_btn
-
-	_cats_scroll = ScrollContainer.new()
-	_cats_scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
-	_cats_scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
-	cats_vbox.add_child(_cats_scroll)
-
-	_cats_container = GridContainer.new()
-	_cats_container.columns = 3
-	_cats_container.add_theme_constant_override("separation", 12)
-	_cats_container.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	_cats_scroll.add_child(_cats_container)
-	_cats_scroller = InertialScroller.attach(_cats_scroll, "vertical")
-
-	var submenu_items: Array = []
-	for type_key: String in ["boss", "dungeon", "arena_attack", "arena_defense"]:
-		submenu_items.append({
-			"key": type_key,
-			"label": str(Constants.TEAM_LABELS[type_key]),
-		})
-	var submenu: Dictionary = SceneSubmenuBar.build(self, {
-		"items": submenu_items,
-		"active_key": _current_team_type,
-		"back_label": UiText.CONFIG_BACK,
-		"back_pressed": Callable(self, "_on_back_pressed"),
-		"button_pressed": Callable(self, "_switch_team_type"),
-		"panel_fill": OverlaySceneChrome.PANEL_FILL,
-		"panel_border": OverlaySceneChrome.PANEL_BORDER,
-		"top": -(OverlaySceneChrome.HOME_MAIN_NAV_H + OverlaySceneChrome.BOTTOM_DOCK_H),
-		"bottom": -OverlaySceneChrome.HOME_MAIN_NAV_H,
+	var chrome: Dictionary = OverlaySceneChrome.build(self, "config", Callable(self, "_on_back_pressed"), {
+		"show_dock": false,
+		"content_bottom": -(OverlaySceneChrome.HOME_MAIN_NAV_H + 14.0),
+		"content_separation": 12,
 	})
-	_team_type_btns = submenu.get("buttons", {})
+	var content_box: VBoxContainer = chrome.get("content_box") as VBoxContainer
 
-	_switch_team_type("boss")
+	var title: Label = Label.new()
+	title.text = "設定中心"
+	title.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_DISPLAY)
+	content_box.add_child(title)
 
+	var subtitle: Label = Label.new()
+	subtitle.text = "管理角色資料、帳號資訊與本機遊戲設定。"
+	subtitle.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	subtitle.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY)
+	subtitle.add_theme_color_override("font_color", MUTED_TEXT_COLOR)
+	content_box.add_child(subtitle)
 
-func _switch_team_type(type_key: String) -> void:
-	_ensure_team_draft(type_key)
-	_current_team_type = type_key
+	var scroll: ScrollContainer = ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+	content_box.add_child(scroll)
 
-	SceneSubmenuBar.refresh(_team_type_btns, type_key, {
-		"active_color": SceneMenuTheme.ACTIVE_COLOR,
-		"inactive_color": SceneMenuTheme.INACTIVE_COLOR,
-	})
+	var body: VBoxContainer = VBoxContainer.new()
+	body.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	body.add_theme_constant_override("separation", 14)
+	scroll.add_child(body)
 
-	_refresh_team()
-	_refresh_cats_list()
-	_update_team_title()
-	_update_save_section()
-	_refresh_cats_sort_buttons()
-
-
-func _get_team_type_key(type_key: String = "") -> String:
-	if type_key == "":
-		type_key = _current_team_type
-	return str(Constants.TEAM_TYPE_MAP.get(type_key, "Boss"))
-
-
-func _get_editing_team_members() -> Array:
-	_ensure_team_draft(_current_team_type)
-	var team: Dictionary = _team_drafts[_current_team_type]
-	return team.get("members", [])
+	body.add_child(_build_profile_section())
+	body.add_child(_build_account_section())
+	body.add_child(_build_game_settings_section())
 
 
-func _get_filled_editing_team_members() -> Array:
-	var filled: Array = []
-	for member_variant: Variant in _get_editing_team_members():
-		if member_variant is Dictionary and not (member_variant as Dictionary).is_empty():
-			filled.append(member_variant)
-	return filled
-
-
-func _ensure_team_draft(type_key: String) -> void:
-	if _team_drafts.has(type_key):
-		return
-	_reset_team_draft(type_key, GameState.get_team(_get_team_type_key(type_key)))
-
-
-func _reset_team_draft(type_key: String, source_team: Dictionary) -> void:
-	var draft: Dictionary = source_team.duplicate(true)
-	draft["teamType"] = _get_team_type_key(type_key)
-	draft["members"] = _normalize_members(draft.get("members", []), type_key)
-	_team_drafts[type_key] = draft
-	_team_dirty[type_key] = false
-
-
-func _normalize_members(members: Array, type_key: String = "") -> Array:
-	if type_key == "":
-		type_key = _current_team_type
-	var max_count: int = _get_max_team_size_for(type_key)
-	var normalized: Array = []
-	normalized.resize(max_count)
-	for index: int in range(max_count):
-		normalized[index] = {}
-
-	for member_variant: Variant in members:
-		if member_variant is Dictionary and (member_variant as Dictionary).is_empty():
-			continue
-		if not (member_variant is Dictionary):
-			continue
-
-		var member: Dictionary = (member_variant as Dictionary).duplicate(true)
-		var slot_no: int = int(member.get("slotNo", -1))
-		if slot_no < 0 or slot_no >= max_count:
-			slot_no = _find_first_empty_slot_index(normalized)
-			if slot_no < 0:
-				continue
-
-		member["slotNo"] = slot_no
-		member["initialDelaySeconds"] = float(member.get("initialDelaySeconds", 0.0))
-		normalized[slot_no] = member
-	return normalized
-
-
-func _find_first_empty_slot_index(members: Array) -> int:
-	for index: int in range(members.size()):
-		var slot_variant: Variant = members[index]
-		if slot_variant is Dictionary and (slot_variant as Dictionary).is_empty():
-			return index
-	return -1
-
-
-func _get_max_team_size_for(type_key: String) -> int:
-	match type_key:
-		"boss":
-			return int(GameState.boss_config.get("max_team_size", 5))
-		"dungeon":
-			return int(GameState.dungeon_config.get("max_team_size", 5))
-		"arena_attack", "arena_defense":
-			return int(GameState.arena_config.get("max_team_size", 5))
-	return 5
-
-
-func _is_current_team_dirty() -> bool:
-	return bool(_team_dirty.get(_current_team_type, false))
-
-
-func _mark_current_team_dirty() -> void:
-	_team_dirty[_current_team_type] = true
-	_update_save_section()
-
-
-func _update_team_title() -> void:
-	var mode_label: String = str(Constants.TEAM_LABELS.get(_current_team_type, _current_team_type))
-	var members: Array = _get_filled_editing_team_members()
-	var max_count: int = _get_max_team_size()
-	var title_text: String = UiText.CONFIG_TEAM_TITLE_FORMAT % [mode_label, members.size(), max_count]
-	_page_title.text = title_text
-
-	_team_summary_label.text = UiText.CONFIG_TEAM_SUMMARY_WITH_DELAY
-
-
-func _refresh_team() -> void:
-	for child: Node in _team_container.get_children():
-		child.queue_free()
-
-	var members: Array = _get_editing_team_members()
-	var max_count: int = _get_max_team_size()
-	_team_container.columns = maxi(1, max_count)
-	for i: int in range(max_count):
-		var member: Dictionary = members[i] if i < members.size() else {}
-		_team_container.add_child(_make_team_slot_card(i, member))
-
-	_update_team_title()
-	_update_save_section()
-
-
-func _make_team_slot_card(slot_index: int, member: Dictionary) -> PanelContainer:
-	var is_filled: bool = not member.is_empty()
-	var card: PanelContainer = OverlaySceneChrome.make_card_panel(OverlaySceneChrome.PANEL_BORDER if is_filled else SLOT_EMPTY_BORDER)
-	card.custom_minimum_size = Vector2(0.0, 166.0)
-	card.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	var margin: MarginContainer = OverlaySceneChrome.make_content_margin(4)
-	card.add_child(margin)
+func _build_profile_section() -> Control:
+	var section: PanelContainer = OverlaySceneChrome.make_card_panel()
+	var margin: MarginContainer = OverlaySceneChrome.make_content_margin(16)
+	section.add_child(margin)
 
 	var column: VBoxContainer = VBoxContainer.new()
-	column.add_theme_constant_override("separation", 4)
+	column.add_theme_constant_override("separation", 12)
 	margin.add_child(column)
 
-	var cat_name: String = str(member.get("catDisplayName", "")) if is_filled else UiText.CONFIG_EMPTY_SLOT
-	var cat_catalog_id: int = int(member.get("catCatalogId", 0)) if is_filled else 0
-	var delay_seconds: float = float(member.get("initialDelaySeconds", 0.0)) if is_filled else 0.0
-	var cat_file_id: String = GameState.get_cat_file_id_by_catalog_id(cat_catalog_id) if is_filled else ""
+	column.add_child(_make_section_header("角色資料", "可設定頭像、暱稱、自介、生日與性別。"))
 
-	var top_row: HBoxContainer = HBoxContainer.new()
-	top_row.add_theme_constant_override("separation", 4)
-	column.add_child(top_row)
+	var avatar_row: HBoxContainer = HBoxContainer.new()
+	avatar_row.add_theme_constant_override("separation", 14)
+	column.add_child(avatar_row)
 
-	var slot_badge: Label = Label.new()
-	slot_badge.text = UiText.CONFIG_SLOT_BADGE_FORMAT % [slot_index + 1]
-	slot_badge.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_TINY)
-	slot_badge.add_theme_color_override("font_color", Color(0.98, 0.90, 0.72, 1.0))
-	top_row.add_child(slot_badge)
+	var preview_panel: PanelContainer = PanelContainer.new()
+	preview_panel.custom_minimum_size = Vector2(156.0, 184.0)
+	preview_panel.add_theme_stylebox_override("panel", OverlaySceneChrome.make_panel_style(FIELD_BG, FIELD_BORDER, 16))
+	avatar_row.add_child(preview_panel)
 
-	var top_name: Label = Label.new()
-	top_name.text = cat_name if is_filled else UiText.CONFIG_TEAM_SLOT_EMPTY_NAME
-	top_name.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	top_name.clip_text = true
-	top_name.add_theme_font_size_override("font_size", 17)
-	top_name.add_theme_color_override("font_color", SLOT_NAME_COLOR if is_filled else EMPTY_SLOT_TEXT_COLOR)
-	top_row.add_child(top_name)
+	var preview_margin: MarginContainer = OverlaySceneChrome.make_content_margin(12)
+	preview_panel.add_child(preview_margin)
 
-	var image_shell: PanelContainer = PanelContainer.new()
-	image_shell.custom_minimum_size = Vector2(0.0, 96.0)
-	image_shell.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	image_shell.add_theme_stylebox_override("panel", OverlaySceneChrome.make_panel_style(SLOT_IMAGE_BG if is_filled else SLOT_EMPTY_FILL, SLOT_IMAGE_BORDER if is_filled else SLOT_EMPTY_BORDER, 14))
-	image_shell.mouse_filter = Control.MOUSE_FILTER_STOP
-	column.add_child(image_shell)
+	var preview_box: VBoxContainer = VBoxContainer.new()
+	preview_box.alignment = BoxContainer.ALIGNMENT_CENTER
+	preview_box.add_theme_constant_override("separation", 8)
+	preview_margin.add_child(preview_box)
 
-	var image_button: Button = Button.new()
-	image_button.flat = true
-	image_button.text = UiText.CONFIG_EMPTY_SLOT_ICON if not is_filled else ""
-	image_button.custom_minimum_size = Vector2(0.0, 96.0)
-	image_button.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	image_button.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	image_button.clip_text = true
-	image_button.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_DISPLAY)
-	image_button.add_theme_color_override("font_color", EMPTY_SLOT_TEXT_COLOR)
-	image_shell.add_child(image_button)
+	_avatar_preview = TextureRect.new()
+	_avatar_preview.custom_minimum_size = Vector2(108.0, 108.0)
+	_avatar_preview.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+	_avatar_preview.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+	_avatar_preview.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	preview_box.add_child(_avatar_preview)
 
-	var overlay_root: Control = Control.new()
-	overlay_root.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	overlay_root.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	image_shell.add_child(overlay_root)
+	_avatar_name_label = Label.new()
+	_avatar_name_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	_avatar_name_label.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY)
+	preview_box.add_child(_avatar_name_label)
 
-	var image_margin: MarginContainer = OverlaySceneChrome.make_content_margin(4)
-	image_margin.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	image_margin.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	overlay_root.add_child(image_margin)
+	var avatar_picker_shell: VBoxContainer = VBoxContainer.new()
+	avatar_picker_shell.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	avatar_picker_shell.add_theme_constant_override("separation", 8)
+	avatar_row.add_child(avatar_picker_shell)
 
-	var icon_holder: CenterContainer = CenterContainer.new()
-	icon_holder.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	image_margin.add_child(icon_holder)
+	var avatar_hint: Label = Label.new()
+	avatar_hint.text = "選擇預設頭像"
+	avatar_hint.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY_LG)
+	avatar_picker_shell.add_child(avatar_hint)
 
-	var team_icon: Texture2D = AssetResolver.resolve_cat_showcase_art(cat_file_id)
-	if team_icon != null:
-		icon_holder.add_child(AssetResolver.create_icon_rect(team_icon, Vector2(72.0, 72.0)))
-	elif is_filled:
-		var fallback_name: Label = Label.new()
-		fallback_name.text = _get_cat_visual_fallback(cat_name)
-		fallback_name.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
-		fallback_name.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
-		fallback_name.add_theme_font_size_override("font_size", 30)
-		fallback_name.add_theme_color_override("font_color", SLOT_NAME_COLOR)
-		icon_holder.add_child(fallback_name)
+	var avatar_grid: GridContainer = GridContainer.new()
+	avatar_grid.columns = 3
+	avatar_grid.add_theme_constant_override("h_separation", 8)
+	avatar_grid.add_theme_constant_override("v_separation", 8)
+	avatar_picker_shell.add_child(avatar_grid)
 
-	if is_filled:
-		var remove_btn: Button = Button.new()
-		remove_btn.text = "－"
-		remove_btn.custom_minimum_size = Vector2(22.0, 22.0)
-		remove_btn.add_theme_font_size_override("font_size", 11)
-		remove_btn.add_theme_color_override("font_color", Color(1.0, 0.97, 0.95, 1.0))
-		remove_btn.anchor_left = 1.0
-		remove_btn.anchor_top = 0.0
-		remove_btn.anchor_right = 1.0
-		remove_btn.anchor_bottom = 0.0
-		remove_btn.offset_left = -20.0
-		remove_btn.offset_top = -10.0
-		remove_btn.offset_right = 2.0
-		remove_btn.offset_bottom = 12.0
-		remove_btn.disabled = _api_in_flight
-		var remove_style: StyleBoxFlat = StyleBoxFlat.new()
-		remove_style.bg_color = SLOT_REMOVE_BG
-		remove_style.corner_radius_top_left = 999
-		remove_style.corner_radius_top_right = 999
-		remove_style.corner_radius_bottom_left = 999
-		remove_style.corner_radius_bottom_right = 999
-		remove_style.border_width_left = 1
-		remove_style.border_width_right = 1
-		remove_style.border_width_top = 1
-		remove_style.border_width_bottom = 1
-		remove_style.border_color = Color(1.0, 0.82, 0.78, 0.95)
-		remove_btn.add_theme_stylebox_override("normal", remove_style)
-		var remove_hover: StyleBoxFlat = remove_style.duplicate()
-		remove_hover.bg_color = SLOT_REMOVE_BG.lightened(0.08)
-		var remove_pressed: StyleBoxFlat = remove_style.duplicate()
-		remove_pressed.bg_color = SLOT_REMOVE_BG.darkened(0.08)
-		remove_btn.add_theme_stylebox_override("hover", remove_hover)
-		remove_btn.add_theme_stylebox_override("pressed", remove_pressed)
-		if not _api_in_flight:
-			remove_btn.pressed.connect(func() -> void:
-				_remove_member_from_draft(slot_index)
-			)
-		overlay_root.add_child(remove_btn)
+	for avatar_id: String in AssetResolver.get_profile_avatar_ids():
+		avatar_grid.add_child(_build_avatar_card(avatar_id))
 
-	image_button.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	if is_filled and cat_file_id != "":
-		image_shell.gui_input.connect(func(event: InputEvent) -> void:
-			if not (event is InputEventMouseButton):
-				return
-			var mouse_event: InputEventMouseButton = event as InputEventMouseButton
-			if not mouse_event.pressed or mouse_event.button_index != MOUSE_BUTTON_LEFT:
-				return
-			_show_skill_popup(cat_file_id)
-			image_shell.accept_event()
-		)
-	else:
-		image_button.disabled = true
+	_display_name_input = _make_line_edit("請輸入暱稱")
+	_player_name_input = _make_line_edit("請輸入角色名稱")
+	_birthday_input = _make_line_edit("YYYY-MM-DD")
+	_region_input = _make_line_edit("例如：台北 / Kaohsiung")
 
-	var delay_button: Button = Button.new()
-	delay_button.text = UiText.CONFIG_DELAY_BUTTON_FORMAT % [_format_delay_label(delay_seconds)] if is_filled else UiText.CONFIG_DELAY_BUTTON_EMPTY
-	delay_button.custom_minimum_size = Vector2(0.0, 24.0)
-	delay_button.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	delay_button.add_theme_font_size_override("font_size", 13)
-	delay_button.disabled = not is_filled or _api_in_flight
-	UiPalette.apply_button_palette(delay_button, SLOT_DELAY_BG, Color(0.98, 0.90, 0.72, 1.0))
-	if is_filled and not _api_in_flight:
-		delay_button.pressed.connect(func() -> void:
-			_update_member_delay_in_draft(slot_index, _get_next_delay_value(delay_seconds))
-		)
-	column.add_child(delay_button)
+	_bio_input = TextEdit.new()
+	_bio_input.custom_minimum_size = Vector2(0.0, 112.0)
+	_bio_input.wrap_mode = TextEdit.LINE_WRAPPING_BOUNDARY
+	_bio_input.add_theme_stylebox_override("normal", OverlaySceneChrome.make_panel_style(FIELD_BG, FIELD_BORDER, 12))
 
-	return card
+	_gender_option = OptionButton.new()
+	_gender_option.custom_minimum_size = Vector2(0.0, 48.0)
+	for option: Dictionary in GENDER_OPTIONS:
+		_gender_option.add_item(str(option.get("label", "")))
+
+	column.add_child(_build_field_row("暱稱", _display_name_input))
+	column.add_child(_build_field_row("角色名稱", _player_name_input))
+	column.add_child(_build_field_row("自介", _bio_input))
+	column.add_child(_build_field_row("生日", _birthday_input))
+	column.add_child(_build_field_row("性別", _gender_option))
+	column.add_child(_build_field_row("地區", _region_input))
+
+	var save_row: HBoxContainer = HBoxContainer.new()
+	save_row.add_theme_constant_override("separation", 12)
+	column.add_child(save_row)
+
+	_save_profile_button = Button.new()
+	_save_profile_button.text = "儲存角色資料"
+	_save_profile_button.custom_minimum_size = Vector2(220.0, 50.0)
+	UiPalette.apply_button_kind(_save_profile_button, "confirm")
+	_save_profile_button.pressed.connect(UiAudio.play_ui_click)
+	_save_profile_button.pressed.connect(_on_save_profile_pressed)
+	save_row.add_child(_save_profile_button)
+
+	_save_profile_hint_label = Label.new()
+	_save_profile_hint_label.text = "資料會同步到帳號。"
+	_save_profile_hint_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_save_profile_hint_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	_save_profile_hint_label.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+	_save_profile_hint_label.add_theme_color_override("font_color", SECTION_HINT_COLOR)
+	save_row.add_child(_save_profile_hint_label)
+
+	_bind_profile_edit_events()
+	_refresh_avatar_selection()
+	_refresh_profile_save_state()
+	return section
 
 
-func _refresh_cats_list() -> void:
-	for child: Node in _cats_container.get_children():
-		child.queue_free()
+func _build_account_section() -> Control:
+	var section: PanelContainer = OverlaySceneChrome.make_card_panel()
+	var margin: MarginContainer = OverlaySceneChrome.make_content_margin(16)
+	section.add_child(margin)
 
-	var in_team_ids: Array = _get_editing_team_members().map(func(member: Dictionary) -> int:
-		return int(member.get("playerCatId", 0))
+	var column: VBoxContainer = VBoxContainer.new()
+	column.add_theme_constant_override("separation", 12)
+	margin.add_child(column)
+
+	column.add_child(_make_section_header("帳號資料", "顯示目前綁定狀態，OAuth 入口先以佔位方式展示。"))
+
+	_account_value_label = _make_readonly_value("載入中")
+	_player_uid_value_label = _make_readonly_value("載入中")
+	column.add_child(_build_field_row("帳號", _account_value_label))
+	column.add_child(_build_field_row("Player UID", _player_uid_value_label))
+
+	var provider_row: HBoxContainer = HBoxContainer.new()
+	provider_row.add_theme_constant_override("separation", 10)
+	column.add_child(provider_row)
+
+	provider_row.add_child(_build_provider_card("Google"))
+	provider_row.add_child(_build_provider_card("Apple"))
+
+	var redeem_title: Label = Label.new()
+	redeem_title.text = "兌換碼"
+	redeem_title.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY_LG)
+	column.add_child(redeem_title)
+
+	var redeem_hint: Label = Label.new()
+	redeem_hint.text = "輸入活動碼即可直接領取獎勵。"
+	redeem_hint.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+	redeem_hint.add_theme_color_override("font_color", SECTION_HINT_COLOR)
+	column.add_child(redeem_hint)
+
+	var redeem_row: HBoxContainer = HBoxContainer.new()
+	redeem_row.add_theme_constant_override("separation", 10)
+	column.add_child(redeem_row)
+
+	_redeem_input = _make_line_edit("請輸入兌換碼")
+	_redeem_input.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	redeem_row.add_child(_redeem_input)
+
+	_redeem_button = Button.new()
+	_redeem_button.text = "兌換"
+	_redeem_button.custom_minimum_size = Vector2(132.0, 48.0)
+	UiPalette.apply_button_kind(_redeem_button, "confirm")
+	_redeem_button.pressed.connect(UiAudio.play_ui_click)
+	_redeem_button.pressed.connect(_on_redeem_pressed)
+	redeem_row.add_child(_redeem_button)
+
+	return section
+
+
+func _build_game_settings_section() -> Control:
+	var section: PanelContainer = OverlaySceneChrome.make_card_panel()
+	var margin: MarginContainer = OverlaySceneChrome.make_content_margin(16)
+	section.add_child(margin)
+
+	var column: VBoxContainer = VBoxContainer.new()
+	column.add_theme_constant_override("separation", 12)
+	margin.add_child(column)
+
+	column.add_child(_make_section_header("遊戲設定", "音量設定保存在本機裝置，不會覆蓋其他裝置。"))
+
+	column.add_child(_build_audio_row("master", "總音量"))
+	column.add_child(_build_audio_row("bgm", "背景音樂"))
+	column.add_child(_build_audio_row("sfx", "音效"))
+
+	return section
+
+
+func _build_avatar_card(avatar_id: String) -> Control:
+	var panel: PanelContainer = PanelContainer.new()
+	panel.custom_minimum_size = Vector2(0.0, 96.0)
+	panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+
+	var margin: MarginContainer = OverlaySceneChrome.make_content_margin(8)
+	panel.add_child(margin)
+
+	var box: VBoxContainer = VBoxContainer.new()
+	box.alignment = BoxContainer.ALIGNMENT_CENTER
+	box.add_theme_constant_override("separation", 6)
+	margin.add_child(box)
+
+	var icon: TextureRect = TextureRect.new()
+	icon.custom_minimum_size = Vector2(54.0, 54.0)
+	icon.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+	icon.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+	icon.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	icon.texture = AssetResolver.resolve_profile_avatar(avatar_id)
+	box.add_child(icon)
+
+	var label: Label = Label.new()
+	label.text = AssetResolver.get_profile_avatar_label(avatar_id)
+	label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	label.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+	box.add_child(label)
+
+	var button: Button = Button.new()
+	button.flat = true
+	button.focus_mode = Control.FOCUS_NONE
+	button.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	button.pressed.connect(UiAudio.play_ui_click)
+	button.pressed.connect(func() -> void:
+		_selected_avatar_id = avatar_id
+		_mark_profile_dirty()
+		_refresh_avatar_selection()
 	)
-	in_team_ids = in_team_ids.filter(func(id: int) -> bool:
-		return id > 0
+	panel.add_child(button)
+
+	_avatar_buttons[avatar_id] = {"panel": panel, "label": label}
+	return panel
+
+
+func _build_provider_card(provider_name: String) -> Control:
+	var panel: PanelContainer = OverlaySceneChrome.make_card_panel(FIELD_BORDER, FIELD_BG, 12)
+	panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+
+	var margin: MarginContainer = OverlaySceneChrome.make_content_margin(12)
+	panel.add_child(margin)
+
+	var column: VBoxContainer = VBoxContainer.new()
+	column.add_theme_constant_override("separation", 8)
+	margin.add_child(column)
+
+	var title: Label = Label.new()
+	title.text = provider_name
+	title.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY_LG)
+	column.add_child(title)
+
+	var status_label: Label = Label.new()
+	status_label.text = "即將開放"
+	status_label.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+	status_label.add_theme_color_override("font_color", SECTION_HINT_COLOR)
+	column.add_child(status_label)
+	_provider_status_labels[provider_name] = status_label
+
+	var action_button: Button = Button.new()
+	action_button.text = "即將開放"
+	action_button.disabled = true
+	action_button.custom_minimum_size = Vector2(0.0, 42.0)
+	UiPalette.apply_button_palette(action_button, Color(0.24, 0.21, 0.18, 0.86), Color(0.72, 0.69, 0.64, 1.0))
+	column.add_child(action_button)
+
+	return panel
+
+
+func _build_audio_row(bus_key: String, label_text: String) -> Control:
+	var panel: PanelContainer = PanelContainer.new()
+	panel.add_theme_stylebox_override("panel", OverlaySceneChrome.make_panel_style(FIELD_BG, FIELD_BORDER, 12))
+
+	var margin: MarginContainer = OverlaySceneChrome.make_content_margin(12)
+	panel.add_child(margin)
+
+	var row: HBoxContainer = HBoxContainer.new()
+	row.add_theme_constant_override("separation", 12)
+	margin.add_child(row)
+
+	var label: Label = Label.new()
+	label.text = label_text
+	label.custom_minimum_size = Vector2(110.0, 0.0)
+	label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	label.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY)
+	row.add_child(label)
+
+	var slider: HSlider = HSlider.new()
+	slider.min_value = 0.0
+	slider.max_value = 1.0
+	slider.step = 0.01
+	slider.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	slider.value_changed.connect(func(value: float) -> void:
+		_on_audio_slider_changed(bus_key, value)
 	)
-	var owned_cats: Array = _get_sorted_owned_cats()
-	for cat_variant: Variant in owned_cats:
-		if cat_variant is Dictionary:
-			_cats_container.add_child(_make_cat_card(cat_variant as Dictionary, in_team_ids))
+	row.add_child(slider)
+	_audio_sliders[bus_key] = slider
+
+	var value_label: Label = Label.new()
+	value_label.custom_minimum_size = Vector2(56.0, 0.0)
+	value_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+	value_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	value_label.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+	row.add_child(value_label)
+	_audio_value_labels[bus_key] = value_label
+
+	var mute_box: CheckBox = CheckBox.new()
+	mute_box.text = "靜音"
+	mute_box.toggled.connect(func(pressed: bool) -> void:
+		_on_audio_mute_toggled(bus_key, pressed)
+	)
+	row.add_child(mute_box)
+	_audio_mute_boxes[bus_key] = mute_box
+
+	return panel
 
 
-func _make_cat_card(cat: Dictionary, in_team_ids: Array) -> PanelContainer:
-	var player_cat_id: int = int(cat.get("playerCatId", 0))
-	var display_name: String = str(cat.get("displayName", ""))
-	var lv: int = int(cat.get("catFoodLevel", 1))
-	var rank: int = int(cat.get("rank", 0))
-	var cat_catalog_id: int = int(cat.get("catCatalogId", 0))
-	var already_in: bool = player_cat_id in in_team_ids
-	var team_full: bool = _get_filled_editing_team_members().size() >= _get_max_team_size()
-	var action_disabled: bool = (not already_in and team_full) or _api_in_flight
+func _make_section_header(title_text: String, subtitle_text: String) -> Control:
+	var column: VBoxContainer = VBoxContainer.new()
+	column.add_theme_constant_override("separation", 4)
 
-	var local_cat_id: String = GameState.get_cat_file_id_by_catalog_id(cat_catalog_id)
-	var cat_icon: Texture2D = AssetResolver.resolve_cat_showcase_art(local_cat_id)
-	var hold_timer: Timer = Timer.new()
-	hold_timer.one_shot = true
-	hold_timer.wait_time = CAT_CARD_HOLD_SECONDS
-	var pointer_down: Array[bool] = [false]
-	var long_press_triggered: Array[bool] = [false]
-	hold_timer.timeout.connect(func() -> void:
-		if not pointer_down[0]:
-			return
-		if local_cat_id == "":
-			return
-		if _cats_scroller != null and _cats_scroller.consume_moved():
-			return
-		long_press_triggered[0] = true
-		_show_skill_popup(local_cat_id)
+	var title: Label = Label.new()
+	title.text = title_text
+	title.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_HEADING)
+	column.add_child(title)
+
+	var subtitle: Label = Label.new()
+	subtitle.text = subtitle_text
+	subtitle.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	subtitle.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+	subtitle.add_theme_color_override("font_color", MUTED_TEXT_COLOR)
+	column.add_child(subtitle)
+
+	return column
+
+
+func _build_field_row(label_text: String, field: Control) -> Control:
+	var column: VBoxContainer = VBoxContainer.new()
+	column.add_theme_constant_override("separation", 6)
+
+	var label: Label = Label.new()
+	label.text = label_text
+	label.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY)
+	column.add_child(label)
+
+	field.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	column.add_child(field)
+	return column
+
+
+func _make_line_edit(placeholder_text: String) -> LineEdit:
+	var input: LineEdit = LineEdit.new()
+	input.custom_minimum_size = Vector2(0.0, 48.0)
+	input.placeholder_text = placeholder_text
+	input.add_theme_stylebox_override("normal", OverlaySceneChrome.make_panel_style(FIELD_BG, FIELD_BORDER, 12))
+	return input
+
+
+func _make_readonly_value(text: String) -> LineEdit:
+	var input: LineEdit = LineEdit.new()
+	input.text = text
+	input.editable = false
+	input.custom_minimum_size = Vector2(0.0, 42.0)
+	input.add_theme_stylebox_override("normal", OverlaySceneChrome.make_panel_style(FIELD_BG, FIELD_BORDER, 12))
+	return input
+
+
+func _bind_profile_edit_events() -> void:
+	_display_name_input.text_changed.connect(func(_value: String) -> void:
+		_mark_profile_dirty()
+	)
+	_player_name_input.text_changed.connect(func(_value: String) -> void:
+		_mark_profile_dirty()
+	)
+	_birthday_input.text_changed.connect(func(_value: String) -> void:
+		_mark_profile_dirty()
+	)
+	_region_input.text_changed.connect(func(_value: String) -> void:
+		_mark_profile_dirty()
+	)
+	_bio_input.text_changed.connect(_mark_profile_dirty)
+	_gender_option.item_selected.connect(func(_index: int) -> void:
+		_mark_profile_dirty()
 	)
 
-	var whole_card_gui_input: Callable = func(event: InputEvent) -> void:
-		if not (event is InputEventMouseButton):
-			return
-		var mouse_event: InputEventMouseButton = event as InputEventMouseButton
-		if mouse_event.button_index != MOUSE_BUTTON_LEFT:
-			return
-		if mouse_event.pressed:
-			pointer_down[0] = true
-			long_press_triggered[0] = false
-			if local_cat_id != "":
-				hold_timer.start()
-			return
 
-		var was_pressed: bool = pointer_down[0]
-		pointer_down[0] = false
-		hold_timer.stop()
-		if not was_pressed:
-			return
-		if _cats_scroller != null and _cats_scroller.consume_moved():
-			return
-		if long_press_triggered[0]:
-			long_press_triggered[0] = false
-			return
-		if action_disabled:
-			return
-		_toggle_member_in_draft(player_cat_id)
-
-	var card: PanelContainer = CatRosterCard.build({
-		"is_selected": already_in,
-		"title_text": display_name,
-		"show_title": false,
-		"icon_texture": cat_icon,
-		"fallback_text": _get_cat_visual_fallback(display_name),
-		"chips": [
-			UiText.CONFIG_CAT_LEVEL_ONLY_FORMAT % [lv],
-			UiText.CONFIG_CAT_STARS_FORMAT % [rank],
-		],
-		"show_action": false,
-		"whole_card_gui_input": whole_card_gui_input,
-		"card_height": 228.0,
-		"art_height": 108.0,
-		"icon_size": Vector2(84.0, 84.0),
-		"card_fill": OverlaySceneChrome.CARD_FILL,
-		"card_border": OverlaySceneChrome.CARD_BORDER,
-		"selected_card_border": OverlaySceneChrome.PANEL_BORDER,
-		"selected_card_fill": Color(0.24, 0.20, 0.13, 0.98),
-		"art_fill": Color(0.19, 0.17, 0.15, 0.96),
-		"art_border": Color(0.90, 0.77, 0.46, 0.88),
-		"selected_art_border": Color(0.90, 0.77, 0.46, 0.88),
-		"selected_art_fill": Color(0.26, 0.21, 0.14, 0.98),
-		"title_color": SLOT_NAME_COLOR,
-		"selected_chip_fill": Color(0.42, 0.29, 0.14, 0.98),
-		"selected_chip_border": Color(0.98, 0.83, 0.48, 1.0),
-		"selected_chip_text_color": Color(1.0, 0.97, 0.86, 1.0),
-	})
-	card.add_child(hold_timer)
-	return card
-
-
-func _set_cats_sort_mode(sort_mode: String) -> void:
-	if _cats_sort_mode == sort_mode:
-		return
-	_cats_sort_mode = sort_mode
-	_refresh_cats_sort_buttons()
-	_refresh_cats_list()
-
-
-func _refresh_cats_sort_buttons() -> void:
-	for key: String in _cats_sort_btns.keys():
-		var button: Button = _cats_sort_btns[key]
-		var is_active: bool = key == _cats_sort_mode
-		if is_active:
-			UiPalette.apply_button_palette(button, Color(0.58, 0.48, 0.26, 0.88), Color(0.97, 0.93, 0.84, 1.0))
-		else:
-			UiPalette.apply_button_palette(button, Color(0.20, 0.18, 0.17, 0.88), Color(0.62, 0.58, 0.54, 1.0))
-
-
-func _get_sorted_owned_cats() -> Array:
-	var owned_cats: Array = GameState.get_config_owned_cats().duplicate(true)
-	owned_cats.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
-		if _cats_sort_mode == "rank":
-			var a_rank: int = int(a.get("rank", 0))
-			var b_rank: int = int(b.get("rank", 0))
-			if a_rank != b_rank:
-				return a_rank > b_rank
-			var a_level: int = int(a.get("catFoodLevel", 1))
-			var b_level: int = int(b.get("catFoodLevel", 1))
-			if a_level != b_level:
-				return a_level > b_level
-			return int(a.get("playerCatId", 0)) < int(b.get("playerCatId", 0))
-
-		var a_level_default: int = int(a.get("catFoodLevel", 1))
-		var b_level_default: int = int(b.get("catFoodLevel", 1))
-		if a_level_default != b_level_default:
-			return a_level_default > b_level_default
-		var a_rank_default: int = int(a.get("rank", 0))
-		var b_rank_default: int = int(b.get("rank", 0))
-		if a_rank_default != b_rank_default:
-			return a_rank_default > b_rank_default
-		return int(a.get("playerCatId", 0)) < int(b.get("playerCatId", 0))
-	)
-	return owned_cats
-
-
-func _build_member_from_player_cat(player_cat_id: int) -> Dictionary:
-	for cat_variant: Variant in GameState.get_config_owned_cats():
-		if not (cat_variant is Dictionary):
-			continue
-
-		var cat: Dictionary = cat_variant as Dictionary
-		if int(cat.get("playerCatId", 0)) != player_cat_id:
-			continue
-
-		return {
-			"slotNo": 0,
-			"playerCatId": player_cat_id,
-			"catCatalogId": int(cat.get("catCatalogId", 0)),
-			"catDisplayName": str(cat.get("displayName", "")),
-			"catFoodLevel": int(cat.get("catFoodLevel", 1)),
-			"rank": int(cat.get("rank", 0)),
-			"initialDelaySeconds": 0.0,
-		}
-
-	return {}
-
-
-func _draft_has_player_cat(members: Array, player_cat_id: int) -> bool:
-	for member_variant: Variant in members:
-		if member_variant is Dictionary:
-			var member: Dictionary = member_variant
-			if int(member.get("playerCatId", 0)) == player_cat_id:
-				return true
-	return false
-
-
-func _find_member_slot_no_by_player_cat_id(player_cat_id: int) -> int:
-	for member_variant: Variant in _get_editing_team_members():
-		if not (member_variant is Dictionary):
-			continue
-		var member: Dictionary = member_variant as Dictionary
-		if member.is_empty():
-			continue
-		if int(member.get("playerCatId", 0)) == player_cat_id:
-			return int(member.get("slotNo", -1))
-	return -1
-
-
-func _toggle_member_in_draft(player_cat_id: int) -> void:
-	if _api_in_flight:
-		return
-
-	var slot_no: int = _find_member_slot_no_by_player_cat_id(player_cat_id)
-	if slot_no >= 0:
-		_remove_member_from_draft(slot_no)
-		return
-
-	_add_member_to_draft(player_cat_id)
-
-
-func _add_member_to_draft(player_cat_id: int) -> void:
-	if _api_in_flight:
-		return
-
-	var members: Array = _get_editing_team_members().duplicate(true)
-	if _get_filled_editing_team_members().size() >= _get_max_team_size():
-		return
-	if _draft_has_player_cat(members, player_cat_id):
-		return
-
-	var new_member: Dictionary = _build_member_from_player_cat(player_cat_id)
-	if new_member.is_empty():
-		return
-
-	var target_index: int = -1
-	for index: int in range(members.size()):
-		var slot_variant: Variant = members[index]
-		if slot_variant is Dictionary and (slot_variant as Dictionary).is_empty():
-			target_index = index
-			break
-
-	if target_index >= 0:
-		new_member["slotNo"] = target_index
-		members[target_index] = new_member
-	else:
-		new_member["slotNo"] = members.size()
-		members.append(new_member)
-
-	_team_drafts[_current_team_type]["members"] = _normalize_members(members)
-	_mark_current_team_dirty()
-	_refresh_team()
-	_refresh_cats_list()
-
-
-func _remove_member_from_draft(slot_no: int) -> void:
-	if _api_in_flight:
-		return
-
-	var members: Array = _get_editing_team_members().duplicate(true)
-	if slot_no < 0 or slot_no >= members.size():
-		return
-
-	members[slot_no] = {}
-	_team_drafts[_current_team_type]["members"] = _normalize_members(members)
-	_mark_current_team_dirty()
-	_refresh_team()
-	_refresh_cats_list()
-
-
-func _update_member_delay_in_draft(slot_no: int, delay_seconds: float) -> void:
-	if _api_in_flight:
-		return
-
-	var members: Array = _get_editing_team_members().duplicate(true)
-	if slot_no < 0 or slot_no >= members.size():
-		return
-
-	var member: Dictionary = members[slot_no]
-	member["initialDelaySeconds"] = maxf(0.0, delay_seconds)
-	members[slot_no] = member
-	_team_drafts[_current_team_type]["members"] = _normalize_members(members)
-	_mark_current_team_dirty()
-	_refresh_team()
-
-
-func _update_save_section() -> void:
-	var dirty: bool = _is_current_team_dirty()
-	_save_team_btn.disabled = _api_in_flight or not dirty
-	if dirty and not _api_in_flight:
-		UiPalette.apply_button_kind(_save_team_btn, "confirm")
-	else:
-		UiPalette.apply_button_palette(_save_team_btn, Color(0.24, 0.21, 0.18, 0.86), Color(0.72, 0.69, 0.64, 1.0))
-
-
-func _on_save_team_pressed() -> void:
-	if _api_in_flight or not _is_current_team_dirty():
-		return
-
-	var request_members: Array = []
-	for member: Dictionary in _get_editing_team_members():
-		if member.is_empty():
-			continue
-		request_members.append({
-			"slotNo": int(member.get("slotNo", 0)),
-			"playerCatId": int(member.get("playerCatId", 0)),
-			"initialDelaySeconds": float(member.get("initialDelaySeconds", 0.0)),
-		})
-
-	_api_in_flight = true
-	_update_save_section()
-	_refresh_team()
-	_refresh_cats_list()
-
-	ApiClient.replace_team(_current_team_type, request_members, func(success: bool, data: Variant, error: Dictionary) -> void:
-		_api_in_flight = false
+func _load_profile_from_api() -> void:
+	_profile_loading = true
+	_refresh_profile_save_state()
+	ApiClient.get_profile_me(func(success: bool, data: Variant, error: Dictionary) -> void:
+		_profile_loading = false
+		_refresh_profile_save_state()
 		if not success:
-			ToastManager.error(UiText.CONFIG_SAVE_FAILED_TITLE, str(error.get("message", UiText.CONFIG_UNKNOWN_ERROR)))
-			_refresh_team()
-			_refresh_cats_list()
+			ToastManager.hint("設定資料使用快取", str(error.get("message", "目前改用本地快取顯示。")))
 			return
 
 		if data is Dictionary:
-			var team_response: Dictionary = data as Dictionary
-			_apply_team_update(team_response)
-			var saved_type_key: String = _team_scene_type_to_key(str(team_response.get("teamType", "")))
-			if saved_type_key != "":
-				_reset_team_draft(saved_type_key, team_response)
-				_restart_home_battle_if_needed(saved_type_key)
-
-		_refresh_team()
-		_refresh_cats_list()
-		ToastManager.success(UiText.CONFIG_SAVE_HINT_CLEAN)
+			var profile: Dictionary = data as Dictionary
+			GameState.apply_profile_response(profile)
+			_apply_profile_data(profile)
 	)
 
 
-func _team_scene_type_to_key(team_type: String) -> String:
-	for key: String in Constants.TEAM_TYPE_MAP.keys():
-		if str(Constants.TEAM_TYPE_MAP[key]) == team_type:
-			return key
+func _apply_profile_data(data: Dictionary) -> void:
+	_applying_profile_form = true
+	_selected_avatar_id = str(data.get("avatarId", AssetResolver.DEFAULT_PROFILE_AVATAR_ID)).strip_edges()
+	if _selected_avatar_id == "":
+		_selected_avatar_id = AssetResolver.DEFAULT_PROFILE_AVATAR_ID
+
+	_display_name_input.text = str(data.get("displayName", ""))
+	_player_name_input.text = str(data.get("playerName", ""))
+	_bio_input.text = str(data.get("bio", ""))
+	_birthday_input.text = str(data.get("birthday", ""))
+	_region_input.text = str(data.get("region", ""))
+	_set_gender_value(str(data.get("genderType", "Unspecified")))
+	_account_value_label.text = str(data.get("account", ""))
+	_player_uid_value_label.text = str(data.get("playerPublicId", ""))
+	_refresh_provider_cards(data.get("linkedProviders", []))
+	_applying_profile_form = false
+	_profile_dirty = false
+	_refresh_avatar_selection()
+	_refresh_profile_save_state()
+
+
+func _apply_audio_settings() -> void:
+	var settings: Dictionary = ClientSettings.get_settings()
+	for bus_key: String in ["master", "bgm", "sfx"]:
+		var slider: HSlider = _audio_sliders.get(bus_key) as HSlider
+		var mute_box: CheckBox = _audio_mute_boxes.get(bus_key) as CheckBox
+		if slider != null:
+			slider.value = float(settings.get("%sVolume" % bus_key, 1.0))
+		if mute_box != null:
+			mute_box.button_pressed = bool(settings.get("%sMuted" % bus_key, false))
+		_refresh_audio_value_label(bus_key)
+
+
+func _build_local_profile_snapshot() -> Dictionary:
+	var player = GameState.player_data
+	return {
+		"account": player.account,
+		"displayName": player.display_name,
+		"playerPublicId": player.player_public_id,
+		"playerName": player.player_name,
+		"avatarId": player.avatar_id,
+		"bio": player.bio,
+		"birthday": player.birthday,
+		"genderType": player.gender_type,
+		"region": player.region,
+		"linkedProviders": player.linked_providers.duplicate(),
+	}
+
+
+func _refresh_avatar_selection() -> void:
+	_avatar_preview.texture = AssetResolver.resolve_profile_avatar(_selected_avatar_id)
+	_avatar_name_label.text = AssetResolver.get_profile_avatar_label(_selected_avatar_id)
+	for avatar_id: String in _avatar_buttons.keys():
+		var refs: Dictionary = _avatar_buttons.get(avatar_id, {})
+		var panel: PanelContainer = refs.get("panel") as PanelContainer
+		var label: Label = refs.get("label") as Label
+		if panel == null or label == null:
+			continue
+		var is_selected: bool = avatar_id == _selected_avatar_id
+		panel.add_theme_stylebox_override(
+			"panel",
+			OverlaySceneChrome.make_panel_style(
+				FIELD_BG if not is_selected else Color(0.22, 0.17, 0.10, 0.98),
+				SELECTED_BORDER if is_selected else UNSELECTED_BORDER,
+				14
+			)
+		)
+		label.add_theme_color_override("font_color", Color(1.0, 0.95, 0.84, 1.0) if is_selected else MUTED_TEXT_COLOR)
+
+
+func _refresh_provider_cards(linked_providers_variant: Variant) -> void:
+	var linked: Array = linked_providers_variant if linked_providers_variant is Array else []
+	for provider_name: String in _provider_status_labels.keys():
+		var status_label: Label = _provider_status_labels.get(provider_name) as Label
+		if status_label == null:
+			continue
+		if linked.has(provider_name):
+			status_label.text = "已綁定"
+			status_label.add_theme_color_override("font_color", Color(0.72, 0.94, 0.72, 1.0))
+		else:
+			status_label.text = "即將開放"
+			status_label.add_theme_color_override("font_color", SECTION_HINT_COLOR)
+
+
+func _refresh_profile_save_state() -> void:
+	if _save_profile_button == null:
+		return
+	_save_profile_button.disabled = _profile_loading or _profile_saving or not _profile_dirty
+	if _profile_saving:
+		_save_profile_button.text = "儲存中..."
+	elif _profile_loading:
+		_save_profile_button.text = "載入中..."
+	else:
+		_save_profile_button.text = "儲存角色資料"
+
+	if _save_profile_hint_label == null:
+		return
+	if _profile_saving:
+		_save_profile_hint_label.text = "正在同步角色資料..."
+	elif _profile_dirty:
+		_save_profile_hint_label.text = "有未儲存的修改。"
+	else:
+		_save_profile_hint_label.text = "資料會同步到帳號。"
+
+
+func _refresh_audio_value_label(bus_key: String) -> void:
+	var slider: HSlider = _audio_sliders.get(bus_key) as HSlider
+	var value_label: Label = _audio_value_labels.get(bus_key) as Label
+	if slider == null or value_label == null:
+		return
+	value_label.text = "%d%%" % int(round(slider.value * 100.0))
+
+
+func _set_gender_value(value: String) -> void:
+	var target_index: int = 0
+	for index: int in range(GENDER_OPTIONS.size()):
+		if str(GENDER_OPTIONS[index].get("value", "")) == value:
+			target_index = index
+			break
+	_gender_option.select(target_index)
+
+
+func _get_selected_gender_value() -> String:
+	var index: int = maxi(0, _gender_option.selected)
+	if index >= GENDER_OPTIONS.size():
+		return "Unspecified"
+	return str(GENDER_OPTIONS[index].get("value", "Unspecified"))
+
+
+func _mark_profile_dirty() -> void:
+	if _applying_profile_form:
+		return
+	_profile_dirty = true
+	_refresh_profile_save_state()
+
+
+func _on_save_profile_pressed() -> void:
+	if _profile_saving:
+		return
+
+	var validation_error: String = _validate_profile_form()
+	if validation_error != "":
+		ToastManager.error("角色資料有誤", validation_error)
+		return
+
+	var payload := {
+		"displayName": _display_name_input.text.strip_edges(),
+		"playerName": _player_name_input.text.strip_edges(),
+		"avatarId": _selected_avatar_id,
+		"bio": _bio_input.text.strip_edges(),
+		"birthday": _birthday_input.text.strip_edges(),
+		"genderType": _get_selected_gender_value(),
+		"region": _region_input.text.strip_edges(),
+	}
+	if str(payload.get("birthday", "")) == "":
+		payload.erase("birthday")
+
+	_profile_saving = true
+	_refresh_profile_save_state()
+	ApiClient.update_profile_me(payload, func(success: bool, data: Variant, error: Dictionary) -> void:
+		_profile_saving = false
+		if not success:
+			_profile_dirty = true
+			_refresh_profile_save_state()
+			ToastManager.error("角色資料儲存失敗", str(error.get("message", "請稍後再試。")))
+			return
+
+		if data is Dictionary:
+			var profile: Dictionary = data as Dictionary
+			GameState.apply_profile_response(profile)
+			_apply_profile_data(profile)
+		ToastManager.success("角色資料已更新")
+	)
+
+
+func _on_redeem_pressed() -> void:
+	if _redeem_in_flight:
+		return
+
+	var code: String = _redeem_input.text.strip_edges()
+	if code == "":
+		ToastManager.error("請輸入兌換碼")
+		return
+
+	_redeem_in_flight = true
+	_redeem_button.disabled = true
+	_redeem_button.text = "兌換中..."
+	ApiClient.redeem_code(code, func(success: bool, data: Variant, error: Dictionary) -> void:
+		_redeem_in_flight = false
+		_redeem_button.disabled = false
+		_redeem_button.text = "兌換"
+		if not success:
+			ToastManager.error("兌換失敗", str(error.get("message", "請稍後再試。")))
+			return
+
+		var response: Dictionary = data if data is Dictionary else {}
+		var wallet_snapshot: Variant = response.get("walletSnapshot", {})
+		if wallet_snapshot is Dictionary:
+			GameState.apply_wallet_snapshot(wallet_snapshot)
+		_redeem_input.text = ""
+		_show_redeem_result(response)
+		ToastManager.success("兌換成功", str(response.get("redeemedCode", "")))
+	)
+
+
+func _show_redeem_result(response: Dictionary) -> void:
+	var lines: Array[String] = []
+	var rewards_variant: Variant = response.get("grantedRewards", [])
+	if rewards_variant is Array:
+		for reward_variant: Variant in rewards_variant:
+			if not (reward_variant is Dictionary):
+				continue
+			var reward: Dictionary = reward_variant
+			var display_name: String = str(reward.get("displayName", reward.get("rewardType", "Reward")))
+			lines.append("%s x%d" % [display_name, int(reward.get("quantity", 0))])
+
+	if lines.is_empty():
+		lines.append("獎勵已發送到帳號。")
+
+	DialogManager.show_info("兌換成功", "\n".join(lines))
+
+
+func _on_audio_slider_changed(bus_key: String, value: float) -> void:
+	ClientSettings.set_volume(bus_key, value)
+	_refresh_audio_value_label(bus_key)
+
+
+func _on_audio_mute_toggled(bus_key: String, pressed: bool) -> void:
+	ClientSettings.set_muted(bus_key, pressed)
+
+
+func _validate_profile_form() -> String:
+	var display_name: String = _display_name_input.text.strip_edges()
+	var player_name: String = _player_name_input.text.strip_edges()
+	var birthday: String = _birthday_input.text.strip_edges()
+	var bio: String = _bio_input.text.strip_edges()
+
+	if display_name == "":
+		return "請填寫暱稱。"
+	if player_name == "":
+		return "請填寫角色名稱。"
+	if bio.length() > 140:
+		return "自介最多 140 字。"
+	if birthday != "" and not _is_valid_birthday_text(birthday):
+		return "生日格式請使用 YYYY-MM-DD。"
 	return ""
 
 
-func _apply_team_update(team_response: Dictionary) -> void:
-	var type_str: String = str(team_response.get("teamType", ""))
-	if type_str == "":
-		return
+func _is_valid_birthday_text(text: String) -> bool:
+	var parts: PackedStringArray = text.split("-")
+	if parts.size() != 3:
+		return false
+	for part: String in parts:
+		if not part.is_valid_int():
+			return false
 
-	GameState.teams_data[type_str] = team_response
-	GameState._save_config_cache("teams", GameState.teams_data.values())
-
-	if type_str == "Boss":
-		GameState.apply_active_team_from_config("Boss")
-
-
-func _restart_home_battle_if_needed(type_key: String) -> void:
-	if type_key != "boss":
-		return
-	var battle_scene: Node = get_tree().get_first_node_in_group("battle_scene")
-	if battle_scene != null and battle_scene.has_method("restart_with_latest_team"):
-		battle_scene.call_deferred("restart_with_latest_team")
-
-
-func _show_skill_popup(cat_file_id: String) -> void:
-	var cat_data: Variant = CatData.from_json_file(cat_file_id + ".json")
-	if cat_data == null:
-		return
-
-	var lines: Array = [str(cat_data.display_name) + UiText.CONFIG_SKILL_DIALOG_SUFFIX]
-
-	for sid: String in cat_data.passive_skill_ids:
-		var passive_skill: Dictionary = CatData._read_skill_json(sid)
-		if passive_skill.is_empty():
-			continue
-		lines.append(UiText.CONFIG_SKILL_PASSIVE_FORMAT % passive_skill.get("display_name", sid))
-		lines.append("  " + str(passive_skill.get("description", "")))
-
-	for active_skill: Dictionary in cat_data.active_skills_data:
-		lines.append(UiText.CONFIG_SKILL_ACTIVE_FORMAT % [
-			active_skill.get("display_name", ""),
-			float(active_skill.get("cooldown", 0.0)),
-		])
-		lines.append("  " + str(active_skill.get("description", "")))
-
-	DialogManager.show_info(UiText.CONFIG_SKILL_DIALOG_TITLE, "\n".join(lines))
-
-
-func _make_separator() -> HSeparator:
-	return HSeparator.new()
-
-
-func _make_chip_style(fill: Color, border: Color, radius: int) -> StyleBoxFlat:
-	var style: StyleBoxFlat = OverlaySceneChrome.make_panel_style(fill, border, radius)
-	style.border_width_left = 1
-	style.border_width_right = 1
-	style.border_width_top = 1
-	style.border_width_bottom = 1
-	return style
-
-
-func _get_next_delay_value(current_delay: float) -> float:
-	var current_seconds: int = maxi(0, int(round(current_delay)))
-	return float((current_seconds + 1) % 10)
-
-
-func _format_delay_label(delay_seconds: float) -> String:
-	var seconds: int = maxi(0, int(round(delay_seconds)))
-	return str(seconds) + "秒"
-
-
-func _get_cat_visual_fallback(cat_name: String) -> String:
-	var trimmed: String = cat_name.strip_edges()
-	if trimmed == "":
-		return "?"
-	return trimmed.substr(0, 1)
-
-
-func _get_max_team_size() -> int:
-	match _current_team_type:
-		"boss":
-			return int(GameState.boss_config.get("max_team_size", 5))
-		"dungeon":
-			return int(GameState.dungeon_config.get("max_team_size", 5))
-		"arena_attack", "arena_defense":
-			return int(GameState.arena_config.get("max_team_size", 5))
-	return 5
+	var year: int = int(parts[0])
+	var month: int = int(parts[1])
+	var day: int = int(parts[2])
+	if year < 1900 or year > 3000:
+		return false
+	if month < 1 or month > 12:
+		return false
+	if day < 1 or day > 31:
+		return false
+	return true
 
 
 func _on_back_pressed() -> void:
-	var boss_team: Dictionary = GameState.get_team("Boss")
-	var boss_members: Array = boss_team.get("members", [])
-	GameState.player_team = boss_members.map(func(member: Dictionary) -> int:
-		return int(member.get("playerCatId", 0))
-	)
 	SceneNavigator.return_to_battle()

--- a/scripts/data/player_data.gd
+++ b/scripts/data/player_data.gd
@@ -14,6 +14,12 @@ var account: String = ""
 var display_name: String = ""
 var player_public_id: String = ""
 var player_name: String = ""
+var avatar_id: String = "black_cat"
+var bio: String = ""
+var birthday: String = ""
+var gender_type: String = "Unspecified"
+var region: String = ""
+var linked_providers: Array = []
 
 var total_pulls: int = 0
 var free_pull_count: int = 1
@@ -79,6 +85,12 @@ static func _from_dict(data: Dictionary) -> PlayerData:
 	p.display_name = data.get("display_name", "")
 	p.player_public_id = data.get("player_public_id", "")
 	p.player_name = data.get("player_name", "")
+	p.avatar_id = data.get("avatar_id", "black_cat")
+	p.bio = data.get("bio", "")
+	p.birthday = data.get("birthday", "")
+	p.gender_type = data.get("gender_type", "Unspecified")
+	p.region = data.get("region", "")
+	p.linked_providers = data.get("linked_providers", [])
 	p.cat_food = data.get("cat_food", 0)
 	p.special_cat_food = data.get("special_cat_food", 0)
 	p.gold = data.get("gold", 0)
@@ -130,6 +142,12 @@ func _to_dict() -> Dictionary:
 		"display_name": display_name,
 		"player_public_id": player_public_id,
 		"player_name": player_name,
+		"avatar_id": avatar_id,
+		"bio": bio,
+		"birthday": birthday,
+		"gender_type": gender_type,
+		"region": region,
+		"linked_providers": linked_providers,
 		"cat_food": cat_food,
 		"special_cat_food": special_cat_food,
 		"gold": gold,

--- a/scripts/gamestate/ClientSettings.gd
+++ b/scripts/gamestate/ClientSettings.gd
@@ -1,0 +1,101 @@
+extends Node
+
+const SAVE_PATH := "user://client_settings.json"
+const DEFAULT_SETTINGS := {
+	"masterVolume": 1.0,
+	"bgmVolume": 0.72,
+	"sfxVolume": 0.9,
+	"masterMuted": false,
+	"bgmMuted": false,
+	"sfxMuted": false,
+}
+
+signal settings_changed(settings: Dictionary)
+
+var _settings: Dictionary = DEFAULT_SETTINGS.duplicate(true)
+
+
+func _ready() -> void:
+	_load_settings()
+	UiAudio.ensure_audio_buses()
+	UiAudio.apply_settings(_settings)
+
+
+func get_settings() -> Dictionary:
+	return _settings.duplicate(true)
+
+
+func get_setting(key: String) -> Variant:
+	return _settings.get(key, DEFAULT_SETTINGS.get(key))
+
+
+func set_setting(key: String, value: Variant) -> void:
+	if not DEFAULT_SETTINGS.has(key):
+		return
+
+	var normalized: Variant = _normalize_value(key, value)
+	if _settings.has(key) and _values_match(_settings[key], normalized):
+		return
+
+	_settings[key] = normalized
+	_save_settings()
+	UiAudio.apply_settings(_settings)
+	settings_changed.emit(get_settings())
+
+
+func set_volume(bus_key: String, value: float) -> void:
+	set_setting("%sVolume" % bus_key, clampf(value, 0.0, 1.0))
+
+
+func set_muted(bus_key: String, muted: bool) -> void:
+	set_setting("%sMuted" % bus_key, muted)
+
+
+func _load_settings() -> void:
+	if not FileAccess.file_exists(SAVE_PATH):
+		return
+
+	var file := FileAccess.open(SAVE_PATH, FileAccess.READ)
+	if file == null:
+		push_error("ClientSettings: failed to open save file")
+		return
+
+	var json := JSON.new()
+	var parse_result: int = json.parse(file.get_as_text())
+	file.close()
+	if parse_result != OK:
+		push_error("ClientSettings: failed to parse save file")
+		return
+
+	var payload: Variant = json.get_data()
+	if not (payload is Dictionary):
+		return
+
+	var data: Dictionary = payload
+	for key: String in DEFAULT_SETTINGS.keys():
+		if not data.has(key):
+			continue
+		_settings[key] = _normalize_value(key, data.get(key))
+
+
+func _save_settings() -> void:
+	var file := FileAccess.open(SAVE_PATH, FileAccess.WRITE)
+	if file == null:
+		push_error("ClientSettings: failed to open save file")
+		return
+	file.store_string(JSON.stringify(_settings, "\t"))
+	file.close()
+
+
+func _normalize_value(key: String, value: Variant) -> Variant:
+	match key:
+		"masterMuted", "bgmMuted", "sfxMuted":
+			return bool(value)
+		_:
+			return clampf(float(value), 0.0, 1.0)
+
+
+func _values_match(left: Variant, right: Variant) -> bool:
+	if typeof(left) == TYPE_FLOAT or typeof(right) == TYPE_FLOAT:
+		return is_equal_approx(float(left), float(right))
+	return left == right

--- a/scripts/gamestate/GameState.gd
+++ b/scripts/gamestate/GameState.gd
@@ -18,6 +18,8 @@ signal chat_connection_state_changed(state: String)
 signal chat_messages_changed(channel_key: String)
 signal chat_unread_changed(channel_key: String, count: int)
 signal party_cheer_coupon_count_changed(count: int)
+signal player_profile_changed
+signal player_wallet_changed
 
 # Primary player state and runtime caches.
 var player_data: PlayerData
@@ -159,6 +161,21 @@ func apply_player_bootstrap(data: Dictionary) -> void:
 	player_data.display_name = data.get("displayName") if data.get("displayName") != null else player_data.display_name
 	player_data.player_public_id = data.get("playerPublicId") if data.get("playerPublicId") != null else player_data.player_public_id
 	player_data.player_name = data.get("playerName") if data.get("playerName") != null else player_data.player_name
+	if data.has("avatarId"):
+		player_data.avatar_id = "" if data.get("avatarId") == null else str(data.get("avatarId", player_data.avatar_id)).strip_edges()
+	if player_data.avatar_id == "":
+		player_data.avatar_id = AssetResolver.DEFAULT_PROFILE_AVATAR_ID
+	if data.has("bio"):
+		player_data.bio = "" if data.get("bio") == null else str(data.get("bio", player_data.bio))
+	if data.has("birthday"):
+		player_data.birthday = "" if data.get("birthday") == null else str(data.get("birthday", player_data.birthday))
+	if data.has("genderType"):
+		player_data.gender_type = "Unspecified" if data.get("genderType") == null else str(data.get("genderType", player_data.gender_type))
+	if data.has("region"):
+		player_data.region = "" if data.get("region") == null else str(data.get("region", player_data.region))
+	if data.has("linkedProviders"):
+		var linked_providers_variant: Variant = data.get("linkedProviders", [])
+		player_data.linked_providers = (linked_providers_variant as Array).duplicate() if linked_providers_variant is Array else []
 	player_data.cat_food = int(data.get("catFood", player_data.cat_food))
 	player_data.special_cat_food = int(data.get("specialCatFood", player_data.special_cat_food))
 	player_data.gold = int(data.get("gold", player_data.gold))
@@ -281,6 +298,58 @@ func apply_player_bootstrap(data: Dictionary) -> void:
 	var chat_summary_variant: Variant = data.get("chatSummary", {})
 	if chat_summary_variant is Dictionary:
 		apply_chat_summary(chat_summary_variant)
+	player_profile_changed.emit()
+	player_wallet_changed.emit()
+
+
+func apply_profile_response(data: Dictionary) -> void:
+	if player_data == null:
+		player_data = PlayerData.load_or_default()
+
+	if data.get("account") != null:
+		player_data.account = str(data.get("account", player_data.account))
+	if data.get("displayName") != null:
+		player_data.display_name = str(data.get("displayName", player_data.display_name))
+	if data.get("playerPublicId") != null:
+		player_data.player_public_id = str(data.get("playerPublicId", player_data.player_public_id))
+	if data.get("playerName") != null:
+		player_data.player_name = str(data.get("playerName", player_data.player_name))
+	if data.has("avatarId"):
+		player_data.avatar_id = "" if data.get("avatarId") == null else str(data.get("avatarId", player_data.avatar_id)).strip_edges()
+	if player_data.avatar_id == "":
+		player_data.avatar_id = AssetResolver.DEFAULT_PROFILE_AVATAR_ID
+	if data.has("bio"):
+		player_data.bio = "" if data.get("bio") == null else str(data.get("bio", player_data.bio))
+	if data.has("birthday"):
+		player_data.birthday = "" if data.get("birthday") == null else str(data.get("birthday", player_data.birthday))
+	if data.has("genderType"):
+		player_data.gender_type = "Unspecified" if data.get("genderType") == null else str(data.get("genderType", player_data.gender_type))
+	if data.has("region"):
+		player_data.region = "" if data.get("region") == null else str(data.get("region", player_data.region))
+	if data.has("linkedProviders"):
+		var linked_providers_variant: Variant = data.get("linkedProviders", [])
+		player_data.linked_providers = (linked_providers_variant as Array).duplicate() if linked_providers_variant is Array else []
+
+	player_data.save()
+	player_profile_changed.emit()
+
+
+func get_profile_avatar_id() -> String:
+	if player_data == null:
+		return AssetResolver.DEFAULT_PROFILE_AVATAR_ID
+	var avatar_id: String = player_data.avatar_id.strip_edges()
+	return avatar_id if avatar_id != "" else AssetResolver.DEFAULT_PROFILE_AVATAR_ID
+
+
+func get_profile_display_name() -> String:
+	if player_data == null:
+		return "Scooper"
+	var profile_name: String = player_data.display_name.strip_edges()
+	if profile_name.is_empty():
+		profile_name = player_data.player_name.strip_edges()
+	if profile_name.is_empty():
+		profile_name = "Scooper"
+	return profile_name
 
 
 func _save_auth_session() -> void:
@@ -630,6 +699,7 @@ func update_scooper_profile(data: Dictionary) -> void:
 	player_data.party_cheer_coupon_count = int(scooper_profile_data.get("partyCheerCouponCount", player_data.party_cheer_coupon_count))
 	player_data.save()
 	party_cheer_coupon_count_changed.emit(player_data.party_cheer_coupon_count)
+	player_wallet_changed.emit()
 
 
 func get_party_cheer_coupon_count() -> int:
@@ -723,6 +793,7 @@ func apply_wallet_snapshot(data: Dictionary) -> void:
 	player_data.memory_shards = int(data.get("memoryShards", player_data.memory_shards))
 	player_data.whisker_shards = int(data.get("whiskerShards", player_data.whisker_shards))
 	player_data.save()
+	player_wallet_changed.emit()
 
 
 func apply_idle_claim_response(data: Dictionary) -> void:

--- a/scripts/lineup/LineupConstants.gd
+++ b/scripts/lineup/LineupConstants.gd
@@ -1,4 +1,4 @@
-class_name ConfigConstants
+class_name LineupConstants
 
 ## ConfigScene 共用常數：尺寸、隊伍類型、標籤、貓咪檔案對映
 

--- a/scripts/lineup/LineupScene.gd
+++ b/scripts/lineup/LineupScene.gd
@@ -1,0 +1,890 @@
+extends Control
+
+const Constants = preload("res://scripts/lineup/LineupConstants.gd")
+const AssetResolver = preload("res://scripts/ui/asset_resolver.gd")
+const SceneSubmenuBar = preload("res://scripts/ui/scene_submenu_bar.gd")
+const CatRosterCard = preload("res://scripts/ui/cat_roster_card.gd")
+
+const DANGER_BUTTON_COLOR := Color(0.94, 0.48, 0.42, 1.0)
+const MUTED_TEXT_COLOR := Color(0.90, 0.88, 0.82, 0.92)
+const DISABLED_TEXT_COLOR := Color(0.70, 0.70, 0.72, 0.92)
+const EMPTY_SLOT_TEXT_COLOR := Color(0.75, 0.70, 0.62, 0.9)
+const SLOT_IMAGE_BG := Color(0.24, 0.20, 0.16, 0.96)
+const SLOT_IMAGE_BORDER := Color(0.98, 0.84, 0.54, 0.95)
+const SLOT_DELAY_BG := Color(0.18, 0.12, 0.08, 0.94)
+const SLOT_HOLD_SECONDS := 0.4
+const SLOT_EMPTY_FILL := Color(0.20, 0.18, 0.16, 0.88)
+const SLOT_EMPTY_BORDER := Color(0.62, 0.54, 0.40, 0.78)
+const SLOT_NAME_COLOR := Color(0.98, 0.95, 0.88, 1.0)
+const SLOT_META_COLOR := Color(0.88, 0.80, 0.67, 0.92)
+const SLOT_REMOVE_BG := Color(0.56, 0.18, 0.18, 0.96)
+const CAT_CARD_HOLD_SECONDS := 2.0
+
+var _current_team_type: String = "boss"
+var _api_in_flight: bool = false
+
+var _team_type_btns: Dictionary = {}
+var _page_title: Label
+var _team_summary_label: Label
+var _team_container: GridContainer
+var _cats_title: Label
+var _cats_sort_btns: Dictionary = {}
+var _cats_scroll: ScrollContainer
+var _cats_container: GridContainer
+var _save_team_btn: Button
+var _cats_scroller: InertialScroller
+
+var _team_drafts: Dictionary = {}
+var _team_dirty: Dictionary = {}
+var _cats_sort_mode: String = "level"
+
+
+func _ready() -> void:
+	_build_ui()
+
+
+func _build_ui() -> void:
+	var bg: Control = AssetResolver.make_fullscreen_background("config")
+	add_child(bg)
+
+	var dim: ColorRect = ColorRect.new()
+	dim.color = Color(0.04, 0.03, 0.05, 0.34)
+	dim.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	add_child(dim)
+
+	var content_panel: PanelContainer = PanelContainer.new()
+	content_panel.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	content_panel.offset_left = 20.0
+	content_panel.offset_top = OverlaySceneChrome.CONTENT_TOP_GAP
+	content_panel.offset_right = -20.0
+	content_panel.offset_bottom = -(OverlaySceneChrome.HOME_MAIN_NAV_H + OverlaySceneChrome.BOTTOM_DOCK_H + 12.0)
+	content_panel.add_theme_stylebox_override("panel", OverlaySceneChrome.make_panel_style(OverlaySceneChrome.PANEL_FILL, OverlaySceneChrome.PANEL_BORDER, 18))
+	add_child(content_panel)
+
+	var content_margin: MarginContainer = OverlaySceneChrome.make_content_margin(18)
+	content_panel.add_child(content_margin)
+
+	var content_vbox: VBoxContainer = VBoxContainer.new()
+	content_vbox.add_theme_constant_override("separation", 14)
+	content_margin.add_child(content_vbox)
+
+	_page_title = Label.new()
+	_page_title.text = UiText.CONFIG_PAGE_TITLE
+	_page_title.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_DISPLAY)
+	content_vbox.add_child(_page_title)
+
+	var page_desc: Label = Label.new()
+	page_desc.text = UiText.CONFIG_PAGE_DESC
+	page_desc.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	page_desc.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY)
+	page_desc.add_theme_color_override("font_color", MUTED_TEXT_COLOR)
+	content_vbox.add_child(page_desc)
+
+	var main_split: VBoxContainer = VBoxContainer.new()
+	main_split.add_theme_constant_override("separation", 12)
+	main_split.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	content_vbox.add_child(main_split)
+
+	var team_panel: PanelContainer = OverlaySceneChrome.make_card_panel()
+	team_panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	team_panel.size_flags_vertical = 0
+	main_split.add_child(team_panel)
+
+	var team_margin: MarginContainer = OverlaySceneChrome.make_content_margin(14)
+	team_panel.add_child(team_margin)
+
+	var team_vbox: VBoxContainer = VBoxContainer.new()
+	team_vbox.add_theme_constant_override("separation", 10)
+	team_vbox.size_flags_vertical = 0
+	team_margin.add_child(team_vbox)
+
+	_team_summary_label = Label.new()
+	_team_summary_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_team_summary_label.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+	_team_summary_label.add_theme_color_override("font_color", MUTED_TEXT_COLOR)
+	_team_summary_label.visible = false
+	team_vbox.add_child(_team_summary_label)
+
+	_team_container = GridContainer.new()
+	_team_container.columns = 5
+	_team_container.add_theme_constant_override("separation", 6)
+	_team_container.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_team_container.size_flags_vertical = 0
+	team_vbox.add_child(_team_container)
+
+	_save_team_btn = Button.new()
+	_save_team_btn.text = UiText.CONFIG_SAVE_BUTTON
+	_save_team_btn.custom_minimum_size = Vector2(0.0, 52.0)
+	_save_team_btn.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY_LG)
+	_save_team_btn.pressed.connect(_on_save_team_pressed)
+	UiPalette.apply_button_kind(_save_team_btn, "confirm")
+	team_vbox.add_child(_save_team_btn)
+
+	var cats_panel: PanelContainer = OverlaySceneChrome.make_card_panel()
+	cats_panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	cats_panel.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	cats_panel.size_flags_stretch_ratio = 1.05
+	main_split.add_child(cats_panel)
+
+	var cats_margin: MarginContainer = OverlaySceneChrome.make_content_margin(14)
+	cats_panel.add_child(cats_margin)
+
+	var cats_vbox: VBoxContainer = VBoxContainer.new()
+	cats_vbox.add_theme_constant_override("separation", 10)
+	cats_margin.add_child(cats_vbox)
+
+	var cats_header: HBoxContainer = HBoxContainer.new()
+	cats_header.add_theme_constant_override("separation", 8)
+	cats_vbox.add_child(cats_header)
+
+	_cats_title = Label.new()
+	_cats_title.text = UiText.CONFIG_OWNED_CATS_TITLE
+	_cats_title.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_HEADING)
+	_cats_title.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	cats_header.add_child(_cats_title)
+
+	var sort_row: HBoxContainer = HBoxContainer.new()
+	sort_row.add_theme_constant_override("separation", 6)
+	cats_header.add_child(sort_row)
+
+	for sort_key: String in ["level", "rank"]:
+		var sort_btn: Button = Button.new()
+		sort_btn.text = UiText.CONFIG_SORT_LEVEL if sort_key == "level" else UiText.CONFIG_SORT_RANK
+		sort_btn.custom_minimum_size = Vector2(64.0, 28.0)
+		sort_btn.add_theme_font_size_override("font_size", 13)
+		sort_btn.pressed.connect(func() -> void:
+			_set_cats_sort_mode(sort_key)
+		)
+		sort_row.add_child(sort_btn)
+		_cats_sort_btns[sort_key] = sort_btn
+
+	_cats_scroll = ScrollContainer.new()
+	_cats_scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	_cats_scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+	cats_vbox.add_child(_cats_scroll)
+
+	_cats_container = GridContainer.new()
+	_cats_container.columns = 3
+	_cats_container.add_theme_constant_override("separation", 12)
+	_cats_container.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_cats_scroll.add_child(_cats_container)
+	_cats_scroller = InertialScroller.attach(_cats_scroll, "vertical")
+
+	var submenu_items: Array = []
+	for type_key: String in ["boss", "dungeon", "arena_attack", "arena_defense"]:
+		submenu_items.append({
+			"key": type_key,
+			"label": str(Constants.TEAM_LABELS[type_key]),
+		})
+	var submenu: Dictionary = SceneSubmenuBar.build(self, {
+		"items": submenu_items,
+		"active_key": _current_team_type,
+		"back_label": UiText.CONFIG_BACK,
+		"back_pressed": Callable(self, "_on_back_pressed"),
+		"button_pressed": Callable(self, "_switch_team_type"),
+		"panel_fill": OverlaySceneChrome.PANEL_FILL,
+		"panel_border": OverlaySceneChrome.PANEL_BORDER,
+		"top": -(OverlaySceneChrome.HOME_MAIN_NAV_H + OverlaySceneChrome.BOTTOM_DOCK_H),
+		"bottom": -OverlaySceneChrome.HOME_MAIN_NAV_H,
+	})
+	_team_type_btns = submenu.get("buttons", {})
+
+	_switch_team_type("boss")
+
+
+func _switch_team_type(type_key: String) -> void:
+	_ensure_team_draft(type_key)
+	_current_team_type = type_key
+
+	SceneSubmenuBar.refresh(_team_type_btns, type_key, {
+		"active_color": SceneMenuTheme.ACTIVE_COLOR,
+		"inactive_color": SceneMenuTheme.INACTIVE_COLOR,
+	})
+
+	_refresh_team()
+	_refresh_cats_list()
+	_update_team_title()
+	_update_save_section()
+	_refresh_cats_sort_buttons()
+
+
+func _get_team_type_key(type_key: String = "") -> String:
+	if type_key == "":
+		type_key = _current_team_type
+	return str(Constants.TEAM_TYPE_MAP.get(type_key, "Boss"))
+
+
+func _get_editing_team_members() -> Array:
+	_ensure_team_draft(_current_team_type)
+	var team: Dictionary = _team_drafts[_current_team_type]
+	return team.get("members", [])
+
+
+func _get_filled_editing_team_members() -> Array:
+	var filled: Array = []
+	for member_variant: Variant in _get_editing_team_members():
+		if member_variant is Dictionary and not (member_variant as Dictionary).is_empty():
+			filled.append(member_variant)
+	return filled
+
+
+func _ensure_team_draft(type_key: String) -> void:
+	if _team_drafts.has(type_key):
+		return
+	_reset_team_draft(type_key, GameState.get_team(_get_team_type_key(type_key)))
+
+
+func _reset_team_draft(type_key: String, source_team: Dictionary) -> void:
+	var draft: Dictionary = source_team.duplicate(true)
+	draft["teamType"] = _get_team_type_key(type_key)
+	draft["members"] = _normalize_members(draft.get("members", []), type_key)
+	_team_drafts[type_key] = draft
+	_team_dirty[type_key] = false
+
+
+func _normalize_members(members: Array, type_key: String = "") -> Array:
+	if type_key == "":
+		type_key = _current_team_type
+	var max_count: int = _get_max_team_size_for(type_key)
+	var normalized: Array = []
+	normalized.resize(max_count)
+	for index: int in range(max_count):
+		normalized[index] = {}
+
+	for member_variant: Variant in members:
+		if member_variant is Dictionary and (member_variant as Dictionary).is_empty():
+			continue
+		if not (member_variant is Dictionary):
+			continue
+
+		var member: Dictionary = (member_variant as Dictionary).duplicate(true)
+		var slot_no: int = int(member.get("slotNo", -1))
+		if slot_no < 0 or slot_no >= max_count:
+			slot_no = _find_first_empty_slot_index(normalized)
+			if slot_no < 0:
+				continue
+
+		member["slotNo"] = slot_no
+		member["initialDelaySeconds"] = float(member.get("initialDelaySeconds", 0.0))
+		normalized[slot_no] = member
+	return normalized
+
+
+func _find_first_empty_slot_index(members: Array) -> int:
+	for index: int in range(members.size()):
+		var slot_variant: Variant = members[index]
+		if slot_variant is Dictionary and (slot_variant as Dictionary).is_empty():
+			return index
+	return -1
+
+
+func _get_max_team_size_for(type_key: String) -> int:
+	match type_key:
+		"boss":
+			return int(GameState.boss_config.get("max_team_size", 5))
+		"dungeon":
+			return int(GameState.dungeon_config.get("max_team_size", 5))
+		"arena_attack", "arena_defense":
+			return int(GameState.arena_config.get("max_team_size", 5))
+	return 5
+
+
+func _is_current_team_dirty() -> bool:
+	return bool(_team_dirty.get(_current_team_type, false))
+
+
+func _mark_current_team_dirty() -> void:
+	_team_dirty[_current_team_type] = true
+	_update_save_section()
+
+
+func _update_team_title() -> void:
+	var mode_label: String = str(Constants.TEAM_LABELS.get(_current_team_type, _current_team_type))
+	var members: Array = _get_filled_editing_team_members()
+	var max_count: int = _get_max_team_size()
+	var title_text: String = UiText.CONFIG_TEAM_TITLE_FORMAT % [mode_label, members.size(), max_count]
+	_page_title.text = title_text
+
+	_team_summary_label.text = UiText.CONFIG_TEAM_SUMMARY_WITH_DELAY
+
+
+func _refresh_team() -> void:
+	for child: Node in _team_container.get_children():
+		child.queue_free()
+
+	var members: Array = _get_editing_team_members()
+	var max_count: int = _get_max_team_size()
+	_team_container.columns = maxi(1, max_count)
+	for i: int in range(max_count):
+		var member: Dictionary = members[i] if i < members.size() else {}
+		_team_container.add_child(_make_team_slot_card(i, member))
+
+	_update_team_title()
+	_update_save_section()
+
+
+func _make_team_slot_card(slot_index: int, member: Dictionary) -> PanelContainer:
+	var is_filled: bool = not member.is_empty()
+	var card: PanelContainer = OverlaySceneChrome.make_card_panel(OverlaySceneChrome.PANEL_BORDER if is_filled else SLOT_EMPTY_BORDER)
+	card.custom_minimum_size = Vector2(0.0, 166.0)
+	card.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	var margin: MarginContainer = OverlaySceneChrome.make_content_margin(4)
+	card.add_child(margin)
+
+	var column: VBoxContainer = VBoxContainer.new()
+	column.add_theme_constant_override("separation", 4)
+	margin.add_child(column)
+
+	var cat_name: String = str(member.get("catDisplayName", "")) if is_filled else UiText.CONFIG_EMPTY_SLOT
+	var cat_catalog_id: int = int(member.get("catCatalogId", 0)) if is_filled else 0
+	var delay_seconds: float = float(member.get("initialDelaySeconds", 0.0)) if is_filled else 0.0
+	var cat_file_id: String = GameState.get_cat_file_id_by_catalog_id(cat_catalog_id) if is_filled else ""
+
+	var top_row: HBoxContainer = HBoxContainer.new()
+	top_row.add_theme_constant_override("separation", 4)
+	column.add_child(top_row)
+
+	var slot_badge: Label = Label.new()
+	slot_badge.text = UiText.CONFIG_SLOT_BADGE_FORMAT % [slot_index + 1]
+	slot_badge.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_TINY)
+	slot_badge.add_theme_color_override("font_color", Color(0.98, 0.90, 0.72, 1.0))
+	top_row.add_child(slot_badge)
+
+	var top_name: Label = Label.new()
+	top_name.text = cat_name if is_filled else UiText.CONFIG_TEAM_SLOT_EMPTY_NAME
+	top_name.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	top_name.clip_text = true
+	top_name.add_theme_font_size_override("font_size", 17)
+	top_name.add_theme_color_override("font_color", SLOT_NAME_COLOR if is_filled else EMPTY_SLOT_TEXT_COLOR)
+	top_row.add_child(top_name)
+
+	var image_shell: PanelContainer = PanelContainer.new()
+	image_shell.custom_minimum_size = Vector2(0.0, 96.0)
+	image_shell.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	image_shell.add_theme_stylebox_override("panel", OverlaySceneChrome.make_panel_style(SLOT_IMAGE_BG if is_filled else SLOT_EMPTY_FILL, SLOT_IMAGE_BORDER if is_filled else SLOT_EMPTY_BORDER, 14))
+	image_shell.mouse_filter = Control.MOUSE_FILTER_STOP
+	column.add_child(image_shell)
+
+	var image_button: Button = Button.new()
+	image_button.flat = true
+	image_button.text = UiText.CONFIG_EMPTY_SLOT_ICON if not is_filled else ""
+	image_button.custom_minimum_size = Vector2(0.0, 96.0)
+	image_button.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	image_button.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	image_button.clip_text = true
+	image_button.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_DISPLAY)
+	image_button.add_theme_color_override("font_color", EMPTY_SLOT_TEXT_COLOR)
+	image_shell.add_child(image_button)
+
+	var overlay_root: Control = Control.new()
+	overlay_root.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	overlay_root.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	image_shell.add_child(overlay_root)
+
+	var image_margin: MarginContainer = OverlaySceneChrome.make_content_margin(4)
+	image_margin.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	image_margin.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	overlay_root.add_child(image_margin)
+
+	var icon_holder: CenterContainer = CenterContainer.new()
+	icon_holder.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	image_margin.add_child(icon_holder)
+
+	var team_icon: Texture2D = AssetResolver.resolve_cat_showcase_art(cat_file_id)
+	if team_icon != null:
+		icon_holder.add_child(AssetResolver.create_icon_rect(team_icon, Vector2(72.0, 72.0)))
+	elif is_filled:
+		var fallback_name: Label = Label.new()
+		fallback_name.text = _get_cat_visual_fallback(cat_name)
+		fallback_name.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+		fallback_name.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+		fallback_name.add_theme_font_size_override("font_size", 30)
+		fallback_name.add_theme_color_override("font_color", SLOT_NAME_COLOR)
+		icon_holder.add_child(fallback_name)
+
+	if is_filled:
+		var remove_btn: Button = Button.new()
+		remove_btn.text = "－"
+		remove_btn.custom_minimum_size = Vector2(22.0, 22.0)
+		remove_btn.add_theme_font_size_override("font_size", 11)
+		remove_btn.add_theme_color_override("font_color", Color(1.0, 0.97, 0.95, 1.0))
+		remove_btn.anchor_left = 1.0
+		remove_btn.anchor_top = 0.0
+		remove_btn.anchor_right = 1.0
+		remove_btn.anchor_bottom = 0.0
+		remove_btn.offset_left = -20.0
+		remove_btn.offset_top = -10.0
+		remove_btn.offset_right = 2.0
+		remove_btn.offset_bottom = 12.0
+		remove_btn.disabled = _api_in_flight
+		var remove_style: StyleBoxFlat = StyleBoxFlat.new()
+		remove_style.bg_color = SLOT_REMOVE_BG
+		remove_style.corner_radius_top_left = 999
+		remove_style.corner_radius_top_right = 999
+		remove_style.corner_radius_bottom_left = 999
+		remove_style.corner_radius_bottom_right = 999
+		remove_style.border_width_left = 1
+		remove_style.border_width_right = 1
+		remove_style.border_width_top = 1
+		remove_style.border_width_bottom = 1
+		remove_style.border_color = Color(1.0, 0.82, 0.78, 0.95)
+		remove_btn.add_theme_stylebox_override("normal", remove_style)
+		var remove_hover: StyleBoxFlat = remove_style.duplicate()
+		remove_hover.bg_color = SLOT_REMOVE_BG.lightened(0.08)
+		var remove_pressed: StyleBoxFlat = remove_style.duplicate()
+		remove_pressed.bg_color = SLOT_REMOVE_BG.darkened(0.08)
+		remove_btn.add_theme_stylebox_override("hover", remove_hover)
+		remove_btn.add_theme_stylebox_override("pressed", remove_pressed)
+		if not _api_in_flight:
+			remove_btn.pressed.connect(func() -> void:
+				_remove_member_from_draft(slot_index)
+			)
+		overlay_root.add_child(remove_btn)
+
+	image_button.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	if is_filled and cat_file_id != "":
+		image_shell.gui_input.connect(func(event: InputEvent) -> void:
+			if not (event is InputEventMouseButton):
+				return
+			var mouse_event: InputEventMouseButton = event as InputEventMouseButton
+			if not mouse_event.pressed or mouse_event.button_index != MOUSE_BUTTON_LEFT:
+				return
+			_show_skill_popup(cat_file_id)
+			image_shell.accept_event()
+		)
+	else:
+		image_button.disabled = true
+
+	var delay_button: Button = Button.new()
+	delay_button.text = UiText.CONFIG_DELAY_BUTTON_FORMAT % [_format_delay_label(delay_seconds)] if is_filled else UiText.CONFIG_DELAY_BUTTON_EMPTY
+	delay_button.custom_minimum_size = Vector2(0.0, 24.0)
+	delay_button.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	delay_button.add_theme_font_size_override("font_size", 13)
+	delay_button.disabled = not is_filled or _api_in_flight
+	UiPalette.apply_button_palette(delay_button, SLOT_DELAY_BG, Color(0.98, 0.90, 0.72, 1.0))
+	if is_filled and not _api_in_flight:
+		delay_button.pressed.connect(func() -> void:
+			_update_member_delay_in_draft(slot_index, _get_next_delay_value(delay_seconds))
+		)
+	column.add_child(delay_button)
+
+	return card
+
+
+func _refresh_cats_list() -> void:
+	for child: Node in _cats_container.get_children():
+		child.queue_free()
+
+	var in_team_ids: Array = _get_editing_team_members().map(func(member: Dictionary) -> int:
+		return int(member.get("playerCatId", 0))
+	)
+	in_team_ids = in_team_ids.filter(func(id: int) -> bool:
+		return id > 0
+	)
+	var owned_cats: Array = _get_sorted_owned_cats()
+	for cat_variant: Variant in owned_cats:
+		if cat_variant is Dictionary:
+			_cats_container.add_child(_make_cat_card(cat_variant as Dictionary, in_team_ids))
+
+
+func _make_cat_card(cat: Dictionary, in_team_ids: Array) -> PanelContainer:
+	var player_cat_id: int = int(cat.get("playerCatId", 0))
+	var display_name: String = str(cat.get("displayName", ""))
+	var lv: int = int(cat.get("catFoodLevel", 1))
+	var rank: int = int(cat.get("rank", 0))
+	var cat_catalog_id: int = int(cat.get("catCatalogId", 0))
+	var already_in: bool = player_cat_id in in_team_ids
+	var team_full: bool = _get_filled_editing_team_members().size() >= _get_max_team_size()
+	var action_disabled: bool = (not already_in and team_full) or _api_in_flight
+
+	var local_cat_id: String = GameState.get_cat_file_id_by_catalog_id(cat_catalog_id)
+	var cat_icon: Texture2D = AssetResolver.resolve_cat_showcase_art(local_cat_id)
+	var hold_timer: Timer = Timer.new()
+	hold_timer.one_shot = true
+	hold_timer.wait_time = CAT_CARD_HOLD_SECONDS
+	var pointer_down: Array[bool] = [false]
+	var long_press_triggered: Array[bool] = [false]
+	hold_timer.timeout.connect(func() -> void:
+		if not pointer_down[0]:
+			return
+		if local_cat_id == "":
+			return
+		if _cats_scroller != null and _cats_scroller.consume_moved():
+			return
+		long_press_triggered[0] = true
+		_show_skill_popup(local_cat_id)
+	)
+
+	var whole_card_gui_input: Callable = func(event: InputEvent) -> void:
+		if not (event is InputEventMouseButton):
+			return
+		var mouse_event: InputEventMouseButton = event as InputEventMouseButton
+		if mouse_event.button_index != MOUSE_BUTTON_LEFT:
+			return
+		if mouse_event.pressed:
+			pointer_down[0] = true
+			long_press_triggered[0] = false
+			if local_cat_id != "":
+				hold_timer.start()
+			return
+
+		var was_pressed: bool = pointer_down[0]
+		pointer_down[0] = false
+		hold_timer.stop()
+		if not was_pressed:
+			return
+		if _cats_scroller != null and _cats_scroller.consume_moved():
+			return
+		if long_press_triggered[0]:
+			long_press_triggered[0] = false
+			return
+		if action_disabled:
+			return
+		_toggle_member_in_draft(player_cat_id)
+
+	var card: PanelContainer = CatRosterCard.build({
+		"is_selected": already_in,
+		"title_text": display_name,
+		"show_title": false,
+		"icon_texture": cat_icon,
+		"fallback_text": _get_cat_visual_fallback(display_name),
+		"chips": [
+			UiText.CONFIG_CAT_LEVEL_ONLY_FORMAT % [lv],
+			UiText.CONFIG_CAT_STARS_FORMAT % [rank],
+		],
+		"show_action": false,
+		"whole_card_gui_input": whole_card_gui_input,
+		"card_height": 228.0,
+		"art_height": 108.0,
+		"icon_size": Vector2(84.0, 84.0),
+		"card_fill": OverlaySceneChrome.CARD_FILL,
+		"card_border": OverlaySceneChrome.CARD_BORDER,
+		"selected_card_border": OverlaySceneChrome.PANEL_BORDER,
+		"selected_card_fill": Color(0.24, 0.20, 0.13, 0.98),
+		"art_fill": Color(0.19, 0.17, 0.15, 0.96),
+		"art_border": Color(0.90, 0.77, 0.46, 0.88),
+		"selected_art_border": Color(0.90, 0.77, 0.46, 0.88),
+		"selected_art_fill": Color(0.26, 0.21, 0.14, 0.98),
+		"title_color": SLOT_NAME_COLOR,
+		"selected_chip_fill": Color(0.42, 0.29, 0.14, 0.98),
+		"selected_chip_border": Color(0.98, 0.83, 0.48, 1.0),
+		"selected_chip_text_color": Color(1.0, 0.97, 0.86, 1.0),
+	})
+	card.add_child(hold_timer)
+	return card
+
+
+func _set_cats_sort_mode(sort_mode: String) -> void:
+	if _cats_sort_mode == sort_mode:
+		return
+	_cats_sort_mode = sort_mode
+	_refresh_cats_sort_buttons()
+	_refresh_cats_list()
+
+
+func _refresh_cats_sort_buttons() -> void:
+	for key: String in _cats_sort_btns.keys():
+		var button: Button = _cats_sort_btns[key]
+		var is_active: bool = key == _cats_sort_mode
+		if is_active:
+			UiPalette.apply_button_palette(button, Color(0.58, 0.48, 0.26, 0.88), Color(0.97, 0.93, 0.84, 1.0))
+		else:
+			UiPalette.apply_button_palette(button, Color(0.20, 0.18, 0.17, 0.88), Color(0.62, 0.58, 0.54, 1.0))
+
+
+func _get_sorted_owned_cats() -> Array:
+	var owned_cats: Array = GameState.get_config_owned_cats().duplicate(true)
+	owned_cats.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
+		if _cats_sort_mode == "rank":
+			var a_rank: int = int(a.get("rank", 0))
+			var b_rank: int = int(b.get("rank", 0))
+			if a_rank != b_rank:
+				return a_rank > b_rank
+			var a_level: int = int(a.get("catFoodLevel", 1))
+			var b_level: int = int(b.get("catFoodLevel", 1))
+			if a_level != b_level:
+				return a_level > b_level
+			return int(a.get("playerCatId", 0)) < int(b.get("playerCatId", 0))
+
+		var a_level_default: int = int(a.get("catFoodLevel", 1))
+		var b_level_default: int = int(b.get("catFoodLevel", 1))
+		if a_level_default != b_level_default:
+			return a_level_default > b_level_default
+		var a_rank_default: int = int(a.get("rank", 0))
+		var b_rank_default: int = int(b.get("rank", 0))
+		if a_rank_default != b_rank_default:
+			return a_rank_default > b_rank_default
+		return int(a.get("playerCatId", 0)) < int(b.get("playerCatId", 0))
+	)
+	return owned_cats
+
+
+func _build_member_from_player_cat(player_cat_id: int) -> Dictionary:
+	for cat_variant: Variant in GameState.get_config_owned_cats():
+		if not (cat_variant is Dictionary):
+			continue
+
+		var cat: Dictionary = cat_variant as Dictionary
+		if int(cat.get("playerCatId", 0)) != player_cat_id:
+			continue
+
+		return {
+			"slotNo": 0,
+			"playerCatId": player_cat_id,
+			"catCatalogId": int(cat.get("catCatalogId", 0)),
+			"catDisplayName": str(cat.get("displayName", "")),
+			"catFoodLevel": int(cat.get("catFoodLevel", 1)),
+			"rank": int(cat.get("rank", 0)),
+			"initialDelaySeconds": 0.0,
+		}
+
+	return {}
+
+
+func _draft_has_player_cat(members: Array, player_cat_id: int) -> bool:
+	for member_variant: Variant in members:
+		if member_variant is Dictionary:
+			var member: Dictionary = member_variant
+			if int(member.get("playerCatId", 0)) == player_cat_id:
+				return true
+	return false
+
+
+func _find_member_slot_no_by_player_cat_id(player_cat_id: int) -> int:
+	for member_variant: Variant in _get_editing_team_members():
+		if not (member_variant is Dictionary):
+			continue
+		var member: Dictionary = member_variant as Dictionary
+		if member.is_empty():
+			continue
+		if int(member.get("playerCatId", 0)) == player_cat_id:
+			return int(member.get("slotNo", -1))
+	return -1
+
+
+func _toggle_member_in_draft(player_cat_id: int) -> void:
+	if _api_in_flight:
+		return
+
+	var slot_no: int = _find_member_slot_no_by_player_cat_id(player_cat_id)
+	if slot_no >= 0:
+		_remove_member_from_draft(slot_no)
+		return
+
+	_add_member_to_draft(player_cat_id)
+
+
+func _add_member_to_draft(player_cat_id: int) -> void:
+	if _api_in_flight:
+		return
+
+	var members: Array = _get_editing_team_members().duplicate(true)
+	if _get_filled_editing_team_members().size() >= _get_max_team_size():
+		return
+	if _draft_has_player_cat(members, player_cat_id):
+		return
+
+	var new_member: Dictionary = _build_member_from_player_cat(player_cat_id)
+	if new_member.is_empty():
+		return
+
+	var target_index: int = -1
+	for index: int in range(members.size()):
+		var slot_variant: Variant = members[index]
+		if slot_variant is Dictionary and (slot_variant as Dictionary).is_empty():
+			target_index = index
+			break
+
+	if target_index >= 0:
+		new_member["slotNo"] = target_index
+		members[target_index] = new_member
+	else:
+		new_member["slotNo"] = members.size()
+		members.append(new_member)
+
+	_team_drafts[_current_team_type]["members"] = _normalize_members(members)
+	_mark_current_team_dirty()
+	_refresh_team()
+	_refresh_cats_list()
+
+
+func _remove_member_from_draft(slot_no: int) -> void:
+	if _api_in_flight:
+		return
+
+	var members: Array = _get_editing_team_members().duplicate(true)
+	if slot_no < 0 or slot_no >= members.size():
+		return
+
+	members[slot_no] = {}
+	_team_drafts[_current_team_type]["members"] = _normalize_members(members)
+	_mark_current_team_dirty()
+	_refresh_team()
+	_refresh_cats_list()
+
+
+func _update_member_delay_in_draft(slot_no: int, delay_seconds: float) -> void:
+	if _api_in_flight:
+		return
+
+	var members: Array = _get_editing_team_members().duplicate(true)
+	if slot_no < 0 or slot_no >= members.size():
+		return
+
+	var member: Dictionary = members[slot_no]
+	member["initialDelaySeconds"] = maxf(0.0, delay_seconds)
+	members[slot_no] = member
+	_team_drafts[_current_team_type]["members"] = _normalize_members(members)
+	_mark_current_team_dirty()
+	_refresh_team()
+
+
+func _update_save_section() -> void:
+	var dirty: bool = _is_current_team_dirty()
+	_save_team_btn.disabled = _api_in_flight or not dirty
+	if dirty and not _api_in_flight:
+		UiPalette.apply_button_kind(_save_team_btn, "confirm")
+	else:
+		UiPalette.apply_button_palette(_save_team_btn, Color(0.24, 0.21, 0.18, 0.86), Color(0.72, 0.69, 0.64, 1.0))
+
+
+func _on_save_team_pressed() -> void:
+	if _api_in_flight or not _is_current_team_dirty():
+		return
+
+	var request_members: Array = []
+	for member: Dictionary in _get_editing_team_members():
+		if member.is_empty():
+			continue
+		request_members.append({
+			"slotNo": int(member.get("slotNo", 0)),
+			"playerCatId": int(member.get("playerCatId", 0)),
+			"initialDelaySeconds": float(member.get("initialDelaySeconds", 0.0)),
+		})
+
+	_api_in_flight = true
+	_update_save_section()
+	_refresh_team()
+	_refresh_cats_list()
+
+	ApiClient.replace_team(_current_team_type, request_members, func(success: bool, data: Variant, error: Dictionary) -> void:
+		_api_in_flight = false
+		if not success:
+			ToastManager.error(UiText.CONFIG_SAVE_FAILED_TITLE, str(error.get("message", UiText.CONFIG_UNKNOWN_ERROR)))
+			_refresh_team()
+			_refresh_cats_list()
+			return
+
+		if data is Dictionary:
+			var team_response: Dictionary = data as Dictionary
+			_apply_team_update(team_response)
+			var saved_type_key: String = _team_scene_type_to_key(str(team_response.get("teamType", "")))
+			if saved_type_key != "":
+				_reset_team_draft(saved_type_key, team_response)
+				_restart_home_battle_if_needed(saved_type_key)
+
+		_refresh_team()
+		_refresh_cats_list()
+		ToastManager.success(UiText.CONFIG_SAVE_HINT_CLEAN)
+	)
+
+
+func _team_scene_type_to_key(team_type: String) -> String:
+	for key: String in Constants.TEAM_TYPE_MAP.keys():
+		if str(Constants.TEAM_TYPE_MAP[key]) == team_type:
+			return key
+	return ""
+
+
+func _apply_team_update(team_response: Dictionary) -> void:
+	var type_str: String = str(team_response.get("teamType", ""))
+	if type_str == "":
+		return
+
+	GameState.teams_data[type_str] = team_response
+	GameState._save_config_cache("teams", GameState.teams_data.values())
+
+	if type_str == "Boss":
+		GameState.apply_active_team_from_config("Boss")
+
+
+func _restart_home_battle_if_needed(type_key: String) -> void:
+	if type_key != "boss":
+		return
+	var battle_scene: Node = get_tree().get_first_node_in_group("battle_scene")
+	if battle_scene != null and battle_scene.has_method("restart_with_latest_team"):
+		battle_scene.call_deferred("restart_with_latest_team")
+
+
+func _show_skill_popup(cat_file_id: String) -> void:
+	var cat_data: Variant = CatData.from_json_file(cat_file_id + ".json")
+	if cat_data == null:
+		return
+
+	var lines: Array = [str(cat_data.display_name) + UiText.CONFIG_SKILL_DIALOG_SUFFIX]
+
+	for sid: String in cat_data.passive_skill_ids:
+		var passive_skill: Dictionary = CatData._read_skill_json(sid)
+		if passive_skill.is_empty():
+			continue
+		lines.append(UiText.CONFIG_SKILL_PASSIVE_FORMAT % passive_skill.get("display_name", sid))
+		lines.append("  " + str(passive_skill.get("description", "")))
+
+	for active_skill: Dictionary in cat_data.active_skills_data:
+		lines.append(UiText.CONFIG_SKILL_ACTIVE_FORMAT % [
+			active_skill.get("display_name", ""),
+			float(active_skill.get("cooldown", 0.0)),
+		])
+		lines.append("  " + str(active_skill.get("description", "")))
+
+	DialogManager.show_info(UiText.CONFIG_SKILL_DIALOG_TITLE, "\n".join(lines))
+
+
+func _make_separator() -> HSeparator:
+	return HSeparator.new()
+
+
+func _make_chip_style(fill: Color, border: Color, radius: int) -> StyleBoxFlat:
+	var style: StyleBoxFlat = OverlaySceneChrome.make_panel_style(fill, border, radius)
+	style.border_width_left = 1
+	style.border_width_right = 1
+	style.border_width_top = 1
+	style.border_width_bottom = 1
+	return style
+
+
+func _get_next_delay_value(current_delay: float) -> float:
+	var current_seconds: int = maxi(0, int(round(current_delay)))
+	return float((current_seconds + 1) % 10)
+
+
+func _format_delay_label(delay_seconds: float) -> String:
+	var seconds: int = maxi(0, int(round(delay_seconds)))
+	return str(seconds) + "秒"
+
+
+func _get_cat_visual_fallback(cat_name: String) -> String:
+	var trimmed: String = cat_name.strip_edges()
+	if trimmed == "":
+		return "?"
+	return trimmed.substr(0, 1)
+
+
+func _get_max_team_size() -> int:
+	match _current_team_type:
+		"boss":
+			return int(GameState.boss_config.get("max_team_size", 5))
+		"dungeon":
+			return int(GameState.dungeon_config.get("max_team_size", 5))
+		"arena_attack", "arena_defense":
+			return int(GameState.arena_config.get("max_team_size", 5))
+	return 5
+
+
+func _on_back_pressed() -> void:
+	var boss_team: Dictionary = GameState.get_team("Boss")
+	var boss_members: Array = boss_team.get("members", [])
+	GameState.player_team = boss_members.map(func(member: Dictionary) -> int:
+		return int(member.get("playerCatId", 0))
+	)
+	SceneNavigator.return_to_battle()

--- a/scripts/ui/UiAudio.gd
+++ b/scripts/ui/UiAudio.gd
@@ -1,6 +1,20 @@
 extends Node
 
 const UI_BUTTON_CLICK_SFX := preload("res://assets/audio/sfx/ui/battle_scene.mp3")
+const MASTER_BUS_NAME := "Master"
+const BGM_BUS_NAME := "BGM"
+const SFX_BUS_NAME := "SFX"
+
+var _bgm_player: AudioStreamPlayer
+var _current_bgm_path: String = ""
+
+
+func _ready() -> void:
+	ensure_audio_buses()
+	_bgm_player = AudioStreamPlayer.new()
+	_bgm_player.bus = BGM_BUS_NAME
+	_bgm_player.stream_paused = false
+	add_child(_bgm_player)
 
 
 func should_play_for_button(button: BaseButton) -> bool:
@@ -12,8 +26,85 @@ func should_play_for_button(button: BaseButton) -> bool:
 func play_ui_click() -> void:
 	if UI_BUTTON_CLICK_SFX == null:
 		return
+	play_sfx(UI_BUTTON_CLICK_SFX, 0.0, 1.0)
+
+
+func ensure_audio_buses() -> void:
+	_ensure_bus(BGM_BUS_NAME, MASTER_BUS_NAME)
+	_ensure_bus(SFX_BUS_NAME, MASTER_BUS_NAME)
+
+
+func apply_settings(settings: Dictionary) -> void:
+	ensure_audio_buses()
+	_apply_bus_settings(MASTER_BUS_NAME, float(settings.get("masterVolume", 1.0)), bool(settings.get("masterMuted", false)))
+	_apply_bus_settings(BGM_BUS_NAME, float(settings.get("bgmVolume", 1.0)), bool(settings.get("bgmMuted", false)))
+	_apply_bus_settings(SFX_BUS_NAME, float(settings.get("sfxVolume", 1.0)), bool(settings.get("sfxMuted", false)))
+
+
+func play_sfx(stream: AudioStream, volume_db: float = 0.0, pitch_scale: float = 1.0) -> void:
+	if stream == null:
+		return
 	var player: AudioStreamPlayer = AudioStreamPlayer.new()
-	player.stream = UI_BUTTON_CLICK_SFX
+	player.bus = SFX_BUS_NAME
+	player.stream = stream
+	player.volume_db = volume_db
+	player.pitch_scale = pitch_scale
 	add_child(player)
 	player.finished.connect(player.queue_free)
 	player.play()
+
+
+func play_bgm(stream: AudioStream, restart: bool = false) -> void:
+	if stream == null:
+		return
+	ensure_audio_buses()
+	if _bgm_player == null:
+		_bgm_player = AudioStreamPlayer.new()
+		_bgm_player.bus = BGM_BUS_NAME
+		add_child(_bgm_player)
+
+	var stream_path: String = str(stream.resource_path)
+	if not restart and _bgm_player.playing and _current_bgm_path == stream_path:
+		return
+
+	var playback_stream: AudioStream = stream.duplicate(true) if stream.has_method("duplicate") else stream
+	if playback_stream is AudioStreamMP3:
+		(playback_stream as AudioStreamMP3).loop = true
+	elif playback_stream is AudioStreamOggVorbis:
+		(playback_stream as AudioStreamOggVorbis).loop = true
+
+	_current_bgm_path = stream_path
+	_bgm_player.stream = playback_stream
+	_bgm_player.play()
+
+
+func stop_bgm() -> void:
+	if _bgm_player == null:
+		return
+	_bgm_player.stop()
+	_current_bgm_path = ""
+
+
+func _ensure_bus(bus_name: String, send_bus_name: String) -> void:
+	var bus_index: int = AudioServer.get_bus_index(bus_name)
+	if bus_index == -1:
+		AudioServer.add_bus()
+		bus_index = AudioServer.get_bus_count() - 1
+		AudioServer.set_bus_name(bus_index, bus_name)
+	var send_index: int = AudioServer.get_bus_index(send_bus_name)
+	if send_index != -1:
+		AudioServer.set_bus_send(bus_index, send_bus_name)
+
+
+func _apply_bus_settings(bus_name: String, linear_value: float, muted: bool) -> void:
+	var bus_index: int = AudioServer.get_bus_index(bus_name)
+	if bus_index == -1:
+		return
+	AudioServer.set_bus_mute(bus_index, muted)
+	AudioServer.set_bus_volume_db(bus_index, _linear_to_db(linear_value))
+
+
+func _linear_to_db(value: float) -> float:
+	if value <= 0.0001:
+		return -80.0
+	return linear_to_db(value)

--- a/scripts/ui/asset_resolver.gd
+++ b/scripts/ui/asset_resolver.gd
@@ -3,6 +3,7 @@ extends RefCounted
 
 const UI_ROOT := "res://assets/sprites/ui/"
 const BACKGROUND_SHADER := preload("res://scripts/ui/background_desaturate_shader.gdshader")
+const DEFAULT_PROFILE_AVATAR_ID := "black_cat"
 
 const BACKGROUNDS := {
 	"activity": UI_ROOT + "activity_background_v1.png",
@@ -25,6 +26,24 @@ const CAT_ICONS := {
 	"orange_cat": UI_ROOT + "character_refs/orange_cat/orange_cat_icon_v1.png",
 	"test_enemy": UI_ROOT + "character_refs/test_enemy/test_enemy_icon_v1.png",
 	"tuxedo_cat": UI_ROOT + "character_refs/tuxedo_cat/tuxedo_cat_icon_v1.png",
+}
+
+const PROFILE_AVATAR_IDS := [
+	"black_cat",
+	"calico_cat",
+	"milk_cat",
+	"ninja_cat",
+	"orange_cat",
+	"tuxedo_cat",
+]
+
+const PROFILE_AVATAR_LABELS := {
+	"black_cat": "黑貓",
+	"calico_cat": "三花貓",
+	"milk_cat": "乳牛貓",
+	"ninja_cat": "忍者貓",
+	"orange_cat": "橘貓",
+	"tuxedo_cat": "燕尾服貓",
 }
 
 const CAT_SHOWCASE_TEXTURES := {
@@ -240,6 +259,23 @@ static func resolve_catalog_path(raw_path: Variant) -> String:
 
 static func resolve_cat_icon(cat_id: String) -> Texture2D:
 	return load_texture(CAT_ICONS.get(cat_id, ""))
+
+
+static func get_profile_avatar_ids() -> Array[String]:
+	return PROFILE_AVATAR_IDS.duplicate()
+
+
+static func get_profile_avatar_label(avatar_id: String) -> String:
+	var normalized_id: String = avatar_id if avatar_id != "" else DEFAULT_PROFILE_AVATAR_ID
+	return str(PROFILE_AVATAR_LABELS.get(normalized_id, normalized_id))
+
+
+static func resolve_profile_avatar(avatar_id: String) -> Texture2D:
+	var normalized_id: String = avatar_id if avatar_id != "" else DEFAULT_PROFILE_AVATAR_ID
+	var texture: Texture2D = resolve_cat_icon(normalized_id)
+	if texture != null:
+		return texture
+	return resolve_cat_icon(DEFAULT_PROFILE_AVATAR_ID)
 
 
 static func resolve_cat_showcase_art(cat_id: String) -> Texture2D:


### PR DESCRIPTION
## What changed
- turned the top-left home portrait into the real settings entry point
- split the old lineup/config flow so lineup lives in `LineupScene` while `ConfigScene` becomes the settings center
- added profile/account/game settings UI including redeem code entry and linked-provider placeholders
- added local client audio settings persistence and updated UI/audio wiring
- updated client GDD to match the implemented settings architecture

## Why
- the project needed a dedicated settings center instead of reusing the lineup scene
- players need editable profile data, visible account linking status, redeem code access, and persistent audio controls

## Impact
- homepage HUD can open settings directly and reflect updated profile data immediately
- lineup remains available from the original bottom navigation entry
- master, BGM, and SFX settings now persist across restarts

## Validation
- `dotnet build MeowPartyDashClient.csproj`

## Notes
- OAuth providers are placeholder status cards only in this PR; no live auth flow is enabled yet