### PR TITLE
[codex] Add admin catalog backoffice frontend

### DIFF
--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -23,3 +23,4 @@
 | 圖像創作總規範 | [13_image_art_direction.md](gdd/13_image_art_direction.md) |
 | 鏟屎官資料架構 | [14_scooper_data_architecture.md](gdd/14_scooper_data_architecture.md) |
 | 屬性數值總覽面板 | [24_stats_panel.md](gdd/24_stats_panel.md) |
+| Admin Catalog 後台 | [25_admin_catalog_frontend.md](gdd/25_admin_catalog_frontend.md) |

--- a/docs/gdd/25_admin_catalog_frontend.md
+++ b/docs/gdd/25_admin_catalog_frontend.md
@@ -1,0 +1,154 @@
+# 25. Admin Catalog Frontend
+
+> Last updated: 2026-04-17
+> Audience: Godot client engineers and agents working on Admin-only tooling
+
+## 1. Scope
+
+`Admin Catalog` is an Admin-only overlay scene for editing server-side catalog and static configuration data.
+
+Current implementation files:
+
+- `res://scripts/configs/ConfigScene.gd`
+- `res://scripts/configs/AdminCatalogScene.gd`
+- `res://scenes/AdminCatalogScene.tscn`
+- `res://scripts/ApiClient.gd`
+- `res://scripts/gamestate/GameState.gd`
+
+This page is intentionally outside the normal player bootstrap flow. Every entry to the page re-validates the session against protected Admin APIs before any catalog payload is shown.
+
+## 2. Entry And Visibility
+
+Entry point:
+
+- `ConfigScene.gd` adds an `Admin Catalog` row inside the settings center.
+
+Visibility rule:
+
+- The row is only rendered when `GameState.is_admin_session()` returns `true`.
+- `GameState.is_admin_session()` accepts either:
+  - `roleType = admin`
+  - `role = admin`
+  - permission list containing `catalog.manage`
+
+This keeps the entry hidden for normal players while still allowing permission-driven Admin sessions.
+
+## 3. Access Validation Flow
+
+Security requirement:
+
+- The Admin page does not reuse player bootstrap payloads as its data source.
+- `AdminCatalogScene._ready()` immediately calls `ApiClient.admin_get_catalog_access(...)`.
+
+API:
+
+- `GET /api/admin/catalog/access`
+
+Behavior:
+
+1. Scene opens.
+2. Client calls `admin_get_catalog_access`.
+3. If the request fails or returns unauthorized, the scene shows an error dialog and returns to the normal flow.
+4. If the request succeeds, the returned section list and reference metadata drive the UI.
+5. The first allowed section is loaded by `GET /api/admin/catalog/{section}`.
+
+Result:
+
+- Each visit re-checks identity and permission at the server boundary.
+- Admin catalog data is never sourced from stale local bootstrap cache.
+
+## 4. Scene Structure
+
+`AdminCatalogScene.tscn` is a thin root scene; the UI is built in code by `AdminCatalogScene.gd`.
+
+Layout:
+
+- overlay chrome from `OverlaySceneChrome`
+- top title and status line
+- left section navigation list
+- right editor panel with:
+  - section title
+  - section hint
+  - action buttons: save / reload / discard
+  - payload editor
+  - reference sidebar
+
+Current v1 editor mode:
+
+- The scene is section-based, but the payload editor itself is a JSON editor.
+- This allows Admins to add, modify, and disable parent/child rows without exposing raw SQL or direct DB access.
+- References for common FK targets are rendered beside the editor to reduce lookup mistakes.
+
+## 5. Client Interaction Rules
+
+Supported actions:
+
+- load allowed sections
+- load one section payload
+- modify payload locally
+- confirm before save
+- reload current section
+- discard unsaved edits
+- warn before switching sections or leaving with dirty state
+
+Important UX rules:
+
+- `Save` is disabled while loading/saving or when there are no local changes.
+- `Reload` and `Discard` are protected by unsaved-change checks.
+- Back navigation prompts if the editor is dirty.
+- Save always goes through a confirmation dialog because the backend applies changes immediately.
+
+## 6. ApiClient Contract
+
+The client uses three dedicated methods:
+
+- `admin_get_catalog_access(callback)`
+- `admin_get_catalog_section(section_key, callback)`
+- `admin_save_catalog_section(section_key, payload, callback)`
+
+HTTP mapping:
+
+- `GET admin/catalog/access`
+- `GET admin/catalog/{section}`
+- `PUT admin/catalog/{section}`
+
+The client does not compose transaction payloads from multiple endpoints. Each section is fetched and saved as one aggregate payload.
+
+## 7. GameState And Cache Boundary
+
+`GameState` is used for session identity only:
+
+- permission check for showing the entry
+- bearer token reuse through `ApiClient`
+
+`GameState` is not used as a cache for admin catalog payloads.
+
+Cache boundary:
+
+- access payload lives only in `AdminCatalogScene`
+- section payload lives only in `AdminCatalogScene`
+- every scene entry re-fetches access
+- section data is re-fetched on demand
+
+This keeps admin data consistent with server-side cache invalidation after save.
+
+## 8. Error Handling
+
+Failure handling rules:
+
+- `access` failure: show dialog, reject page entry, return to normal scene flow
+- section load failure: keep current UI, show dialog
+- malformed JSON: block save locally
+- save failure: keep edited content, show backend message
+
+The page does not attempt optimistic local reconciliation. The server response after save is treated as the source of truth and replaces the current editor payload.
+
+## 9. Acceptance Checklist
+
+- Non-admin sessions do not see the `Admin Catalog` entry.
+- Admin sessions always re-validate through `GET /api/admin/catalog/access`.
+- Section payloads are loaded from protected admin endpoints, not bootstrap.
+- Dirty navigation prompts work for section switch, reload, and back.
+- Save requires explicit confirmation.
+- Successful save refreshes the editor with the normalized backend payload.
+- Failed save preserves local edits for correction and retry.

--- a/scenes/AdminCatalogScene.tscn
+++ b/scenes/AdminCatalogScene.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/configs/AdminCatalogScene.gd" id="1"]
+
+[node name="AdminCatalogScene" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource("1")

--- a/scripts/ApiClient.gd
+++ b/scripts/ApiClient.gd
@@ -144,6 +144,18 @@ func get_authenticated_bootstrap(callback: Callable) -> void:
 	_api_get("auth/bootstrap", callback)
 
 
+func admin_get_catalog_access(callback: Callable) -> void:
+	_api_get("admin/catalog/access", callback)
+
+
+func admin_get_catalog_section(section_key: String, callback: Callable) -> void:
+	_api_get("admin/catalog/%s" % section_key.uri_encode(), callback)
+
+
+func admin_save_catalog_section(section_key: String, payload: Dictionary, callback: Callable) -> void:
+	_api_put("admin/catalog/%s" % section_key.uri_encode(), payload, callback)
+
+
 func get_profile_me(callback: Callable) -> void:
 	_api_get("profile/me", callback)
 

--- a/scripts/configs/AdminCatalogScene.gd
+++ b/scripts/configs/AdminCatalogScene.gd
@@ -1,0 +1,375 @@
+extends Control
+
+const SECTION_HINTS := {
+	"core": "管理貨幣與消耗品 catalog。數值修改會在後續請求生效。",
+	"cats": "管理貓咪基礎素質、稀有度與主被動技能綁定。請勿手動改動既有 id。",
+	"skills": "管理主動/被動技能與其效果、rank scaling。",
+	"stages": "管理 stage 公式、boss 世界設定、territory 與 zone suffix。",
+	"dungeons": "管理地城靜態數值與每層獎勵公式。",
+	"arena": "管理競技場全域設定、rank 區間與 bot 內容。",
+	"gacha": "管理 gacha 設定、pull option、技巧等級與稀有度展示。",
+	"scooper": "管理 idle 設定、裝備與特殊能力 catalog。",
+	"memories": "管理記憶 catalog。",
+	"treasures": "管理寶物與效果。",
+	"achievements": "管理成就條件與獎勵。",
+	"shop": "管理 shop category、group、bundle 與獎勵。",
+}
+
+var _access_payload: Dictionary = {}
+var _references: Dictionary = {}
+var _section_buttons: Dictionary = {}
+var _current_section_key := ""
+var _current_section_data: Dictionary = {}
+var _dirty := false
+var _loading_access := false
+var _loading_section := false
+var _saving := false
+var _updating_editor := false
+
+var _status_label: Label
+var _section_list: VBoxContainer
+var _section_title_label: Label
+var _section_hint_label: Label
+var _save_button: Button
+var _reload_button: Button
+var _discard_button: Button
+var _editor: TextEdit
+var _reference_label: RichTextLabel
+
+
+func _ready() -> void:
+	_build_ui()
+	_load_access()
+
+
+func _build_ui() -> void:
+	var chrome: Dictionary = OverlaySceneChrome.build(self, "config", Callable(self, "_on_back_pressed"), {
+		"show_dock": false,
+		"content_bottom": -(OverlaySceneChrome.HOME_MAIN_NAV_H + 14.0),
+		"content_separation": 12,
+	})
+	var content_box: VBoxContainer = chrome.get("content_box") as VBoxContainer
+
+	var title: Label = Label.new()
+	title.text = "Admin Catalog"
+	title.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_DISPLAY)
+	content_box.add_child(title)
+
+	_status_label = Label.new()
+	_status_label.text = "驗證中..."
+	_status_label.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+	content_box.add_child(_status_label)
+
+	var split: HSplitContainer = HSplitContainer.new()
+	split.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	split.split_offset = 220
+	content_box.add_child(split)
+
+	var nav_panel: PanelContainer = OverlaySceneChrome.make_card_panel()
+	split.add_child(nav_panel)
+	var nav_margin: MarginContainer = OverlaySceneChrome.make_content_margin(12)
+	nav_panel.add_child(nav_margin)
+	_section_list = VBoxContainer.new()
+	_section_list.add_theme_constant_override("separation", 8)
+	nav_margin.add_child(_section_list)
+
+	var right_panel: PanelContainer = OverlaySceneChrome.make_card_panel()
+	split.add_child(right_panel)
+	var right_margin: MarginContainer = OverlaySceneChrome.make_content_margin(12)
+	right_panel.add_child(right_margin)
+	var right_column: VBoxContainer = VBoxContainer.new()
+	right_column.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	right_column.add_theme_constant_override("separation", 10)
+	right_margin.add_child(right_column)
+
+	_section_title_label = Label.new()
+	_section_title_label.text = "尚未載入"
+	_section_title_label.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY_LG)
+	right_column.add_child(_section_title_label)
+
+	_section_hint_label = Label.new()
+	_section_hint_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_section_hint_label.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+	right_column.add_child(_section_hint_label)
+
+	var action_row: HBoxContainer = HBoxContainer.new()
+	action_row.add_theme_constant_override("separation", 8)
+	right_column.add_child(action_row)
+
+	_save_button = Button.new()
+	_save_button.text = "儲存"
+	_save_button.custom_minimum_size = Vector2(120.0, 42.0)
+	UiPalette.apply_button_kind(_save_button, "confirm")
+	_save_button.pressed.connect(UiAudio.play_ui_click)
+	_save_button.pressed.connect(_on_save_pressed)
+	action_row.add_child(_save_button)
+
+	_reload_button = Button.new()
+	_reload_button.text = "重新載入"
+	_reload_button.custom_minimum_size = Vector2(120.0, 42.0)
+	UiPalette.apply_button_kind(_reload_button, "secondary")
+	_reload_button.pressed.connect(UiAudio.play_ui_click)
+	_reload_button.pressed.connect(_on_reload_pressed)
+	action_row.add_child(_reload_button)
+
+	_discard_button = Button.new()
+	_discard_button.text = "放棄變更"
+	_discard_button.custom_minimum_size = Vector2(120.0, 42.0)
+	UiPalette.apply_button_kind(_discard_button, "secondary")
+	_discard_button.pressed.connect(UiAudio.play_ui_click)
+	_discard_button.pressed.connect(_on_discard_pressed)
+	action_row.add_child(_discard_button)
+
+	var content_split: HSplitContainer = HSplitContainer.new()
+	content_split.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	content_split.split_offset = 760
+	right_column.add_child(content_split)
+
+	_editor = TextEdit.new()
+	_editor.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	_editor.wrap_mode = TextEdit.LINE_WRAPPING_NONE
+	_editor.text_changed.connect(_on_editor_text_changed)
+	content_split.add_child(_editor)
+
+	_reference_label = RichTextLabel.new()
+	_reference_label.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	_reference_label.fit_content = false
+	_reference_label.bbcode_enabled = true
+	_reference_label.scroll_active = true
+	content_split.add_child(_reference_label)
+
+	_refresh_action_state()
+
+
+func _load_access() -> void:
+	_loading_access = true
+	_refresh_action_state()
+	_status_label.text = "驗證 Admin 權限..."
+	ApiClient.admin_get_catalog_access(func(success: bool, data: Variant, error: Dictionary) -> void:
+		_loading_access = false
+		if not success:
+			_status_label.text = "驗權失敗"
+			DialogManager.show_info("無法進入 Admin Catalog", str(error.get("message", "驗證失敗。")))
+			SceneNavigator.return_to_battle()
+			_refresh_action_state()
+			return
+
+		_access_payload = data if data is Dictionary else {}
+		_references = _access_payload.get("references", {}) if _access_payload.get("references", {}) is Dictionary else {}
+		_build_section_buttons()
+		var sections: Array = _access_payload.get("sections", []) if _access_payload.get("sections", []) is Array else []
+		if sections.is_empty():
+			_status_label.text = "沒有可用 section"
+			_refresh_action_state()
+			return
+		var first_section: Dictionary = sections[0] if sections[0] is Dictionary else {}
+		_request_section_switch(str(first_section.get("sectionKey", "")).strip_edges())
+	)
+
+
+func _build_section_buttons() -> void:
+	for child: Node in _section_list.get_children():
+		child.queue_free()
+	_section_buttons.clear()
+
+	var sections: Array = _access_payload.get("sections", []) if _access_payload.get("sections", []) is Array else []
+	for section_variant: Variant in sections:
+		if not (section_variant is Dictionary):
+			continue
+		var section: Dictionary = section_variant
+		var section_key := str(section.get("sectionKey", "")).strip_edges()
+		if section_key == "":
+			continue
+
+		var button: Button = Button.new()
+		button.text = str(section.get("displayName", section_key))
+		button.custom_minimum_size = Vector2(0.0, 42.0)
+		button.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		UiPalette.apply_button_kind(button, "secondary")
+		button.pressed.connect(UiAudio.play_ui_click)
+		button.pressed.connect(func() -> void:
+			_request_section_switch(section_key)
+		)
+		_section_buttons[section_key] = button
+		_section_list.add_child(button)
+
+
+func _request_section_switch(section_key: String) -> void:
+	if section_key == "" or section_key == _current_section_key and not _current_section_data.is_empty():
+		return
+	if _dirty:
+		DialogManager.show_confirm("放棄未儲存變更", "切換 section 會丟棄目前未儲存的內容，是否繼續？", func() -> void:
+			_load_section(section_key)
+		)
+		return
+	_load_section(section_key)
+
+
+func _load_section(section_key: String) -> void:
+	_loading_section = true
+	_refresh_action_state()
+	_status_label.text = "載入 %s..." % section_key
+	ApiClient.admin_get_catalog_section(section_key, func(success: bool, data: Variant, error: Dictionary) -> void:
+		_loading_section = false
+		if not success:
+			_status_label.text = "載入失敗"
+			DialogManager.show_info("載入失敗", str(error.get("message", "無法載入 section。")))
+			_refresh_action_state()
+			return
+
+		_current_section_key = section_key
+		_current_section_data = (data if data is Dictionary else {}).duplicate(true)
+		_set_editor_payload(_current_section_data)
+		_dirty = false
+		_refresh_section_visuals()
+		_refresh_action_state()
+	)
+
+
+func _set_editor_payload(payload: Dictionary) -> void:
+	_updating_editor = true
+	_editor.text = JSON.stringify(payload, "\t")
+	_updating_editor = false
+
+
+func _refresh_section_visuals() -> void:
+	for key: String in _section_buttons.keys():
+		var button: Button = _section_buttons.get(key)
+		if button == null:
+			continue
+		button.disabled = _loading_access or _loading_section or _saving
+		if key == _current_section_key:
+			UiPalette.apply_button_kind(button, "confirm")
+		else:
+			UiPalette.apply_button_kind(button, "secondary")
+
+	var title_text := _current_section_key
+	var sections: Array = _access_payload.get("sections", []) if _access_payload.get("sections", []) is Array else []
+	for section_variant: Variant in sections:
+		if section_variant is Dictionary and str((section_variant as Dictionary).get("sectionKey", "")) == _current_section_key:
+			title_text = str((section_variant as Dictionary).get("displayName", _current_section_key))
+			break
+
+	_section_title_label.text = title_text
+	_section_hint_label.text = str(SECTION_HINTS.get(_current_section_key, ""))
+	_reference_label.text = _build_reference_text(_current_section_key)
+	_status_label.text = _build_status_text()
+
+
+func _build_status_text() -> String:
+	if _saving:
+		return "儲存中..."
+	if _loading_access:
+		return "驗證中..."
+	if _loading_section:
+		return "載入中..."
+	if _current_section_key == "":
+		return "尚未選擇 section"
+	return "目前 section: %s%s" % [_current_section_key, " (未儲存)" if _dirty else ""]
+
+
+func _build_reference_text(section_key: String) -> String:
+	var lines: PackedStringArray = []
+	lines.append("[b]Section Hint[/b]")
+	lines.append(str(SECTION_HINTS.get(section_key, "")))
+	lines.append("")
+	lines.append("[b]Common References[/b]")
+	lines.append(_format_reference_group("skills"))
+	lines.append(_format_reference_group("cats"))
+	if section_key == "shop":
+		lines.append(_format_reference_group("currencies"))
+		lines.append(_format_reference_group("treasures"))
+		lines.append(_format_reference_group("shopBundleGroups"))
+	return "\n".join(lines)
+
+
+func _format_reference_group(key: String) -> String:
+	var items: Array = _references.get(key, []) if _references.get(key, []) is Array else []
+	if items.is_empty():
+		return "%s: none" % key
+	var result: PackedStringArray = []
+	result.append("%s:" % key)
+	var limit := mini(items.size(), 24)
+	for i in range(limit):
+		var item: Dictionary = items[i] if items[i] is Dictionary else {}
+		result.append("- %s | %s | %s" % [str(item.get("id", "")), str(item.get("key", "")), str(item.get("displayName", ""))])
+	if items.size() > limit:
+		result.append("- ... %d more" % [items.size() - limit])
+	return "\n".join(result)
+
+
+func _on_editor_text_changed() -> void:
+	if _updating_editor:
+		return
+	_dirty = true
+	_refresh_action_state()
+
+
+func _on_save_pressed() -> void:
+	if _saving or _loading_section or _current_section_key == "":
+		return
+	DialogManager.show_confirm("確認儲存", "儲存後會立即生效，是否繼續？", func() -> void:
+		_save_current_section()
+	)
+
+
+func _save_current_section() -> void:
+	var parser := JSON.new()
+	if parser.parse(_editor.text) != OK:
+		DialogManager.show_info("JSON 格式錯誤", "請先修正 JSON 內容後再儲存。")
+		return
+	var payload: Variant = parser.get_data()
+	if not (payload is Dictionary):
+		DialogManager.show_info("格式錯誤", "Section payload 必須是 JSON object。")
+		return
+
+	_saving = true
+	_refresh_action_state()
+	ApiClient.admin_save_catalog_section(_current_section_key, payload, func(success: bool, data: Variant, error: Dictionary) -> void:
+		_saving = false
+		if not success:
+			_status_label.text = "儲存失敗"
+			DialogManager.show_info("儲存失敗", str(error.get("message", "無法儲存 section。")))
+			_refresh_action_state()
+			return
+
+		_current_section_data = (data if data is Dictionary else {}).duplicate(true)
+		_set_editor_payload(_current_section_data)
+		_dirty = false
+		_refresh_action_state()
+		_refresh_section_visuals()
+	)
+
+
+func _on_reload_pressed() -> void:
+	if _current_section_key == "" or _loading_section or _saving:
+		return
+	if _dirty:
+		DialogManager.show_confirm("重新載入 section", "重新載入會放棄目前未儲存的內容，是否繼續？", func() -> void:
+			_load_section(_current_section_key)
+		)
+		return
+	_load_section(_current_section_key)
+
+
+func _on_discard_pressed() -> void:
+	if _dirty:
+		_load_section(_current_section_key)
+
+
+func _refresh_action_state() -> void:
+	var can_edit := not _loading_access and not _loading_section and _current_section_key != ""
+	_editor.editable = can_edit and not _saving
+	_save_button.disabled = not can_edit or not _dirty or _saving
+	_reload_button.disabled = not can_edit or _saving
+	_discard_button.disabled = not can_edit or not _dirty or _saving
+	_refresh_section_visuals()
+
+
+func _on_back_pressed() -> void:
+	if _dirty:
+		DialogManager.show_confirm("離開 Admin Catalog", "目前有未儲存的變更，離開會直接放棄，是否離開？", func() -> void:
+			SceneNavigator.return_to_battle()
+		)
+		return
+	SceneNavigator.return_to_battle()

--- a/scripts/configs/ConfigScene.gd
+++ b/scripts/configs/ConfigScene.gd
@@ -1,6 +1,7 @@
 extends Control
 
 const AssetResolver = preload("res://scripts/ui/asset_resolver.gd")
+const ADMIN_CATALOG_SCENE_PATH := "res://scenes/AdminCatalogScene.tscn"
 
 const MUTED_TEXT_COLOR := Color(0.90, 0.88, 0.82, 0.92)
 const SECTION_HINT_COLOR := Color(0.84, 0.80, 0.72, 0.88)
@@ -190,6 +191,8 @@ func _build_profile_section() -> Control:
 	_bind_profile_edit_events()
 	_refresh_avatar_selection()
 	_refresh_profile_save_state()
+	if GameState.is_admin_session():
+		column.add_child(_build_admin_catalog_row())
 	return section
 
 
@@ -262,6 +265,47 @@ func _build_game_settings_section() -> Control:
 	column.add_child(_build_audio_row("sfx", "音效"))
 
 	return section
+
+
+func _build_admin_catalog_row() -> Control:
+	var panel: PanelContainer = PanelContainer.new()
+	panel.add_theme_stylebox_override("panel", OverlaySceneChrome.make_panel_style(FIELD_BG, FIELD_BORDER, 12))
+
+	var margin: MarginContainer = OverlaySceneChrome.make_content_margin(12)
+	panel.add_child(margin)
+
+	var row: HBoxContainer = HBoxContainer.new()
+	row.add_theme_constant_override("separation", 12)
+	margin.add_child(row)
+
+	var text_box: VBoxContainer = VBoxContainer.new()
+	text_box.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	text_box.add_theme_constant_override("separation", 4)
+	row.add_child(text_box)
+
+	var title: Label = Label.new()
+	title.text = "Admin Catalog"
+	title.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY_LG)
+	text_box.add_child(title)
+
+	var hint: Label = Label.new()
+	hint.text = "Every visit re-validates admin access before loading catalog settings."
+	hint.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	hint.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+	hint.add_theme_color_override("font_color", SECTION_HINT_COLOR)
+	text_box.add_child(hint)
+
+	var button: Button = Button.new()
+	button.text = "Open"
+	button.custom_minimum_size = Vector2(160.0, 46.0)
+	UiPalette.apply_button_kind(button, "confirm")
+	button.pressed.connect(UiAudio.play_ui_click)
+	button.pressed.connect(func() -> void:
+		SceneNavigator.open_overlay_scene(ADMIN_CATALOG_SCENE_PATH)
+	)
+	row.add_child(button)
+
+	return panel
 
 
 func _build_avatar_card(avatar_id: String) -> Control:

--- a/scripts/gamestate/GameState.gd
+++ b/scripts/gamestate/GameState.gd
@@ -142,12 +142,12 @@ func is_admin_session() -> bool:
 	if permissions_variant is Array:
 		for permission_variant: Variant in permissions_variant:
 			var permission: String = str(permission_variant).strip_edges().to_lower()
-			if permission == "admin":
+			if permission == "admin" or permission == "catalog.manage":
 				return true
 	elif permissions_variant is Dictionary:
 		for key_variant: Variant in permissions_variant.keys():
 			var permission_key: String = str(key_variant).strip_edges().to_lower()
-			if permission_key == "admin" and bool(permissions_variant.get(key_variant, false)):
+			if (permission_key == "admin" or permission_key == "catalog.manage") and bool(permissions_variant.get(key_variant, false)):
 				return true
 
 	return false


### PR DESCRIPTION
## What changed
- add an Admin Catalog overlay scene and entry point from the settings center
- add dedicated Admin Catalog API client methods
- update admin-session detection so `catalog.manage` permission can unlock the entry
- add frontend GDD documentation for the Admin Catalog page

## Why
- Admin needs a client-side entry point to manage catalog/static data through protected admin APIs
- the page must re-check access on every entry instead of relying on cached bootstrap payloads

## Impact
- only admin-capable sessions see the Admin Catalog row in settings
- entering the page calls `GET /api/admin/catalog/access` before any section data is shown
- v1 editor is a section-based JSON aggregate editor with a reference sidebar

## Validation
- diff reviewed in clean publish worktree to ensure expedition-related changes were excluded
- no automated Godot runtime smoke test was available in this environment

## Notes
- this PR is paired with the backend PR that adds the admin catalog endpoints and DB model
- the page intentionally does not use player bootstrap data as its source of truth