### PR TITLE
fix:修正首頁社交與子選單 UI 流程

### DIFF
--- a/scenes/ui/HomeTopHudEditor.tscn
+++ b/scenes/ui/HomeTopHudEditor.tscn
@@ -5,6 +5,7 @@
 [ext_resource type="Texture2D" uid="uid://dsr2bhbkssjhs" path="res://assets/sprites/ui/character_refs/black_cat/black_cat_icon_v1.png" id="3"]
 [ext_resource type="Texture2D" uid="uid://bakdwyhnhd6rl" path="res://assets/sprites/ui/rewards/diamonds.png" id="4"]
 [ext_resource type="Texture2D" uid="uid://dji0cn00sr1pf" path="res://assets/sprites/ui/rewards/gold.png.png" id="5"]
+[ext_resource type="Texture2D" path="res://assets/sprites/ui/rewards/collision_coin.png" id="9"]
 [ext_resource type="Texture2D" uid="uid://dp37dv6b4djcv" path="res://assets/sprites/ui/skill_icons/strike_v1.png" id="6"]
 
 [sub_resource type="StyleBoxFlat" id="1"]
@@ -151,7 +152,7 @@ offset_left = -186.0
 offset_top = 26.0
 offset_right = -125.0
 offset_bottom = 87.0
-texture = ExtResource("5")
+texture = ExtResource("9")
 expand_mode = 1
 stretch_mode = 5
 

--- a/scripts/ApiClient.gd
+++ b/scripts/ApiClient.gd
@@ -2,7 +2,7 @@ extends Node
 
 const POOL_SIZE := 3
 const REQUEST_TIMEOUT := 15.0
-const LOADING_LAYER := 90
+const LOADING_LAYER := 140
 const DEFAULT_LOADING_MESSAGE := "loading."
 const NGROK_SKIP_WARNING_HEADER := "ngrok-skip-browser-warning: true"
 
@@ -278,8 +278,8 @@ func disband_party(party_id: int, callback: Callable) -> void:
 	_api_delete("party/%d" % party_id, callback)
 
 
-func transfer_party_leadership(party_id: int, callback: Callable) -> void:
-	_api_post("party/%d/transfer-leadership" % party_id, {}, callback)
+func transfer_party_leadership(party_id: int, target_user_id: int, callback: Callable) -> void:
+	_api_post("party/%d/transfer-leadership" % party_id, {"targetUserId": target_user_id}, callback)
 
 
 func kick_party_member(party_id: int, target_user_id: int, callback: Callable) -> void:

--- a/scripts/MailScene.gd
+++ b/scripts/MailScene.gd
@@ -2,8 +2,14 @@ extends Control
 
 const AssetResolver = preload("res://scripts/ui/asset_resolver.gd")
 
+const SELECTED_BUTTON_COLOR := Color(1.0, 0.94, 0.78, 1.0)
+const UNSELECTED_BUTTON_COLOR := Color(0.92, 0.90, 0.86, 1.0)
+const ERROR_COLOR := Color(1.0, 0.45, 0.45, 1.0)
+const NORMAL_COLOR := Color(0.92, 0.92, 0.92, 1.0)
+
 var _summary_label: Label
-var _mail_list: ItemList
+var _mail_button_list: VBoxContainer
+var _mail_buttons: Dictionary = {}
 var _detail_title: Label
 var _detail_meta: Label
 var _detail_content: RichTextLabel
@@ -13,19 +19,17 @@ var _claim_all_btn: Button
 var _status_label: Label
 var _close_action: Callable = Callable()
 var _api_in_flight: bool = false
+var _selected_mail_id: int = 0
 
 
 func _ready() -> void:
 	set_anchors_preset(Control.PRESET_FULL_RECT)
-	custom_minimum_size = Vector2(620, 900)
+	custom_minimum_size = Vector2(620.0, 900.0)
 	_build_ui()
 	_refresh_summary()
-	_populate_mail_list()
-	if _mail_list.item_count > 0:
-		_mail_list.select(0)
-		_on_mail_selected(0)
-	else:
-		_render_detail({})
+	_render_detail({})
+	_load_mail_summary()
+	_load_mail_list()
 
 
 func set_close_action(action: Callable) -> void:
@@ -33,10 +37,9 @@ func set_close_action(action: Callable) -> void:
 
 
 func _build_ui() -> void:
-	var bg := AssetResolver.make_fullscreen_background("mail")
-	add_child(bg)
+	add_child(AssetResolver.make_fullscreen_background("mail"))
 
-	var root := MarginContainer.new()
+	var root: MarginContainer = MarginContainer.new()
 	root.set_anchors_preset(Control.PRESET_FULL_RECT)
 	root.add_theme_constant_override("margin_left", 24)
 	root.add_theme_constant_override("margin_top", 24)
@@ -44,17 +47,17 @@ func _build_ui() -> void:
 	root.add_theme_constant_override("margin_bottom", 24)
 	add_child(root)
 
-	var layout := VBoxContainer.new()
+	var layout: VBoxContainer = VBoxContainer.new()
 	layout.add_theme_constant_override("separation", 16)
 	root.add_child(layout)
 
-	var header := HBoxContainer.new()
+	var header: HBoxContainer = HBoxContainer.new()
 	header.add_theme_constant_override("separation", 12)
 	layout.add_child(header)
 
-	var back_btn := Button.new()
+	var back_btn: Button = Button.new()
 	back_btn.text = "返回"
-	back_btn.custom_minimum_size = Vector2(92, 48)
+	back_btn.custom_minimum_size = Vector2(92.0, 48.0)
 	back_btn.pressed.connect(func() -> void:
 		if _close_action.is_valid():
 			_close_action.call()
@@ -63,155 +66,236 @@ func _build_ui() -> void:
 	)
 	header.add_child(back_btn)
 
-	var title := Label.new()
-	title.text = "郵件"
+	var title: Label = Label.new()
+	title.text = "信箱"
 	title.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	title.add_theme_font_size_override("font_size", 30)
+	title.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_DISPLAY)
 	header.add_child(title)
+
+	var body_row: HBoxContainer = HBoxContainer.new()
+	body_row.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	body_row.add_theme_constant_override("separation", 16)
+	layout.add_child(body_row)
+
+	var left_panel: PanelContainer = OverlaySceneChrome.make_card_panel()
+	left_panel.custom_minimum_size = Vector2(240.0, 0.0)
+	left_panel.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	body_row.add_child(left_panel)
+
+	var left_margin: MarginContainer = OverlaySceneChrome.make_content_margin(16)
+	left_panel.add_child(left_margin)
+
+	var left_box: VBoxContainer = VBoxContainer.new()
+	left_box.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	left_box.add_theme_constant_override("separation", 12)
+	left_margin.add_child(left_box)
+
+	_summary_label = Label.new()
+	_summary_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_summary_label.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY)
+	left_box.add_child(_summary_label)
 
 	_claim_all_btn = Button.new()
 	_claim_all_btn.text = "全部領取"
-	_claim_all_btn.custom_minimum_size = Vector2(140, 48)
+	_claim_all_btn.custom_minimum_size = Vector2(0.0, 48.0)
+	UiPalette.apply_button_kind(_claim_all_btn, "confirm")
 	_claim_all_btn.pressed.connect(_on_claim_all_pressed)
-	header.add_child(_claim_all_btn)
+	left_box.add_child(_claim_all_btn)
 
-	_summary_label = Label.new()
-	_summary_label.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY)
-	layout.add_child(_summary_label)
+	var list_scroll: ScrollContainer = ScrollContainer.new()
+	list_scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	list_scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	list_scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+	left_box.add_child(list_scroll)
+	InertialScroller.attach(list_scroll, "vertical")
 
-	var split := VSplitContainer.new()
-	split.size_flags_vertical = Control.SIZE_EXPAND_FILL
-	layout.add_child(split)
+	_mail_button_list = VBoxContainer.new()
+	_mail_button_list.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_mail_button_list.add_theme_constant_override("separation", 8)
+	list_scroll.add_child(_mail_button_list)
 
-	_mail_list = ItemList.new()
-	_mail_list.custom_minimum_size = Vector2(0, 360)
-	_mail_list.item_selected.connect(_on_mail_selected)
-	split.add_child(_mail_list)
+	var right_panel: PanelContainer = OverlaySceneChrome.make_card_panel()
+	right_panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	right_panel.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	body_row.add_child(right_panel)
 
-	var detail_panel := PanelContainer.new()
-	split.add_child(detail_panel)
+	var right_margin: MarginContainer = OverlaySceneChrome.make_content_margin(16)
+	right_panel.add_child(right_margin)
 
-	var detail_margin := MarginContainer.new()
-	detail_margin.add_theme_constant_override("margin_left", 16)
-	detail_margin.add_theme_constant_override("margin_top", 16)
-	detail_margin.add_theme_constant_override("margin_right", 16)
-	detail_margin.add_theme_constant_override("margin_bottom", 16)
-	detail_panel.add_child(detail_margin)
-
-	var detail_layout := VBoxContainer.new()
-	detail_layout.add_theme_constant_override("separation", 10)
-	detail_margin.add_child(detail_layout)
+	var right_box: VBoxContainer = VBoxContainer.new()
+	right_box.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	right_box.add_theme_constant_override("separation", 10)
+	right_margin.add_child(right_box)
 
 	_detail_title = Label.new()
 	_detail_title.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_TITLE)
-	detail_layout.add_child(_detail_title)
+	right_box.add_child(_detail_title)
 
 	_detail_meta = Label.new()
 	_detail_meta.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	detail_layout.add_child(_detail_meta)
+	_detail_meta.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+	_detail_meta.add_theme_color_override("font_color", OverlaySceneChrome.MUTED_TEXT_COLOR)
+	right_box.add_child(_detail_meta)
+
+	var detail_scroll: ScrollContainer = ScrollContainer.new()
+	detail_scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	detail_scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	detail_scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+	right_box.add_child(detail_scroll)
+	InertialScroller.attach(detail_scroll, "vertical")
+
+	var detail_layout: VBoxContainer = VBoxContainer.new()
+	detail_layout.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	detail_layout.add_theme_constant_override("separation", 12)
+	detail_scroll.add_child(detail_layout)
 
 	_detail_content = RichTextLabel.new()
 	_detail_content.fit_content = true
-	_detail_content.scroll_active = true
-	_detail_content.custom_minimum_size = Vector2(0, 180)
+	_detail_content.scroll_active = false
+	_detail_content.bbcode_enabled = false
+	_detail_content.custom_minimum_size = Vector2(0.0, 220.0)
 	detail_layout.add_child(_detail_content)
 
-	var attachment_title := Label.new()
+	var attachment_title: Label = Label.new()
 	attachment_title.text = "附件"
 	attachment_title.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY_LG)
 	detail_layout.add_child(attachment_title)
 
-	var attachment_scroll := ScrollContainer.new()
-	attachment_scroll.custom_minimum_size = Vector2(0, 180)
-	attachment_scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	attachment_scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
-	detail_layout.add_child(attachment_scroll)
-
 	_attachment_box = VBoxContainer.new()
-	_attachment_box.add_theme_constant_override("separation", 8)
 	_attachment_box.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	_attachment_box.custom_minimum_size = Vector2(360, 0)
-	attachment_scroll.add_child(_attachment_box)
+	_attachment_box.add_theme_constant_override("separation", 8)
+	detail_layout.add_child(_attachment_box)
 
 	_claim_btn = Button.new()
 	_claim_btn.text = "領取"
-	_claim_btn.custom_minimum_size = Vector2(0, 50)
+	_claim_btn.custom_minimum_size = Vector2(0.0, 50.0)
+	UiPalette.apply_button_kind(_claim_btn, "confirm")
 	_claim_btn.pressed.connect(_on_claim_pressed)
-	detail_layout.add_child(_claim_btn)
+	right_box.add_child(_claim_btn)
 
 	_status_label = Label.new()
 	_status_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	layout.add_child(_status_label)
 
 
-func _load_mail_list(select_first: bool = true) -> void:
-	_set_status("正在同步郵件...", false)
+func _load_mail_list() -> void:
+	_set_status("正在同步信箱...", false)
 	ApiClient.get_mail_list(func(success: bool, data: Variant, error: Dictionary) -> void:
 		if not success:
-			_set_status(error.get("message", "讀取郵件失敗。"), true)
+			_set_status(str(error.get("message", "讀取信箱失敗。")), true)
 			return
+
 		var payload: Dictionary = data if data is Dictionary else {}
 		var items_variant: Variant = payload.get("items", [])
 		var items: Array = items_variant if items_variant is Array else []
 		GameState.update_mail_list(items)
 		_refresh_summary()
-		_populate_mail_list()
-		_api_in_flight = false
-		_refresh_action_buttons()
+		_rebuild_mail_buttons()
 		_set_status("", false)
-		if select_first and _mail_list.item_count > 0:
-			_mail_list.select(0)
-			_on_mail_selected(0)
-		elif _mail_list.item_count == 0:
+
+		var target_mail_id: int = _selected_mail_id
+		if target_mail_id <= 0 and not GameState.mail_list_data.is_empty():
+			target_mail_id = int((GameState.mail_list_data[0] as Dictionary).get("mailId", 0))
+		if target_mail_id > 0:
+			_select_mail(target_mail_id)
+		else:
 			GameState.update_selected_mail({})
+			_selected_mail_id = 0
 			_render_detail({})
 	)
 
 
-func _populate_mail_list() -> void:
-	_mail_list.clear()
+func _load_mail_summary() -> void:
+	ApiClient.get_mail_summary(func(success: bool, data: Variant, _error: Dictionary) -> void:
+		if success and data is Dictionary:
+			GameState.update_mail_summary(data)
+			_refresh_summary()
+	)
+
+
+func _rebuild_mail_buttons() -> void:
+	for child: Node in _mail_button_list.get_children():
+		child.queue_free()
+	_mail_buttons.clear()
+
 	for item_variant: Variant in GameState.mail_list_data:
 		if not (item_variant is Dictionary):
 			continue
 		var item: Dictionary = item_variant
-		var title := str(item.get("title", "未命名郵件"))
-		var label := title
-		if not bool(item.get("isClaimed", false)) and bool(item.get("hasAttachment", false)):
-			label = "獎 " + label
-		if not bool(item.get("isRead", false)):
-			label = "● " + label
-		if str(item.get("status", "")) == "Expired":
-			label += " [已過期]"
-		_mail_list.add_item(label)
+		var mail_id: int = int(item.get("mailId", 0))
+		if mail_id <= 0:
+			continue
+		var button: Button = Button.new()
+		button.text = _build_mail_button_text(item)
+		button.alignment = HORIZONTAL_ALIGNMENT_LEFT
+		button.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
+		button.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+		button.custom_minimum_size = Vector2(0.0, 60.0)
+		button.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		button.pressed.connect(func() -> void:
+			_select_mail(mail_id)
+		)
+		_mail_button_list.add_child(button)
+		_mail_buttons[mail_id] = button
+
+	_refresh_mail_button_states()
 
 
-func _on_mail_selected(index: int) -> void:
-	if index < 0 or index >= GameState.mail_list_data.size():
-		return
-	var detail_variant: Variant = GameState.mail_list_data[index]
-	if not (detail_variant is Dictionary):
-		return
-	var detail: Dictionary = detail_variant
-	var mail_id := int(detail.get("mailId", 0))
+func _build_mail_button_text(item: Dictionary) -> String:
+	var parts: Array[String] = []
+	if not bool(item.get("isRead", false)):
+		parts.append("●")
+	if bool(item.get("hasAttachment", false)) and not bool(item.get("isClaimed", false)):
+		parts.append("可領")
+	parts.append(str(item.get("title", "未命名郵件")))
+	if str(item.get("status", "")) == "Expired":
+		parts.append("[已過期]")
+	return " ".join(parts)
+
+
+func _select_mail(mail_id: int) -> void:
 	if mail_id <= 0:
 		return
+	_selected_mail_id = mail_id
+	_refresh_mail_button_states()
+	_load_mail_detail(mail_id)
 
-	GameState.update_selected_mail(detail)
-	_render_detail(detail)
-	_set_status("", false)
 
-	if not bool(detail.get("isRead", false)):
-		GameState.mark_mail_read_local(mail_id)
-		_refresh_summary()
-		ApiClient.mark_mail_read(mail_id, func(mark_success: bool, mark_data: Variant, _mark_error: Dictionary) -> void:
-			if mark_success and mark_data is Dictionary:
-				GameState.update_mail_summary(mark_data)
-				_refresh_summary()
-		)
+func _refresh_mail_button_states() -> void:
+	for mail_id_variant: Variant in _mail_buttons.keys():
+		var mail_id: int = int(mail_id_variant)
+		var button: Button = _mail_buttons.get(mail_id) as Button
+		if button == null:
+			continue
+		button.modulate = SELECTED_BUTTON_COLOR if mail_id == _selected_mail_id else UNSELECTED_BUTTON_COLOR
+
+
+func _load_mail_detail(mail_id: int) -> void:
+	_set_status("正在讀取郵件內容...", false)
+	ApiClient.get_mail_detail(mail_id, func(success: bool, data: Variant, error: Dictionary) -> void:
+		if not success:
+			_set_status(str(error.get("message", "讀取郵件內容失敗。")), true)
+			return
+
+		var detail: Dictionary = data if data is Dictionary else {}
+		GameState.update_selected_mail(detail)
+		_render_detail(detail)
+		_set_status("", false)
+
+		if not bool(detail.get("isRead", false)):
+			GameState.mark_mail_read_local(mail_id)
+			_refresh_summary()
+			_rebuild_mail_buttons()
+			ApiClient.mark_mail_read(mail_id, func(mark_success: bool, mark_data: Variant, _mark_error: Dictionary) -> void:
+				if mark_success and mark_data is Dictionary:
+					GameState.update_mail_summary(mark_data)
+					_refresh_summary()
+			)
+	)
 
 
 func _render_detail(detail: Dictionary) -> void:
-	for child in _attachment_box.get_children():
+	for child: Node in _attachment_box.get_children():
 		child.queue_free()
 
 	if detail.is_empty():
@@ -223,14 +307,10 @@ func _render_detail(detail: Dictionary) -> void:
 		return
 
 	_detail_title.text = str(detail.get("title", "未命名郵件"))
-	var expire_text := "無"
-	var expire_variant: Variant = detail.get("expireAtUtc", null)
-	if expire_variant != null:
-		expire_text = str(expire_variant).substr(0, 19)
 	_detail_meta.text = "類型：%s | 狀態：%s | 到期：%s" % [
 		str(detail.get("mailType", "")),
 		str(detail.get("status", "")),
-		expire_text
+		_format_expire_text(detail.get("expireAtUtc", null))
 	]
 	_detail_content.text = str(detail.get("content", ""))
 
@@ -239,52 +319,68 @@ func _render_detail(detail: Dictionary) -> void:
 	for attachment_variant: Variant in attachments:
 		if not (attachment_variant is Dictionary):
 			continue
-		var attachment: Dictionary = attachment_variant
-		var row := HBoxContainer.new()
-		row.add_theme_constant_override("separation", 8)
-		row.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-		row.custom_minimum_size = Vector2(340, 0)
-		var attachment_texture := AssetResolver.load_texture(AssetResolver.resolve_catalog_path(attachment.get("imagePath", "")))
-		if attachment_texture != null:
-			row.add_child(AssetResolver.create_icon_rect(attachment_texture, Vector2(48.0, 48.0)))
-		var body := Label.new()
-		body.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-		body.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-		var prefix := "已領取" if bool(attachment.get("isClaimed", false)) else "可領取"
-		body.text = "%s %s x%d\n%s" % [
-			prefix,
-			str(attachment.get("displayName", attachment.get("rewardType", ""))),
-			int(attachment.get("quantity", 0)),
-			str(attachment.get("description", ""))
-		]
-		row.add_child(body)
-		_attachment_box.add_child(row)
+		_attachment_box.add_child(_build_attachment_row(attachment_variant))
 
-	_claim_btn.disabled = not bool(detail.get("canClaim", false))
+	_claim_btn.disabled = _api_in_flight or not bool(detail.get("canClaim", false))
 	_claim_btn.text = "已領取" if bool(detail.get("isClaimed", false)) else "領取"
+
+
+func _build_attachment_row(attachment_variant: Variant) -> Control:
+	var attachment: Dictionary = attachment_variant
+	var row: HBoxContainer = HBoxContainer.new()
+	row.add_theme_constant_override("separation", 8)
+	row.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+
+	var texture: Texture2D = AssetResolver.load_texture(AssetResolver.resolve_catalog_path(attachment.get("imagePath", "")))
+	if texture != null:
+		row.add_child(AssetResolver.create_icon_rect(texture, Vector2(48.0, 48.0)))
+
+	var body: Label = Label.new()
+	body.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	body.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	body.text = "%s %s x%d\n%s" % [
+		"已領取" if bool(attachment.get("isClaimed", false)) else "可領取",
+		str(attachment.get("displayName", attachment.get("rewardType", ""))),
+		int(attachment.get("quantity", 0)),
+		str(attachment.get("description", ""))
+	]
+	row.add_child(body)
+	return row
+
+
+func _format_expire_text(expire_variant: Variant) -> String:
+	if expire_variant == null:
+		return "無"
+	var expire_text: String = str(expire_variant)
+	if expire_text == "":
+		return "無"
+	return expire_text.substr(0, 19)
 
 
 func _on_claim_pressed() -> void:
 	if _api_in_flight:
 		return
-	var mail_id := int(GameState.selected_mail_data.get("mailId", 0))
+	var mail_id: int = int(GameState.selected_mail_data.get("mailId", 0))
 	if mail_id <= 0:
 		return
+
 	_api_in_flight = true
 	_refresh_action_buttons()
 	ApiClient.claim_mail(mail_id, func(success: bool, data: Variant, error: Dictionary) -> void:
+		_api_in_flight = false
 		if not success:
-			_api_in_flight = false
 			_refresh_action_buttons()
-			_set_status(error.get("message", "領取失敗。"), true)
+			_set_status(str(error.get("message", "領取失敗。")), true)
 			return
+
 		var payload: Dictionary = data if data is Dictionary else {}
 		GameState.apply_wallet_snapshot(payload.get("walletSnapshot", {}))
 		GameState.update_mail_summary(payload.get("mailSummary", {}))
 		GameState.mark_mail_claimed_local(mail_id)
 		_refresh_summary()
+		_rebuild_mail_buttons()
 		_render_detail(GameState.selected_mail_data)
-		_populate_mail_list()
+		_refresh_action_buttons()
 		_render_reward_dialog(payload.get("grantedRewards", []), "領取成功")
 	)
 
@@ -295,22 +391,25 @@ func _on_claim_all_pressed() -> void:
 	if int(GameState.mail_summary_data.get("claimableCount", 0)) <= 0:
 		_set_status("目前沒有可領取的郵件。", true)
 		return
+
 	DialogManager.show_confirm("全部領取", "確定要領取目前所有可領取附件嗎？", func() -> void:
 		_api_in_flight = true
 		_refresh_action_buttons()
 		ApiClient.claim_all_mails(func(success: bool, data: Variant, error: Dictionary) -> void:
 			_api_in_flight = false
-			_refresh_action_buttons()
 			if not success:
-				_set_status(error.get("message", "全部領取失敗。"), true)
+				_refresh_action_buttons()
+				_set_status(str(error.get("message", "全部領取失敗。")), true)
 				return
+
 			var payload: Dictionary = data if data is Dictionary else {}
 			GameState.apply_wallet_snapshot(payload.get("walletSnapshot", {}))
 			GameState.update_mail_summary(payload.get("mailSummary", {}))
 			GameState.mark_mail_claimed_many_local(payload.get("claimedMailIds", []))
 			_refresh_summary()
+			_rebuild_mail_buttons()
 			_render_detail(GameState.selected_mail_data)
-			_populate_mail_list()
+			_refresh_action_buttons()
 			_render_reward_dialog(payload.get("grantedRewards", []), "全部領取完成")
 		)
 	)
@@ -333,18 +432,17 @@ func _render_reward_dialog(rewards: Variant, title: String) -> void:
 
 
 func _refresh_summary() -> void:
-	_summary_label.text = "未讀 %d | 可領 %d | 總數 %d" % [
+	_summary_label.text = "未讀 %d\n可領 %d\n總數 %d" % [
 		int(GameState.mail_summary_data.get("unreadCount", 0)),
 		int(GameState.mail_summary_data.get("claimableCount", 0)),
 		int(GameState.mail_summary_data.get("totalCount", 0))
 	]
-	_claim_all_btn.disabled = int(GameState.mail_summary_data.get("claimableCount", 0)) <= 0
 	_refresh_action_buttons()
 
 
 func _set_status(message: String, is_error: bool) -> void:
 	_status_label.text = message
-	_status_label.modulate = Color(1.0, 0.45, 0.45, 1.0) if is_error else Color(0.9, 0.9, 0.9, 1.0)
+	_status_label.modulate = ERROR_COLOR if is_error else NORMAL_COLOR
 
 
 func _refresh_action_buttons() -> void:

--- a/scripts/backpack/backpack_scene.gd
+++ b/scripts/backpack/backpack_scene.gd
@@ -2,9 +2,19 @@ class_name BackpackScene
 extends Control
 
 const AssetResolver = preload("res://scripts/ui/asset_resolver.gd")
+const SceneSubmenuBar = preload("res://scripts/ui/scene_submenu_bar.gd")
+
+const TAB_ALL := "all"
+const TAB_CURRENCY := "currency"
+const TAB_TICKET := "ticket"
+const TAB_CONSUMABLE := "consumable"
 
 const ICON_SIZE := Vector2(52.0, 52.0)
 const GRID_COLS := 3
+
+var _active_tab: String = TAB_ALL
+var _tab_buttons: Dictionary = {}
+var _content_box: VBoxContainer
 
 @onready var GameState = get_node("/root/GameState")
 
@@ -12,67 +22,113 @@ const GRID_COLS := 3
 func _ready() -> void:
 	set_anchors_preset(Control.PRESET_FULL_RECT)
 	var chrome: Dictionary = OverlaySceneChrome.build(self, "shop", _on_back_pressed, {
-		"show_dock": false,
+		"show_dock": true,
+		"dock_items": _build_tab_items(),
+		"active_key": _active_tab,
+		"button_pressed": Callable(self, "_switch_tab"),
 	})
-	_build_content(chrome["content_box"])
+	_tab_buttons = chrome.get("dock_buttons", {})
+	_build_content(chrome.get("content_box") as VBoxContainer)
+	_refresh_content()
 
 
 func _on_back_pressed() -> void:
 	SceneNavigator.return_to_battle()
 
 
+func _switch_tab(tab_key: String) -> void:
+	if _active_tab == tab_key:
+		return
+	_active_tab = tab_key
+	_refresh_content()
+
+
 func _build_content(box: VBoxContainer) -> void:
-	var title := Label.new()
+	var title: Label = Label.new()
 	title.text = UiText.BACKPACK_TITLE
 	title.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_DISPLAY)
 	title.add_theme_color_override("font_color", OverlaySceneChrome.TITLE_TEXT_COLOR)
 	box.add_child(title)
 
+	var subtitle: Label = Label.new()
+	subtitle.text = "切換下方子選單檢視背包內容。"
+	subtitle.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	subtitle.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY)
+	subtitle.add_theme_color_override("font_color", OverlaySceneChrome.MUTED_TEXT_COLOR)
+	box.add_child(subtitle)
+
 	box.add_child(HSeparator.new())
 
-	var scroll := ScrollContainer.new()
+	var scroll: ScrollContainer = ScrollContainer.new()
 	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	box.add_child(scroll)
 	InertialScroller.attach(scroll, "vertical")
 
-	var vbox := VBoxContainer.new()
-	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	vbox.add_theme_constant_override("separation", 16)
-	scroll.add_child(vbox)
+	_content_box = VBoxContainer.new()
+	_content_box.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_content_box.add_theme_constant_override("separation", 16)
+	scroll.add_child(_content_box)
 
-	_build_currency_section(vbox)
-	vbox.add_child(HSeparator.new())
-	_build_ticket_section(vbox)
-	vbox.add_child(HSeparator.new())
-	_build_consumable_section(vbox)
+
+func _refresh_content() -> void:
+	if _content_box == null:
+		return
+	for child: Node in _content_box.get_children():
+		child.queue_free()
+
+	match _active_tab:
+		TAB_CURRENCY:
+			_build_currency_section(_content_box)
+		TAB_TICKET:
+			_build_ticket_section(_content_box)
+		TAB_CONSUMABLE:
+			_build_consumable_section(_content_box)
+		_:
+			_build_currency_section(_content_box)
+			_content_box.add_child(HSeparator.new())
+			_build_ticket_section(_content_box)
+			_content_box.add_child(HSeparator.new())
+			_build_consumable_section(_content_box)
+
+	SceneSubmenuBar.refresh(_tab_buttons, _active_tab)
+
+
+func _build_tab_items() -> Array:
+	return [
+		{"key": TAB_ALL, "label": "全部"},
+		{"key": TAB_CURRENCY, "label": UiText.BACKPACK_SECTION_CURRENCY},
+		{"key": TAB_TICKET, "label": UiText.BACKPACK_SECTION_TICKET},
+		{"key": TAB_CONSUMABLE, "label": UiText.BACKPACK_SECTION_CONSUMABLE},
+	]
 
 
 func _build_section_header(parent: VBoxContainer, label_text: String) -> void:
-	var row := HBoxContainer.new()
+	var row: HBoxContainer = HBoxContainer.new()
 	row.add_theme_constant_override("separation", 10)
 	parent.add_child(row)
 
-	var lbl := Label.new()
+	var lbl: Label = Label.new()
 	lbl.text = label_text
 	lbl.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY)
 	lbl.add_theme_color_override("font_color", OverlaySceneChrome.MUTED_TEXT_COLOR)
 	row.add_child(lbl)
 
-	var sep := HSeparator.new()
+	var sep: HSeparator = HSeparator.new()
 	sep.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	row.add_child(sep)
 
 
 func _build_item_grid(parent: VBoxContainer, items: Array) -> void:
-	var grid := GridContainer.new()
+	var grid: GridContainer = GridContainer.new()
 	grid.columns = GRID_COLS
 	grid.add_theme_constant_override("h_separation", 10)
 	grid.add_theme_constant_override("v_separation", 10)
 	grid.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	parent.add_child(grid)
 
-	for item: Dictionary in items:
-		grid.add_child(_make_item_card(item))
+	for item_variant: Variant in items:
+		if item_variant is Dictionary:
+			grid.add_child(_make_item_card(item_variant as Dictionary))
 
 
 func _make_item_card(item: Dictionary) -> Control:
@@ -83,10 +139,10 @@ func _make_item_card(item: Dictionary) -> Control:
 	var panel: PanelContainer = OverlaySceneChrome.make_card_panel(accent)
 	panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 
-	var margin := OverlaySceneChrome.make_content_margin(10)
+	var margin: MarginContainer = OverlaySceneChrome.make_content_margin(10)
 	panel.add_child(margin)
 
-	var vbox := VBoxContainer.new()
+	var vbox: VBoxContainer = VBoxContainer.new()
 	vbox.add_theme_constant_override("separation", 4)
 	margin.add_child(vbox)
 
@@ -94,15 +150,15 @@ func _make_item_card(item: Dictionary) -> Control:
 		AssetResolver.resolve_catalog_path(str(item.get("path", "")))
 	)
 	if tex != null:
-		var icon_row := CenterContainer.new()
+		var icon_row: CenterContainer = CenterContainer.new()
 		icon_row.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 		vbox.add_child(icon_row)
-		var icon := AssetResolver.create_icon_rect(tex, ICON_SIZE)
+		var icon: TextureRect = AssetResolver.create_icon_rect(tex, ICON_SIZE)
 		if not has_qty:
 			icon.modulate = Color(0.55, 0.55, 0.55, 0.80)
 		icon_row.add_child(icon)
 
-	var name_lbl := Label.new()
+	var name_lbl: Label = Label.new()
 	name_lbl.text = str(item.get("name", ""))
 	name_lbl.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_LABEL)
 	name_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
@@ -111,7 +167,7 @@ func _make_item_card(item: Dictionary) -> Control:
 		name_lbl.add_theme_color_override("font_color", Color(0.55, 0.55, 0.55, 0.90))
 	vbox.add_child(name_lbl)
 
-	var qty_lbl := Label.new()
+	var qty_lbl: Label = Label.new()
 	qty_lbl.text = str(qty)
 	qty_lbl.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY)
 	qty_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
@@ -151,21 +207,18 @@ func _build_ticket_section(parent: VBoxContainer) -> void:
 	_build_section_header(parent, UiText.BACKPACK_SECTION_TICKET)
 
 	var items: Array = []
-
-	var arena_overview: Dictionary = \
-		GameState.arena_overview_data if GameState.arena_overview_data is Dictionary else {}
+	var arena_overview: Dictionary = GameState.arena_overview_data if GameState.arena_overview_data is Dictionary else {}
 	items.append({
 		"path": "catalog/arena/bronze_1",
 		"name": UiText.BACKPACK_ARENA_TICKET,
 		"qty": int(arena_overview.get("tickets", 0)),
 	})
 
-	var dungeon_list: Array = \
-		GameState.dungeon_overview_data if GameState.dungeon_overview_data is Array else []
+	var dungeon_list: Array = GameState.dungeon_overview_data if GameState.dungeon_overview_data is Array else []
 	for dungeon_variant: Variant in dungeon_list:
 		if not (dungeon_variant is Dictionary):
 			continue
-		var dungeon: Dictionary = dungeon_variant
+		var dungeon: Dictionary = dungeon_variant as Dictionary
 		var key: String = str(dungeon.get("key", ""))
 		items.append({
 			"path": "catalog/dungeon/" + key,

--- a/scripts/battle/battle_scene.gd
+++ b/scripts/battle/battle_scene.gd
@@ -7,6 +7,14 @@ const BATTLE_BG_TEXTURE := preload("res://assets/sprites/ui/battle_background_ho
 const HOME_TOP_HUD_SCENE := preload("res://scenes/ui/HomeTopHudEditor.tscn")
 const HOME_SCOOP_TEMPLATE_SCENE := preload("res://scenes/ui/HomeScoopButtonTemplate.tscn")
 const HOME_TOP_BAR_TEXTURE := preload("res://assets/sprites/ui/home/v2/home_hud_main_v3.png")
+const HOME_NAV_BAR_TEXTURE := preload("res://assets/sprites/ui/home/nav/home_nav_bar_v2.png")
+const HOME_NAV_TAB_IDLE_TEXTURE := preload("res://assets/sprites/ui/home/nav/home_nav_tab_idle_v2.png")
+const HOME_NAV_TAB_ACTIVE_TEXTURE := preload("res://assets/sprites/ui/home/nav/home_nav_tab_active_v2.png")
+const HOME_NAV_TAB_PRESSED_TEXTURE := preload("res://assets/sprites/ui/home/nav/home_nav_tab_pressed_v2.png")
+const HOME_NAV_ICON_SCOOPER_TEXTURE := preload("res://assets/sprites/ui/home/nav/home_nav_icon_scooper_v2.png")
+const HOME_NAV_ICON_ENHANCE_TEXTURE := preload("res://assets/sprites/ui/home/nav/home_nav_icon_enhance_v2.png")
+const HOME_NAV_ICON_ACTIVITY_TEXTURE := preload("res://assets/sprites/ui/home/nav/home_nav_icon_activity_v2.png")
+const HOME_NAV_ICON_SHOP_TEXTURE := preload("res://assets/sprites/ui/home/nav/home_nav_icon_shop_v2.png")
 const HOME_SCOOP_SHEET_TEXTURE := preload("res://assets/sprites/ui/home/scooper/clean_litter_button_sheet.png")
 const HOME_AUTO_SCOOP_TOGGLE_OFF_TEXTURE := preload("res://assets/sprites/ui/home/scooper/auto_scoop_toggle_off.svg")
 const HOME_AUTO_SCOOP_TOGGLE_ON_TEXTURE := preload("res://assets/sprites/ui/home/scooper/auto_scoop_toggle_on.svg")
@@ -34,6 +42,11 @@ const SH := 1280.0
 const BATTLE_Y := 750.0
 const NAV_H := 110.0
 const NAV_Y := SH - NAV_H
+const HOME_NAV_LABEL_IDLE := Color(0.92, 0.86, 0.76, 0.96)
+const HOME_NAV_LABEL_ACTIVE := Color(1.0, 0.95, 0.83, 1.0)
+const HOME_NAV_LABEL_OUTLINE := Color(0.17, 0.09, 0.04, 0.98)
+const HOME_NAV_ICON_IDLE_MODULATE := Color(0.95, 0.93, 0.88, 0.92)
+const HOME_NAV_ICON_ACTIVE_MODULATE := Color(1.0, 1.0, 1.0, 1.0)
 
 # Skill bar baseline positioned just below BATTLE_Y.
 const SKILL_BAR_Y := BATTLE_Y + 10.0
@@ -131,6 +144,8 @@ var _mail_badge: Label
 var _friend_btn: Button
 var _party_btn: Button
 var _chat_btn: Button
+var _backpack_btn: Button
+var _lineup_btn: Button
 var _chat_badge: Label
 var _resource_value_labels: Dictionary = {}
 var _battle_countdown_fill: ColorRect
@@ -318,6 +333,7 @@ func _build_ui() -> void:
 	_top_avatar_rect.material = avatar_circle_material
 	var profile_entry_button := Button.new()
 	profile_entry_button.flat = true
+	profile_entry_button.action_mode = BaseButton.ACTION_MODE_BUTTON_PRESS
 	profile_entry_button.focus_mode = Control.FOCUS_NONE
 	profile_entry_button.position = Vector2(0.0, 14.0)
 	profile_entry_button.size = Vector2(180.0, 170.0)
@@ -330,7 +346,7 @@ func _build_ui() -> void:
 	_top_exp_bar = top_bar_root.get_node("TopExpBar") as ProgressBar
 	_top_progress_value_label = top_bar_root.get_node("ExpValueLabel") as Label
 	_resource_value_labels["diamonds"] = top_bar_root.get_node("DiamondsPanel/Value") as Label
-	_resource_value_labels["gold"] = top_bar_root.get_node("GoldPanel/Value") as Label
+	_resource_value_labels["trap_points"] = top_bar_root.get_node("GoldPanel/Value") as Label
 	_resource_value_labels["power"] = top_bar_root.get_node("PowerPanel/Value") as Label
 	var stage_panel := _make_panel(
 		Vector2(188.0, 244.0),
@@ -402,8 +418,21 @@ func _build_ui() -> void:
 	_stats_btn.pressed.connect(_on_stats_btn_pressed)
 	_ui_layer.add_child(_stats_btn)
 
+	_backpack_btn = _make_button(UiText.NAV_BACKPACK,
+			Vector2(ACTION_STACK_X, ACTION_STACK_Y + (ACTION_STACK_H + 10.0) * 5.0),
+			Vector2(ACTION_STACK_W, ACTION_STACK_H))
+	_backpack_btn.pressed.connect(_on_nav_backpack)
+	_ui_layer.add_child(_backpack_btn)
+
+	_lineup_btn = _make_button(UiText.NAV_CONFIG,
+			Vector2(ACTION_STACK_X, ACTION_STACK_Y + (ACTION_STACK_H + 10.0) * 6.0),
+			Vector2(ACTION_STACK_W, ACTION_STACK_H))
+	_lineup_btn.pressed.connect(_on_nav_config)
+	_ui_layer.add_child(_lineup_btn)
+
 	_stats_panel = StatsPanel.new()
 	_stats_panel.visible = false
+	_stats_panel.z_index = 50
 	_ui_layer.add_child(_stats_panel)
 
 	_boss_btn = _make_button(UiText.HOME_BOSS, Vector2(252.0, 350.0), Vector2(216.0, 42.0))
@@ -556,31 +585,25 @@ func _build_ui() -> void:
 	_nav_canvas.layer = 20
 	add_child(_nav_canvas)
 
-	var nav_bg: Control = _make_panel(
-		Vector2(0.0, NAV_Y),
-		Vector2(SW, NAV_H),
-		Color(0.11, 0.08, 0.06, 0.94),
-		Color(0.52, 0.40, 0.24, 1.0)
-	)
+	var nav_bg: Control = _build_home_nav_background()
 	_nav_canvas.add_child(nav_bg)
 
 	var nav_items: Array = [
-		[UiText.NAV_SCOOPER, "res://scenes/ScooperScene.tscn", _on_nav_scooper],
-		[UiText.NAV_CONFIG, "res://scenes/LineupScene.tscn", _on_nav_config],
-		[UiText.NAV_ENHANCE, "res://scenes/EnhanceScene.tscn", _on_nav_enhance],
-		[UiText.NAV_ACTIVITY, "res://scenes/ActivityScene.tscn", _on_nav_activity],
-		[UiText.NAV_SHOP, "res://scenes/ShopScene.tscn", _on_nav_shop],
-		[UiText.NAV_BACKPACK, "res://scenes/BackpackScene.tscn", _on_nav_backpack],
+		[UiText.NAV_SCOOPER, "res://scenes/ScooperScene.tscn", _on_nav_scooper, HOME_NAV_ICON_SCOOPER_TEXTURE],
+		[UiText.NAV_ENHANCE, "res://scenes/EnhanceScene.tscn", _on_nav_enhance, HOME_NAV_ICON_ENHANCE_TEXTURE],
+		[UiText.NAV_ACTIVITY, "res://scenes/ActivityScene.tscn", _on_nav_activity, HOME_NAV_ICON_ACTIVITY_TEXTURE],
+		[UiText.NAV_SHOP, "res://scenes/ShopScene.tscn", _on_nav_shop, HOME_NAV_ICON_SHOP_TEXTURE],
 	]
-	var btn_w := SW / nav_items.size()
+	var btn_w: float = SW / float(nav_items.size())
 	for i in range(nav_items.size()):
-		var nav_btn: Button = _make_button(
+		var nav_btn: TextureButton = _build_home_nav_button(
 			nav_items[i][0],
-			Vector2(i * btn_w + 8.0, NAV_Y + 12.0),
-			Vector2(btn_w - 16.0, NAV_H - 24.0)
+			nav_items[i][3],
+			Vector2(i * btn_w + 6.0, NAV_Y + 12.0),
+			Vector2(btn_w - 12.0, NAV_H - 22.0)
 		)
 		nav_btn.pressed.connect(nav_items[i][2])
-		nav_btn.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_HEADING)
+		_apply_home_nav_button_style(nav_btn, false)
 		_nav_canvas.add_child(nav_btn)
 		_nav_buttons[String(nav_items[i][1])] = nav_btn
 
@@ -920,6 +943,80 @@ func _make_button(txt: String, pos: Vector2, sz: Vector2) -> Button:
 	return btn
 
 
+func _build_home_nav_background() -> Control:
+	var background: TextureRect = TextureRect.new()
+	background.position = Vector2(0.0, NAV_Y)
+	background.size = Vector2(SW, NAV_H)
+	background.texture = HOME_NAV_BAR_TEXTURE
+	background.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	background.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+	background.stretch_mode = TextureRect.STRETCH_SCALE
+	background.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	return background
+
+
+func _build_home_nav_button(txt: String, icon_texture: Texture2D, pos: Vector2, sz: Vector2) -> TextureButton:
+	var btn: TextureButton = TextureButton.new()
+	btn.position = pos
+	btn.size = sz
+	btn.ignore_texture_size = true
+	btn.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	btn.stretch_mode = TextureButton.STRETCH_SCALE
+	btn.focus_mode = Control.FOCUS_NONE
+	btn.action_mode = BaseButton.ACTION_MODE_BUTTON_PRESS
+	btn.mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
+	btn.modulate = Color(1.0, 1.0, 1.0, 1.0)
+	btn.pressed.connect(UiAudio.play_ui_click)
+
+	var icon: TextureRect = TextureRect.new()
+	icon.name = "Icon"
+	icon.position = Vector2((sz.x - 46.0) * 0.5, 12.0)
+	icon.size = Vector2(46.0, 46.0)
+	icon.texture = icon_texture
+	icon.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	icon.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+	icon.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+	icon.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	btn.add_child(icon)
+
+	var label: Label = Label.new()
+	label.name = "Label"
+	label.position = Vector2(10.0, sz.y - 28.0)
+	label.size = Vector2(sz.x - 20.0, 18.0)
+	label.text = txt
+	label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	label.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_LABEL)
+	label.add_theme_constant_override("outline_size", 3)
+	label.add_theme_color_override("font_outline_color", HOME_NAV_LABEL_OUTLINE)
+	label.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	btn.add_child(label)
+
+	btn.set_meta("label_node", label)
+	btn.set_meta("icon_node", icon)
+	return btn
+
+
+func _apply_home_nav_button_style(button: TextureButton, is_active: bool) -> void:
+	if button == null:
+		return
+	button.texture_normal = HOME_NAV_TAB_ACTIVE_TEXTURE if is_active else HOME_NAV_TAB_IDLE_TEXTURE
+	button.texture_hover = HOME_NAV_TAB_ACTIVE_TEXTURE if is_active else HOME_NAV_TAB_IDLE_TEXTURE
+	button.texture_pressed = HOME_NAV_TAB_PRESSED_TEXTURE
+	button.texture_disabled = HOME_NAV_TAB_IDLE_TEXTURE
+
+	var label_variant: Variant = button.get_meta("label_node", null)
+	var label: Label = label_variant as Label
+	if label != null:
+		label.add_theme_font_size_override("font_size", 17 if is_active else 16)
+		label.add_theme_color_override("font_color", HOME_NAV_LABEL_ACTIVE if is_active else HOME_NAV_LABEL_IDLE)
+
+	var icon_variant: Variant = button.get_meta("icon_node", null)
+	var icon: TextureRect = icon_variant as TextureRect
+	if icon != null:
+		icon.modulate = HOME_NAV_ICON_ACTIVE_MODULATE if is_active else HOME_NAV_ICON_IDLE_MODULATE
+
+
 func _apply_skill_speed_button_style(button: Button, is_active: bool) -> void:
 	if button == null:
 		return
@@ -974,8 +1071,8 @@ func _refresh_resource_strip() -> void:
 		return
 	if _resource_value_labels.has("diamonds"):
 		_resource_value_labels["diamonds"].text = _format_resource_count(GameState.player_data.diamonds)
-	if _resource_value_labels.has("gold"):
-		_resource_value_labels["gold"].text = _format_resource_count(GameState.player_data.gold)
+	if _resource_value_labels.has("trap_points"):
+		_resource_value_labels["trap_points"].text = _format_resource_count(GameState.player_data.trap_points)
 	if _resource_value_labels.has("power"):
 		_resource_value_labels["power"].text = _format_resource_count(_cached_team_power)
 
@@ -1290,7 +1387,7 @@ func _layout_home_scoop_panel() -> void:
 	if _home_scoop_panel == null or _home_scoop_button == null:
 		return
 	var enhance_btn_variant: Variant = _nav_buttons.get("res://scenes/EnhanceScene.tscn")
-	var enhance_btn: Button = enhance_btn_variant as Button
+	var enhance_btn: TextureButton = enhance_btn_variant as TextureButton
 	if enhance_btn == null:
 		return
 	var target_center_x: float = enhance_btn.position.x + enhance_btn.size.x * 0.5
@@ -1305,12 +1402,11 @@ func _layout_home_scoop_panel() -> void:
 func _refresh_main_nav_state() -> void:
 	var active_scene_path: String = SceneNavigator.get_current_overlay_scene_path()
 	for scene_path: String in _nav_buttons.keys():
-		var btn: Button = _nav_buttons[scene_path]
+		var btn: TextureButton = _nav_buttons[scene_path] as TextureButton
 		if btn == null:
 			continue
 		var is_active: bool = scene_path == active_scene_path
-		btn.modulate = Color(1.0, 0.93, 0.76, 1.0) if is_active else Color(0.97, 0.93, 0.88, 1.0)
-		btn.add_theme_font_size_override("font_size", 30 if is_active else 28)
+		_apply_home_nav_button_style(btn, is_active)
 
 
 func get_damage_fx_host() -> Node2D:
@@ -2005,7 +2101,7 @@ func _on_nav_config() -> void:
 
 
 func _open_settings_scene() -> void:
-	_toggle_overlay_scene("res://scenes/ConfigScene.tscn")
+	call_deferred("_toggle_overlay_scene", "res://scenes/ConfigScene.tscn")
 
 
 func _on_nav_enhance() -> void:
@@ -2046,6 +2142,7 @@ func _on_stats_btn_pressed() -> void:
 		return
 	_stats_panel.visible = not _stats_panel.visible
 	if _stats_panel.visible:
+		_stats_panel.move_to_front()
 		_stats_panel.refresh()
 
 

--- a/scripts/chat/ChatScene.gd
+++ b/scripts/chat/ChatScene.gd
@@ -2,31 +2,29 @@ extends Control
 
 const ChatTabScript = preload("res://scripts/chat/chat_channel_tab.gd")
 const ChatItemScript = preload("res://scripts/chat/chat_message_item.gd")
-const AssetResolver = preload("res://scripts/ui/asset_resolver.gd")
 
-var _active_channel := "system"
+var _active_channel: String = "world"
 var _tab_buttons: Dictionary = {}
-var _initial_channel := ""
-var _status_label: Label
+var _initial_channel: String = ""
+var _header: HBoxContainer
 var _list_root: VBoxContainer
 var _scroll: ScrollContainer
 var _input: LineEdit
 var _send_button: Button
 var _hint_label: Label
-var _load_more_button: Button
 
 
 func _ready() -> void:
-	custom_minimum_size = Vector2(620, 900)
+	custom_minimum_size = Vector2(620.0, 900.0)
 	_build_ui()
 	GameState.chat_connection_state_changed.connect(_on_connection_state_changed)
 	GameState.chat_messages_changed.connect(_on_messages_changed)
 	GameState.chat_unread_changed.connect(_on_unread_changed)
-	if _initial_channel != "" and _available_channels().has(_initial_channel):
-		_active_channel = _initial_channel
+	_apply_requested_channel()
 	_refresh_tabs()
-	_refresh_connection_state(GameState.chat_connection_state)
 	_load_history(_active_channel, 0)
+	_render_messages()
+	_refresh_chat_summary()
 
 
 func set_initial_channel(channel_key: String) -> void:
@@ -34,34 +32,19 @@ func set_initial_channel(channel_key: String) -> void:
 
 
 func _build_ui() -> void:
-	add_child(AssetResolver.make_fullscreen_background("chat"))
-	var root := VBoxContainer.new()
+	var root: VBoxContainer = VBoxContainer.new()
 	root.set_anchors_preset(Control.PRESET_FULL_RECT)
 	root.add_theme_constant_override("separation", 8)
 	add_child(root)
 
-	var header := HBoxContainer.new()
-	root.add_child(header)
-
-	for item: Array in _build_channel_defs():
-		var tab := ChatTabScript.new()
-		tab.configure(item[0], item[1])
-		tab.pressed.connect(_on_tab_pressed.bind(item[0]))
-		header.add_child(tab)
-		_tab_buttons[item[0]] = tab
-
-	_status_label = Label.new()
-	_status_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
-	root.add_child(_status_label)
+	_header = HBoxContainer.new()
+	_header.add_theme_constant_override("separation", 8)
+	root.add_child(_header)
+	_rebuild_tabs()
 
 	_hint_label = Label.new()
 	_hint_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	root.add_child(_hint_label)
-
-	_load_more_button = Button.new()
-	_load_more_button.text = "Load older messages"
-	_load_more_button.pressed.connect(_on_load_more_pressed)
-	root.add_child(_load_more_button)
 
 	_scroll = ScrollContainer.new()
 	_scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
@@ -72,82 +55,160 @@ func _build_ui() -> void:
 	_list_root.add_theme_constant_override("separation", 6)
 	_scroll.add_child(_list_root)
 
-	var input_row := HBoxContainer.new()
+	var input_row: HBoxContainer = HBoxContainer.new()
+	input_row.add_theme_constant_override("separation", 8)
 	root.add_child(input_row)
 
 	_input = LineEdit.new()
 	_input.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	_input.placeholder_text = "Enter message"
-	_input.text_submitted.connect(func(_text: String) -> void: _submit_message())
+	_input.placeholder_text = "輸入聊天內容"
+	_input.text_submitted.connect(func(_text: String) -> void:
+		_submit_message()
+	)
 	input_row.add_child(_input)
 
 	_send_button = Button.new()
-	_send_button.text = "Send"
+	_send_button.text = "送出"
 	_send_button.pressed.connect(_submit_message)
 	input_row.add_child(_send_button)
+	_refresh_input_state()
+
+
+func _refresh_chat_summary() -> void:
+	ApiClient.get_chat_summary(func(success: bool, data: Variant, _error: Dictionary) -> void:
+		if not success or not (data is Dictionary):
+			return
+		GameState.apply_chat_summary(data as Dictionary)
+		_rebuild_tabs()
+		_apply_requested_channel()
+		_refresh_tabs()
+		if _get_render_messages_for_channel(_active_channel).is_empty():
+			_load_history(_active_channel, 0)
+		_render_messages()
+	)
+
+
+func _rebuild_tabs() -> void:
+	if _header == null:
+		return
+	_tab_buttons.clear()
+	for child: Node in _header.get_children():
+		child.queue_free()
+	for item: Array in _build_channel_defs():
+		var tab: Button = ChatTabScript.new()
+		tab.configure(item[0], item[1])
+		tab.pressed.connect(_on_tab_pressed.bind(item[0]))
+		_header.add_child(tab)
+		_tab_buttons[item[0]] = tab
+
+
+func _apply_requested_channel() -> void:
+	if _initial_channel != "" and _available_channels().has(_initial_channel):
+		_active_channel = _initial_channel
+		return
+	if _available_channels().has(_active_channel):
+		return
+	_active_channel = "world"
 
 
 func _on_tab_pressed(channel_key: String) -> void:
 	_active_channel = channel_key
 	_refresh_tabs()
-	if GameState.get_chat_messages(channel_key).is_empty():
+	if _get_render_messages_for_channel(channel_key).is_empty():
 		_load_history(channel_key, 0)
 	_render_messages()
 	_mark_active_channel_read()
 
 
-func _on_load_more_pressed() -> void:
-	var messages := GameState.get_chat_messages(_active_channel)
-	var before_seq := int(messages[0].get("sequence", 0)) if not messages.is_empty() else 0
-	_load_history(_active_channel, before_seq)
-
-
 func _load_history(channel_key: String, before_seq: int) -> void:
-	var resolved_channel_key := _resolve_channel_key(channel_key)
+	if channel_key == "world":
+		_load_channel_history("system", before_seq)
+		_load_channel_history("world", before_seq)
+		return
+	_load_channel_history(channel_key, before_seq)
+
+
+func _load_channel_history(channel_key: String, before_seq: int) -> void:
+	var resolved_channel_key: String = _resolve_channel_key(channel_key)
 	if resolved_channel_key == "":
+		_refresh_input_state()
 		return
 	ApiClient.get_chat_history(resolved_channel_key, before_seq, 50, func(success: bool, data: Variant, error: Dictionary) -> void:
 		if not success:
-			_hint_label.text = str(error.get("message", "Failed to load chat history."))
+			_hint_label.text = str(error.get("message", "讀取聊天紀錄失敗"))
 			return
 		var payload: Dictionary = data if data is Dictionary else {}
 		var messages_variant: Variant = payload.get("messages", [])
 		if messages_variant is Array:
 			GameState.replace_chat_history(channel_key, messages_variant)
-			if channel_key == _active_channel:
+			if channel_key == _active_channel or (_active_channel == "world" and channel_key == "system"):
 				_render_messages()
 				_mark_active_channel_read()
 	)
 
 
 func _submit_message() -> void:
-	var content := _input.text.strip_edges()
+	var content: String = _input.text.strip_edges()
 	if content == "":
 		return
-	if _active_channel != "world":
-		if _active_channel != "party":
-			return
-	var resolved_channel_key := _resolve_channel_key(_active_channel)
-	if resolved_channel_key == "":
+	if _active_channel != "world" and _active_channel != "party":
 		return
+
+	var resolved_channel_key: String = _resolve_channel_key(_active_channel)
+	if resolved_channel_key == "":
+		_refresh_input_state()
+		return
+
 	ApiClient.post_chat_message(resolved_channel_key, content, func(success: bool, _data: Variant, error: Dictionary) -> void:
 		if success:
 			_input.text = ""
 		else:
-			_hint_label.text = str(error.get("message", "Failed to send chat message."))
+			_hint_label.text = str(error.get("message", "送出訊息失敗"))
 	)
 
 
 func _render_messages() -> void:
-	for child in _list_root.get_children():
+	for child: Node in _list_root.get_children():
 		child.queue_free()
-	var messages := GameState.get_chat_messages(_active_channel)
-	for message: Dictionary in messages:
-		var item := ChatItemScript.new()
-		item.setup(_active_channel, message)
+
+	for message_variant: Variant in _get_render_messages_for_channel(_active_channel):
+		if not (message_variant is Dictionary):
+			continue
+		var message: Dictionary = message_variant
+		var item: Control = ChatItemScript.new()
+		item.setup(str(message.get("_channelKey", _active_channel)), message)
 		_list_root.add_child(item)
+
 	call_deferred("_scroll_to_bottom")
 	_refresh_input_state()
+
+
+func _get_render_messages_for_channel(channel_key: String) -> Array:
+	if channel_key != "world":
+		return _decorate_messages(channel_key, GameState.get_chat_messages(channel_key))
+
+	var merged: Array = []
+	merged.append_array(_decorate_messages("system", GameState.get_chat_messages("system")))
+	merged.append_array(_decorate_messages("world", GameState.get_chat_messages("world")))
+	merged.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
+		var a_time: String = str(a.get("sentAtUtc", ""))
+		var b_time: String = str(b.get("sentAtUtc", ""))
+		if a_time == b_time:
+			return int(a.get("sequence", 0)) < int(b.get("sequence", 0))
+		return a_time < b_time
+	)
+	return merged
+
+
+func _decorate_messages(channel_key: String, messages: Array) -> Array:
+	var result: Array = []
+	for message_variant: Variant in messages:
+		if not (message_variant is Dictionary):
+			continue
+		var entry: Dictionary = (message_variant as Dictionary).duplicate(true)
+		entry["_channelKey"] = channel_key
+		result.append(entry)
+	return result
 
 
 func _scroll_to_bottom() -> void:
@@ -157,44 +218,55 @@ func _scroll_to_bottom() -> void:
 func _refresh_tabs() -> void:
 	for key: String in _tab_buttons.keys():
 		var button: Button = _tab_buttons[key]
+		if button == null:
+			continue
 		button.disabled = key == _active_channel
-		button.set_badge_count(int(GameState.chat_unread_counts.get(key, 0)))
+		button.set_badge_count(_get_tab_unread_count(key))
+
+
+func _get_tab_unread_count(channel_key: String) -> int:
+	if channel_key == "world":
+		return int(GameState.chat_unread_counts.get("world", 0)) + int(GameState.chat_unread_counts.get("system", 0))
+	return int(GameState.chat_unread_counts.get(channel_key, 0))
 
 
 func _refresh_input_state() -> void:
-	var can_send := _active_channel == "world" or (_active_channel == "party" and GameState.chat_party_available)
+	var can_send: bool = _active_channel == "world" or (_active_channel == "party" and _resolve_channel_key("party") != "")
 	_input.editable = can_send
 	_send_button.disabled = not can_send
-	if _active_channel == "guild":
-		_hint_label.text = "Guild chat unlocks after guild system is implemented."
-	elif _active_channel == "system":
-		_hint_label.text = "System messages are read only."
-	elif _active_channel == "party":
-		_hint_label.text = "Party chat is available to current party members only."
+	if _active_channel == "party":
+		if _resolve_channel_key("party") == "":
+			_hint_label.text = "隊伍頻道尚未開放。"
+		else:
+			_hint_label.text = "只有目前隊伍成員可以使用隊伍頻道。"
 	else:
 		_hint_label.text = ""
 
 
 func _mark_active_channel_read() -> void:
-	var latest_seq := GameState.get_chat_latest_sequence(_active_channel)
+	if _active_channel == "world":
+		_mark_channel_read("system")
+		_mark_channel_read("world")
+		return
+	_mark_channel_read(_active_channel)
+
+
+func _mark_channel_read(channel_key: String) -> void:
+	var latest_seq: int = GameState.get_chat_latest_sequence(channel_key)
 	if latest_seq <= 0:
 		return
-	GameState.set_chat_unread_count(_active_channel, 0)
-	var resolved_channel_key := _resolve_channel_key(_active_channel)
+	GameState.set_chat_unread_count(channel_key, 0)
+	var resolved_channel_key: String = _resolve_channel_key(channel_key)
 	if resolved_channel_key != "":
 		ChatRealtimeClient.mark_read(resolved_channel_key, latest_seq)
 
 
-func _on_connection_state_changed(state: String) -> void:
-	_refresh_connection_state(state)
-
-
-func _refresh_connection_state(state: String) -> void:
-	_status_label.text = "Connection: %s" % state
+func _on_connection_state_changed(_state: String) -> void:
+	pass
 
 
 func _on_messages_changed(channel_key: String) -> void:
-	if channel_key == _active_channel:
+	if channel_key == _active_channel or (_active_channel == "world" and channel_key == "system"):
 		_render_messages()
 
 
@@ -204,12 +276,10 @@ func _on_unread_changed(_channel_key: String, _count: int) -> void:
 
 func _build_channel_defs() -> Array:
 	var defs: Array = [
-		["system", "System"],
-		["world", "World"],
-		["guild", "Guild"],
+		["world", "全頻"],
 	]
-	if GameState.chat_party_available:
-		defs.append(["party", "Party"])
+	if GameState.chat_party_available or GameState.chat_party_channel_key != "" or _initial_channel == "party":
+		defs.append(["party", "隊伍"])
 	return defs
 
 

--- a/scripts/configs/ConfigScene.gd
+++ b/scripts/configs/ConfigScene.gd
@@ -1,6 +1,8 @@
 extends Control
 
 const AssetResolver = preload("res://scripts/ui/asset_resolver.gd")
+const InertialScroller = preload("res://scripts/ui/inertial_scroll.gd")
+const SceneSubmenuBar = preload("res://scripts/ui/scene_submenu_bar.gd")
 const ADMIN_CATALOG_SCENE_PATH := "res://scenes/AdminCatalogScene.tscn"
 
 const MUTED_TEXT_COLOR := Color(0.90, 0.88, 0.82, 0.92)
@@ -10,11 +12,11 @@ const FIELD_BORDER := Color(0.42, 0.36, 0.26, 0.96)
 const SELECTED_BORDER := Color(0.92, 0.79, 0.44, 1.0)
 const UNSELECTED_BORDER := Color(0.42, 0.36, 0.26, 0.96)
 const GENDER_OPTIONS := [
-	{"label": "未指定", "value": "Unspecified"},
-	{"label": "男性", "value": "Male"},
-	{"label": "女性", "value": "Female"},
-	{"label": "非二元", "value": "NonBinary"},
-	{"label": "不透露", "value": "PreferNotToSay"},
+	{"label": "?????, "value": "Unspecified"},
+	{"label": "??鞎???, "value": "Male"},
+	{"label": "?鞈察????, "value": "Female"},
+	{"label": "?????, "value": "NonBinary"},
+	{"label": "?鞊??????", "value": "PreferNotToSay"},
 ]
 
 var _profile_dirty: bool = false
@@ -43,6 +45,10 @@ var _redeem_button: Button
 var _audio_value_labels: Dictionary = {}
 var _audio_sliders: Dictionary = {}
 var _audio_mute_boxes: Dictionary = {}
+var _active_section: String = "profile"
+var _submenu_buttons: Dictionary = {}
+var _section_content: VBoxContainer
+var _section_scroll: ScrollContainer
 
 
 func _ready() -> void:
@@ -54,37 +60,106 @@ func _ready() -> void:
 
 func _build_ui() -> void:
 	var chrome: Dictionary = OverlaySceneChrome.build(self, "config", Callable(self, "_on_back_pressed"), {
-		"show_dock": false,
-		"content_bottom": -(OverlaySceneChrome.HOME_MAIN_NAV_H + 14.0),
+		"show_dock": true,
+		"dock_items": _build_section_items(),
+		"active_key": _active_section,
+		"button_pressed": Callable(self, "_on_section_selected"),
 		"content_separation": 12,
 	})
 	var content_box: VBoxContainer = chrome.get("content_box") as VBoxContainer
+	_submenu_buttons = chrome.get("dock_buttons", {})
 
 	var title: Label = Label.new()
-	title.text = "設定中心"
+	title.text = "\u8a2d\u5b9a\u4e2d\u5fc3"
 	title.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_DISPLAY)
 	content_box.add_child(title)
 
-	var subtitle: Label = Label.new()
-	subtitle.text = "管理角色資料、帳號資訊與本機遊戲設定。"
-	subtitle.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	subtitle.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY)
-	subtitle.add_theme_color_override("font_color", MUTED_TEXT_COLOR)
-	content_box.add_child(subtitle)
 
-	var scroll: ScrollContainer = ScrollContainer.new()
-	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
-	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
-	content_box.add_child(scroll)
+	_section_scroll = ScrollContainer.new()
+	_section_scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	_section_scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+	_section_scroll.vertical_scroll_mode = ScrollContainer.SCROLL_MODE_AUTO
+	content_box.add_child(_section_scroll)
+	InertialScroller.attach(_section_scroll, "vertical")
 
-	var body: VBoxContainer = VBoxContainer.new()
-	body.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	body.add_theme_constant_override("separation", 14)
-	scroll.add_child(body)
+	_section_content = VBoxContainer.new()
+	_section_content.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_section_content.add_theme_constant_override("separation", 12)
+	_section_scroll.add_child(_section_content)
 
-	body.add_child(_build_profile_section())
-	body.add_child(_build_account_section())
-	body.add_child(_build_game_settings_section())
+	_render_active_section()
+
+
+func _build_section_items() -> Array:
+	var items: Array = [
+		{"key": "profile", "label": "\u89d2\u8272\u8cc7\u6599"},
+		{"key": "account", "label": "\u5e33\u865f\u8cc7\u6599"},
+		{"key": "game", "label": "\u904a\u6232\u8a2d\u5b9a"},
+	]
+	if GameState.is_admin_session():
+		items.append({"key": "admin", "label": "Admin Catalog"})
+	return items
+
+
+func _on_section_selected(section_key: String) -> void:
+	if section_key == _active_section:
+		return
+	_active_section = section_key
+	_render_active_section()
+
+
+func _render_active_section() -> void:
+	if _section_content == null:
+		return
+	_clear_section_control_refs()
+	for child: Node in _section_content.get_children():
+		child.queue_free()
+
+	match _active_section:
+		"account":
+			_section_content.add_child(_build_account_section())
+		"game":
+			_section_content.add_child(_build_game_settings_section())
+		"admin":
+			if GameState.is_admin_session():
+				_section_content.add_child(_build_admin_section())
+			else:
+				_active_section = "profile"
+				_section_content.add_child(_build_profile_section())
+		_:
+			_section_content.add_child(_build_profile_section())
+
+	_refresh_submenu_buttons()
+	_apply_profile_data(_build_local_profile_snapshot())
+	_apply_audio_settings()
+	if is_instance_valid(_section_scroll):
+		_section_scroll.scroll_vertical = 0
+
+
+func _refresh_submenu_buttons() -> void:
+	SceneSubmenuBar.refresh(_submenu_buttons, _active_section)
+
+
+func _clear_section_control_refs() -> void:
+	_avatar_preview = null
+	_avatar_name_label = null
+	_avatar_buttons = {}
+	_display_name_input = null
+	_player_name_input = null
+	_bio_input = null
+	_birthday_input = null
+	_gender_option = null
+	_region_input = null
+	_save_profile_button = null
+	_save_profile_hint_label = null
+	_account_value_label = null
+	_player_uid_value_label = null
+	_provider_status_labels = {}
+	_redeem_input = null
+	_redeem_button = null
+	_audio_value_labels = {}
+	_audio_sliders = {}
+	_audio_mute_boxes = {}
 
 
 func _build_profile_section() -> Control:
@@ -96,7 +171,7 @@ func _build_profile_section() -> Control:
 	column.add_theme_constant_override("separation", 12)
 	margin.add_child(column)
 
-	column.add_child(_make_section_header("角色資料", "可設定頭像、暱稱、自介、生日與性別。"))
+	column.add_child(_make_section_header("????????", "?????????????????????????拆???鞊?????????????))
 
 	var avatar_row: HBoxContainer = HBoxContainer.new()
 	avatar_row.add_theme_constant_override("separation", 14)
@@ -133,7 +208,7 @@ func _build_profile_section() -> Control:
 	avatar_row.add_child(avatar_picker_shell)
 
 	var avatar_hint: Label = Label.new()
-	avatar_hint.text = "選擇預設頭像"
+	avatar_hint.text = "???????????"
 	avatar_hint.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY_LG)
 	avatar_picker_shell.add_child(avatar_hint)
 
@@ -146,10 +221,9 @@ func _build_profile_section() -> Control:
 	for avatar_id: String in AssetResolver.get_profile_avatar_ids():
 		avatar_grid.add_child(_build_avatar_card(avatar_id))
 
-	_display_name_input = _make_line_edit("請輸入暱稱")
-	_player_name_input = _make_line_edit("請輸入角色名稱")
+	_player_name_input = _make_line_edit("????????????)
 	_birthday_input = _make_line_edit("YYYY-MM-DD")
-	_region_input = _make_line_edit("例如：台北 / Kaohsiung")
+	_region_input = _make_line_edit("?雓???雓撥????/ Kaohsiung")
 
 	_bio_input = TextEdit.new()
 	_bio_input.custom_minimum_size = Vector2(0.0, 112.0)
@@ -161,19 +235,18 @@ func _build_profile_section() -> Control:
 	for option: Dictionary in GENDER_OPTIONS:
 		_gender_option.add_item(str(option.get("label", "")))
 
-	column.add_child(_build_field_row("暱稱", _display_name_input))
-	column.add_child(_build_field_row("角色名稱", _player_name_input))
-	column.add_child(_build_field_row("自介", _bio_input))
-	column.add_child(_build_field_row("生日", _birthday_input))
-	column.add_child(_build_field_row("性別", _gender_option))
-	column.add_child(_build_field_row("地區", _region_input))
+	column.add_child(_build_field_row("??????雓?", _player_name_input))
+	column.add_child(_build_field_row("???", _bio_input))
+	column.add_child(_build_field_row("???蝮?", _birthday_input))
+	column.add_child(_build_field_row("????", _gender_option))
+	column.add_child(_build_field_row("???", _region_input))
 
 	var save_row: HBoxContainer = HBoxContainer.new()
 	save_row.add_theme_constant_override("separation", 12)
 	column.add_child(save_row)
 
 	_save_profile_button = Button.new()
-	_save_profile_button.text = "儲存角色資料"
+	_save_profile_button.text = "???????????"
 	_save_profile_button.custom_minimum_size = Vector2(220.0, 50.0)
 	UiPalette.apply_button_kind(_save_profile_button, "confirm")
 	_save_profile_button.pressed.connect(UiAudio.play_ui_click)
@@ -181,7 +254,7 @@ func _build_profile_section() -> Control:
 	save_row.add_child(_save_profile_button)
 
 	_save_profile_hint_label = Label.new()
-	_save_profile_hint_label.text = "資料會同步到帳號。"
+	_save_profile_hint_label.text = "????????????蝘?????
 	_save_profile_hint_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	_save_profile_hint_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
 	_save_profile_hint_label.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
@@ -191,8 +264,6 @@ func _build_profile_section() -> Control:
 	_bind_profile_edit_events()
 	_refresh_avatar_selection()
 	_refresh_profile_save_state()
-	if GameState.is_admin_session():
-		column.add_child(_build_admin_catalog_row())
 	return section
 
 
@@ -205,11 +276,11 @@ func _build_account_section() -> Control:
 	column.add_theme_constant_override("separation", 12)
 	margin.add_child(column)
 
-	column.add_child(_make_section_header("帳號資料", "顯示目前綁定狀態，OAuth 入口先以佔位方式展示。"))
+	column.add_child(_make_section_header("????????", "???????怏???????????OAuth ??????????????????鞈ㄜ???))
 
-	_account_value_label = _make_readonly_value("載入中")
-	_player_uid_value_label = _make_readonly_value("載入中")
-	column.add_child(_build_field_row("帳號", _account_value_label))
+	_account_value_label = _make_readonly_value("?雓丐?????)
+	_player_uid_value_label = _make_readonly_value("?雓丐?????)
+	column.add_child(_build_field_row("????", _account_value_label))
 	column.add_child(_build_field_row("Player UID", _player_uid_value_label))
 
 	var provider_row: HBoxContainer = HBoxContainer.new()
@@ -220,12 +291,12 @@ func _build_account_section() -> Control:
 	provider_row.add_child(_build_provider_card("Apple"))
 
 	var redeem_title: Label = Label.new()
-	redeem_title.text = "兌換碼"
+	redeem_title.text = "?????
 	redeem_title.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY_LG)
 	column.add_child(redeem_title)
 
 	var redeem_hint: Label = Label.new()
-	redeem_hint.text = "輸入活動碼即可直接領取獎勵。"
+	redeem_hint.text = "?雓???????????????????????????
 	redeem_hint.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
 	redeem_hint.add_theme_color_override("font_color", SECTION_HINT_COLOR)
 	column.add_child(redeem_hint)
@@ -234,12 +305,12 @@ func _build_account_section() -> Control:
 	redeem_row.add_theme_constant_override("separation", 10)
 	column.add_child(redeem_row)
 
-	_redeem_input = _make_line_edit("請輸入兌換碼")
+	_redeem_input = _make_line_edit("?????????偃???)
 	_redeem_input.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	redeem_row.add_child(_redeem_input)
 
 	_redeem_button = Button.new()
-	_redeem_button.text = "兌換"
+	_redeem_button.text = "???"
 	_redeem_button.custom_minimum_size = Vector2(132.0, 48.0)
 	UiPalette.apply_button_kind(_redeem_button, "confirm")
 	_redeem_button.pressed.connect(UiAudio.play_ui_click)
@@ -258,11 +329,11 @@ func _build_game_settings_section() -> Control:
 	column.add_theme_constant_override("separation", 12)
 	margin.add_child(column)
 
-	column.add_child(_make_section_header("遊戲設定", "音量設定保存在本機裝置，不會覆蓋其他裝置。"))
+	column.add_child(_make_section_header("??頩???Ⅹ??", "?????Ⅹ?????????佇?憯??????謚???鞊???????????????))
 
-	column.add_child(_build_audio_row("master", "總音量"))
-	column.add_child(_build_audio_row("bgm", "背景音樂"))
-	column.add_child(_build_audio_row("sfx", "音效"))
+	column.add_child(_build_audio_row("master", "???瘀賊???))
+	column.add_child(_build_audio_row("bgm", "???????"))
+	column.add_child(_build_audio_row("sfx", "???"))
 
 	return section
 
@@ -306,6 +377,20 @@ func _build_admin_catalog_row() -> Control:
 	row.add_child(button)
 
 	return panel
+
+
+func _build_admin_section() -> Control:
+	var section: PanelContainer = OverlaySceneChrome.make_card_panel()
+	var margin: MarginContainer = OverlaySceneChrome.make_content_margin(16)
+	section.add_child(margin)
+
+	var column: VBoxContainer = VBoxContainer.new()
+	column.add_theme_constant_override("separation", 12)
+	margin.add_child(column)
+
+	column.add_child(_make_section_header("Admin Catalog", "??? Admin ?????????????????????????????橫???祈???鞊??謅?鞊堊??鞊啣???))
+	column.add_child(_build_admin_catalog_row())
+	return section
 
 
 func _build_avatar_card(avatar_id: String) -> Control:
@@ -368,14 +453,14 @@ func _build_provider_card(provider_name: String) -> Control:
 	column.add_child(title)
 
 	var status_label: Label = Label.new()
-	status_label.text = "即將開放"
+	status_label.text = "?????鞊?"
 	status_label.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
 	status_label.add_theme_color_override("font_color", SECTION_HINT_COLOR)
 	column.add_child(status_label)
 	_provider_status_labels[provider_name] = status_label
 
 	var action_button: Button = Button.new()
-	action_button.text = "即將開放"
+	action_button.text = "?????鞊?"
 	action_button.disabled = true
 	action_button.custom_minimum_size = Vector2(0.0, 42.0)
 	UiPalette.apply_button_palette(action_button, Color(0.24, 0.21, 0.18, 0.86), Color(0.72, 0.69, 0.64, 1.0))
@@ -422,7 +507,7 @@ func _build_audio_row(bus_key: String, label_text: String) -> Control:
 	_audio_value_labels[bus_key] = value_label
 
 	var mute_box: CheckBox = CheckBox.new()
-	mute_box.text = "靜音"
+	mute_box.text = "??垮??"
 	mute_box.toggled.connect(func(pressed: bool) -> void:
 		_on_audio_mute_toggled(bus_key, pressed)
 	)
@@ -483,9 +568,6 @@ func _make_readonly_value(text: String) -> LineEdit:
 
 
 func _bind_profile_edit_events() -> void:
-	_display_name_input.text_changed.connect(func(_value: String) -> void:
-		_mark_profile_dirty()
-	)
 	_player_name_input.text_changed.connect(func(_value: String) -> void:
 		_mark_profile_dirty()
 	)
@@ -508,7 +590,7 @@ func _load_profile_from_api() -> void:
 		_profile_loading = false
 		_refresh_profile_save_state()
 		if not success:
-			ToastManager.hint("設定資料使用快取", str(error.get("message", "目前改用本地快取顯示。")))
+			ToastManager.hint("??Ⅹ?????????????散??", str(error.get("message", "???怏???謘?????蹎????????????)))
 			return
 
 		if data is Dictionary:
@@ -524,14 +606,22 @@ func _apply_profile_data(data: Dictionary) -> void:
 	if _selected_avatar_id == "":
 		_selected_avatar_id = AssetResolver.DEFAULT_PROFILE_AVATAR_ID
 
-	_display_name_input.text = str(data.get("displayName", ""))
-	_player_name_input.text = str(data.get("playerName", ""))
-	_bio_input.text = str(data.get("bio", ""))
-	_birthday_input.text = str(data.get("birthday", ""))
-	_region_input.text = str(data.get("region", ""))
-	_set_gender_value(str(data.get("genderType", "Unspecified")))
-	_account_value_label.text = str(data.get("account", ""))
-	_player_uid_value_label.text = str(data.get("playerPublicId", ""))
+	if is_instance_valid(_display_name_input):
+		_display_name_input.text = str(data.get("displayName", ""))
+	if is_instance_valid(_player_name_input):
+		_player_name_input.text = str(data.get("playerName", ""))
+	if is_instance_valid(_bio_input):
+		_bio_input.text = str(data.get("bio", ""))
+	if is_instance_valid(_birthday_input):
+		_birthday_input.text = str(data.get("birthday", ""))
+	if is_instance_valid(_region_input):
+		_region_input.text = str(data.get("region", ""))
+	if is_instance_valid(_gender_option):
+		_set_gender_value(str(data.get("genderType", "Unspecified")))
+	if is_instance_valid(_account_value_label):
+		_account_value_label.text = str(data.get("account", ""))
+	if is_instance_valid(_player_uid_value_label):
+		_player_uid_value_label.text = str(data.get("playerPublicId", ""))
 	_refresh_provider_cards(data.get("linkedProviders", []))
 	_applying_profile_form = false
 	_profile_dirty = false
@@ -544,9 +634,9 @@ func _apply_audio_settings() -> void:
 	for bus_key: String in ["master", "bgm", "sfx"]:
 		var slider: HSlider = _audio_sliders.get(bus_key) as HSlider
 		var mute_box: CheckBox = _audio_mute_boxes.get(bus_key) as CheckBox
-		if slider != null:
+		if is_instance_valid(slider):
 			slider.value = float(settings.get("%sVolume" % bus_key, 1.0))
-		if mute_box != null:
+		if is_instance_valid(mute_box):
 			mute_box.button_pressed = bool(settings.get("%sMuted" % bus_key, false))
 		_refresh_audio_value_label(bus_key)
 
@@ -568,13 +658,15 @@ func _build_local_profile_snapshot() -> Dictionary:
 
 
 func _refresh_avatar_selection() -> void:
+	if not is_instance_valid(_avatar_preview) or not is_instance_valid(_avatar_name_label):
+		return
 	_avatar_preview.texture = AssetResolver.resolve_profile_avatar(_selected_avatar_id)
 	_avatar_name_label.text = AssetResolver.get_profile_avatar_label(_selected_avatar_id)
 	for avatar_id: String in _avatar_buttons.keys():
 		var refs: Dictionary = _avatar_buttons.get(avatar_id, {})
 		var panel: PanelContainer = refs.get("panel") as PanelContainer
 		var label: Label = refs.get("label") as Label
-		if panel == null or label == null:
+		if not is_instance_valid(panel) or not is_instance_valid(label):
 			continue
 		var is_selected: bool = avatar_id == _selected_avatar_id
 		panel.add_theme_stylebox_override(
@@ -592,41 +684,41 @@ func _refresh_provider_cards(linked_providers_variant: Variant) -> void:
 	var linked: Array = linked_providers_variant if linked_providers_variant is Array else []
 	for provider_name: String in _provider_status_labels.keys():
 		var status_label: Label = _provider_status_labels.get(provider_name) as Label
-		if status_label == null:
+		if not is_instance_valid(status_label):
 			continue
 		if linked.has(provider_name):
-			status_label.text = "已綁定"
+			status_label.text = "??頦????
 			status_label.add_theme_color_override("font_color", Color(0.72, 0.94, 0.72, 1.0))
 		else:
-			status_label.text = "即將開放"
+			status_label.text = "?????鞊?"
 			status_label.add_theme_color_override("font_color", SECTION_HINT_COLOR)
 
 
 func _refresh_profile_save_state() -> void:
-	if _save_profile_button == null:
+	if not is_instance_valid(_save_profile_button):
 		return
 	_save_profile_button.disabled = _profile_loading or _profile_saving or not _profile_dirty
 	if _profile_saving:
-		_save_profile_button.text = "儲存中..."
+		_save_profile_button.text = "?????.."
 	elif _profile_loading:
-		_save_profile_button.text = "載入中..."
+		_save_profile_button.text = "?雓丐?????.."
 	else:
-		_save_profile_button.text = "儲存角色資料"
+		_save_profile_button.text = "???????????"
 
-	if _save_profile_hint_label == null:
+	if not is_instance_valid(_save_profile_hint_label):
 		return
 	if _profile_saving:
-		_save_profile_hint_label.text = "正在同步角色資料..."
+		_save_profile_hint_label.text = "???????????????..."
 	elif _profile_dirty:
-		_save_profile_hint_label.text = "有未儲存的修改。"
+		_save_profile_hint_label.text = "???撕??????????????
 	else:
-		_save_profile_hint_label.text = "資料會同步到帳號。"
+		_save_profile_hint_label.text = "????????????蝘?????
 
 
 func _refresh_audio_value_label(bus_key: String) -> void:
 	var slider: HSlider = _audio_sliders.get(bus_key) as HSlider
 	var value_label: Label = _audio_value_labels.get(bus_key) as Label
-	if slider == null or value_label == null:
+	if not is_instance_valid(slider) or not is_instance_valid(value_label):
 		return
 	value_label.text = "%d%%" % int(round(slider.value * 100.0))
 
@@ -660,11 +752,11 @@ func _on_save_profile_pressed() -> void:
 
 	var validation_error: String = _validate_profile_form()
 	if validation_error != "":
-		ToastManager.error("角色資料有誤", validation_error)
+		ToastManager.error("????????????", validation_error)
 		return
 
 	var payload := {
-		"displayName": _display_name_input.text.strip_edges(),
+		"displayName": str(GameState.player_data.display_name).strip_edges(),
 		"playerName": _player_name_input.text.strip_edges(),
 		"avatarId": _selected_avatar_id,
 		"bio": _bio_input.text.strip_edges(),
@@ -682,14 +774,14 @@ func _on_save_profile_pressed() -> void:
 		if not success:
 			_profile_dirty = true
 			_refresh_profile_save_state()
-			ToastManager.error("角色資料儲存失敗", str(error.get("message", "請稍後再試。")))
+			ToastManager.error("???????????????", str(error.get("message", "??????祈?????謅????)))
 			return
 
 		if data is Dictionary:
 			var profile: Dictionary = data as Dictionary
 			GameState.apply_profile_response(profile)
 			_apply_profile_data(profile)
-		ToastManager.success("角色資料已更新")
+		ToastManager.success("??????????頦????)
 	)
 
 
@@ -699,18 +791,18 @@ func _on_redeem_pressed() -> void:
 
 	var code: String = _redeem_input.text.strip_edges()
 	if code == "":
-		ToastManager.error("請輸入兌換碼")
+		ToastManager.error("?????????偃???)
 		return
 
 	_redeem_in_flight = true
 	_redeem_button.disabled = true
-	_redeem_button.text = "兌換中..."
+	_redeem_button.text = "?????.."
 	ApiClient.redeem_code(code, func(success: bool, data: Variant, error: Dictionary) -> void:
 		_redeem_in_flight = false
 		_redeem_button.disabled = false
-		_redeem_button.text = "兌換"
+		_redeem_button.text = "???"
 		if not success:
-			ToastManager.error("兌換失敗", str(error.get("message", "請稍後再試。")))
+			ToastManager.error("???????", str(error.get("message", "??????祈?????謅????)))
 			return
 
 		var response: Dictionary = data if data is Dictionary else {}
@@ -719,7 +811,7 @@ func _on_redeem_pressed() -> void:
 			GameState.apply_wallet_snapshot(wallet_snapshot)
 		_redeem_input.text = ""
 		_show_redeem_result(response)
-		ToastManager.success("兌換成功", str(response.get("redeemedCode", "")))
+		ToastManager.success("??????", str(response.get("redeemedCode", "")))
 	)
 
 
@@ -735,9 +827,9 @@ func _show_redeem_result(response: Dictionary) -> void:
 			lines.append("%s x%d" % [display_name, int(reward.get("quantity", 0))])
 
 	if lines.is_empty():
-		lines.append("獎勵已發送到帳號。")
+		lines.append("???????頦????拆????????)
 
-	DialogManager.show_info("兌換成功", "\n".join(lines))
+	DialogManager.show_info("??????", "\n".join(lines))
 
 
 func _on_audio_slider_changed(bus_key: String, value: float) -> void:
@@ -750,19 +842,16 @@ func _on_audio_mute_toggled(bus_key: String, pressed: bool) -> void:
 
 
 func _validate_profile_form() -> String:
-	var display_name: String = _display_name_input.text.strip_edges()
 	var player_name: String = _player_name_input.text.strip_edges()
 	var birthday: String = _birthday_input.text.strip_edges()
 	var bio: String = _bio_input.text.strip_edges()
 
-	if display_name == "":
-		return "請填寫暱稱。"
 	if player_name == "":
-		return "請填寫角色名稱。"
+		return "????????????????
 	if bio.length() > 140:
-		return "自介最多 140 字。"
+		return "???????140 ?????
 	if birthday != "" and not _is_valid_birthday_text(birthday):
-		return "生日格式請使用 YYYY-MM-DD。"
+		return "???蝮??????????YYYY-MM-DD??
 	return ""
 
 

--- a/scripts/social/SocialScene.gd
+++ b/scripts/social/SocialScene.gd
@@ -1,17 +1,22 @@
 extends Control
 
-const CHAT_SCENE := preload("res://scenes/chat/ChatScene.tscn")
+const ContentBottomSubmenu = preload("res://scripts/ui/content_bottom_submenu.gd")
 const OverlaySceneChrome = preload("res://scripts/ui/overlay_scene_chrome.gd")
 const UiPalette = preload("res://scripts/ui/ui_palette.gd")
 
 var _mode: String = "friend"
 var _friend_list: Dictionary = {}
+var _friend_gift_in_flight: bool = false
 var _party_detail: Dictionary = {}
 var _party_cheer_status: Dictionary = {}
+var _party_section: String = "overview"
+var _party_applications: Array = []
 
 var _root_box: VBoxContainer
 var _scroll: ScrollContainer
 var _content_box: VBoxContainer
+var _footer_panel: PanelContainer
+var _party_footer_buttons: Dictionary = {}
 
 
 func set_mode(mode: String) -> void:
@@ -41,36 +46,29 @@ func _build_shell() -> void:
 	root_panel.add_child(margin)
 
 	_root_box = VBoxContainer.new()
-	_root_box.add_theme_constant_override("separation", 14)
+	_root_box.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_root_box.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	_root_box.add_theme_constant_override("separation", 12)
 	margin.add_child(_root_box)
 
-	var header: HBoxContainer = HBoxContainer.new()
-	header.add_theme_constant_override("separation", 10)
-	_root_box.add_child(header)
-
-	var title: Label = Label.new()
-	title.text = UiText.HOME_FRIEND_DIALOG_TITLE if _mode == "friend" else UiText.HOME_PARTY_DIALOG_TITLE
-	title.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	title.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_TITLE)
-	title.add_theme_color_override("font_color", OverlaySceneChrome.TITLE_TEXT_COLOR)
-	header.add_child(title)
-
-	var refresh_button: Button = Button.new()
-	refresh_button.text = UiText.SOCIAL_REFRESH
-	refresh_button.custom_minimum_size = Vector2(120.0, 44.0)
-	UiPalette.apply_button_kind(refresh_button, "secondary")
-	refresh_button.pressed.connect(_refresh_current)
-	header.add_child(refresh_button)
-
 	_scroll = ScrollContainer.new()
+	_scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	_scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	_scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
 	_root_box.add_child(_scroll)
+	InertialScroller.attach(_scroll, "vertical")
 
 	_content_box = VBoxContainer.new()
 	_content_box.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_content_box.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	_content_box.add_theme_constant_override("separation", 14)
 	_scroll.add_child(_content_box)
+
+	_footer_panel = OverlaySceneChrome.make_card_panel()
+	_footer_panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_footer_panel.custom_minimum_size = Vector2(0.0, 56.0)
+	_footer_panel.visible = false
+	_root_box.add_child(_footer_panel)
 
 
 func _refresh_current() -> void:
@@ -117,16 +115,20 @@ func _clear_content() -> void:
 
 func _render_friend() -> void:
 	_clear_content()
+	if _footer_panel != null:
+		_footer_panel.visible = false
 
 	var friend_rows: Array = _friend_list.get("friends", [])
 	var friends_card: PanelContainer = OverlaySceneChrome.make_card_panel(OverlaySceneChrome.PANEL_BORDER)
 	friends_card.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	friends_card.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	_content_box.add_child(friends_card)
 
 	var friends_margin: MarginContainer = OverlaySceneChrome.make_content_margin(16)
 	friends_card.add_child(friends_margin)
 
 	var friends_box: VBoxContainer = VBoxContainer.new()
+	friends_box.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	friends_box.add_theme_constant_override("separation", 12)
 	friends_margin.add_child(friends_box)
 
@@ -157,8 +159,22 @@ func _render_friend() -> void:
 	gift_button.pressed.connect(_on_friend_gift_pressed)
 	button_row.add_child(gift_button)
 
+	var refresh_button: Button = _make_action_button(UiText.SOCIAL_REFRESH, "secondary")
+	refresh_button.pressed.connect(_refresh_friend)
+	button_row.add_child(refresh_button)
+
 	if friend_rows.is_empty():
-		friends_box.add_child(_make_empty_label(UiText.SOCIAL_EMPTY))
+		var empty_panel: PanelContainer = OverlaySceneChrome.make_card_panel()
+		empty_panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		empty_panel.size_flags_vertical = Control.SIZE_EXPAND_FILL
+		empty_panel.custom_minimum_size = Vector2(0.0, 220.0)
+		friends_box.add_child(empty_panel)
+
+		var empty_center: CenterContainer = CenterContainer.new()
+		empty_center.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		empty_center.size_flags_vertical = Control.SIZE_EXPAND_FILL
+		empty_panel.add_child(empty_center)
+		empty_center.add_child(_make_empty_label(UiText.SOCIAL_EMPTY))
 		return
 
 	for item_variant: Variant in friend_rows:
@@ -170,9 +186,62 @@ func _render_friend() -> void:
 func _render_party() -> void:
 	_clear_content()
 	if _party_detail.is_empty():
+		if _footer_panel != null:
+			_footer_panel.visible = false
 		_render_party_empty()
 		return
-	_render_party_detail()
+	_render_party_footer()
+	if _party_section == "applications" and _is_party_leader():
+		_render_party_applications(_content_box)
+		return
+	_party_section = "overview"
+	_render_party_detail(_content_box)
+
+
+
+func _render_party_footer() -> void:
+	if _footer_panel == null:
+		return
+	_footer_panel.visible = true
+	var items: Array = [
+		{"key": "overview", "label": "\u968a\u4f0d\u8cc7\u8a0a"},
+	]
+	if _is_party_leader():
+		items.append({"key": "applications", "label": UiText.SOCIAL_PARTY_APPLICATIONS})
+	var submenu: Dictionary = ContentBottomSubmenu.build(self, {
+		"panel": _footer_panel,
+		"items": items,
+		"active_key": _party_section,
+		"button_pressed": Callable(self, "_on_party_section_selected"),
+	})
+	_party_footer_buttons = submenu.get("buttons", {})
+
+
+
+
+func _on_party_section_selected(section_key: String) -> void:
+	if _party_section == section_key:
+		return
+	_party_section = section_key
+	_refresh_party_footer_buttons()
+	if _party_section == "applications" and _is_party_leader():
+		_load_party_applications()
+		return
+	_render_party()
+
+
+func _refresh_party_footer_buttons() -> void:
+	ContentBottomSubmenu.refresh(_party_footer_buttons, _party_section)
+
+
+func _load_party_applications() -> void:
+	ApiClient.get_party_applications(int(_party_detail.get("partyId", 0)), func(success: bool, data: Variant, error: Dictionary) -> void:
+		if not success:
+			ToastManager.error(UiText.SOCIAL_PARTY_APPLICATIONS, _error_message(error))
+			return
+		_party_applications = data if data is Array else []
+		_render_party()
+	)
 
 
 func _render_party_empty() -> void:
@@ -227,10 +296,10 @@ func _render_party_empty() -> void:
 	))
 
 
-func _render_party_detail() -> void:
+func _render_party_detail(host: VBoxContainer) -> void:
 	var header_card: PanelContainer = OverlaySceneChrome.make_card_panel(OverlaySceneChrome.PANEL_BORDER)
 	header_card.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	_content_box.add_child(header_card)
+	host.add_child(header_card)
 
 	var header_margin: MarginContainer = OverlaySceneChrome.make_content_margin(16)
 	header_card.add_child(header_margin)
@@ -251,14 +320,12 @@ func _render_party_detail() -> void:
 	title.add_theme_color_override("font_color", OverlaySceneChrome.TITLE_TEXT_COLOR)
 	title_row.add_child(title)
 
-	var free_button: Button = _make_action_button(_get_free_cheer_button_text(), "confirm")
-	free_button.size_flags_horizontal = Control.SIZE_SHRINK_END
-	free_button.custom_minimum_size = Vector2(220.0, 52.0)
-	free_button.disabled = bool(_party_cheer_status.get("hasCheeredFree", false))
-	free_button.pressed.connect(func() -> void:
-		_cheer_party(false)
-	)
-	title_row.add_child(free_button)
+	if _is_party_leader():
+		var rename_button: Button = _make_action_button(UiText.SOCIAL_PARTY_RENAME, "secondary")
+		rename_button.custom_minimum_size = Vector2(140.0, 48.0)
+		rename_button.size_flags_horizontal = Control.SIZE_SHRINK_END
+		rename_button.pressed.connect(_open_rename_party_dialog)
+		title_row.add_child(rename_button)
 
 	var subline: Label = Label.new()
 	subline.text = UiText.SOCIAL_PARTY_LEADER_FORMAT % str(_party_detail.get("leaderDisplayName", ""))
@@ -270,16 +337,16 @@ func _render_party_detail() -> void:
 	quick_row.add_theme_constant_override("separation", 10)
 	header_box.add_child(quick_row)
 
-	var chat_button: Button = _make_action_button(UiText.SOCIAL_PARTY_CHAT, "info")
-	chat_button.pressed.connect(_open_party_chat)
-	quick_row.add_child(chat_button)
+	var refresh_button: Button = _make_action_button(UiText.SOCIAL_REFRESH, "secondary")
+	refresh_button.pressed.connect(_refresh_party)
+	quick_row.add_child(refresh_button)
 
 	var invite_button: Button = _make_action_button(UiText.SOCIAL_PARTY_INVITE, "add")
 	invite_button.pressed.connect(_open_invite_party_dialog)
 	quick_row.add_child(invite_button)
 
 	var leave_button: Button = _make_action_button(
-		UiText.SOCIAL_PARTY_USURP if bool(_party_detail.get("isUsurpationEligible", false)) and not _is_party_leader() else UiText.SOCIAL_PARTY_LEAVE,
+		_get_party_exit_button_text(),
 		"danger"
 	)
 	leave_button.pressed.connect(_on_party_exit_pressed)
@@ -287,7 +354,7 @@ func _render_party_detail() -> void:
 
 	var member_card: PanelContainer = OverlaySceneChrome.make_card_panel()
 	member_card.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	_content_box.add_child(member_card)
+	host.add_child(member_card)
 
 	var member_margin: MarginContainer = OverlaySceneChrome.make_content_margin(16)
 	member_card.add_child(member_margin)
@@ -296,88 +363,84 @@ func _render_party_detail() -> void:
 	member_box.add_theme_constant_override("separation", 10)
 	member_margin.add_child(member_box)
 
+	var member_header: HBoxContainer = HBoxContainer.new()
+	member_header.add_theme_constant_override("separation", 10)
+	member_box.add_child(member_header)
+
 	var member_title: Label = Label.new()
 	member_title.text = UiText.SOCIAL_PARTY_MEMBER_LIST
+	member_title.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	member_title.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY_LG)
 	member_title.add_theme_color_override("font_color", OverlaySceneChrome.TITLE_TEXT_COLOR)
-	member_box.add_child(member_title)
+	member_header.add_child(member_title)
+
+	member_header.add_child(_build_party_cheer_button())
 
 	for member_variant: Variant in members:
 		if member_variant is Dictionary:
 			member_box.add_child(_build_party_member_row(member_variant))
 
-	var action_card: PanelContainer = OverlaySceneChrome.make_card_panel()
-	action_card.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	_content_box.add_child(action_card)
 
-	var action_margin: MarginContainer = OverlaySceneChrome.make_content_margin(16)
-	action_card.add_child(action_margin)
+func _render_party_applications(host: VBoxContainer) -> void:
+	var card: PanelContainer = OverlaySceneChrome.make_card_panel(OverlaySceneChrome.PANEL_BORDER)
+	card.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	host.add_child(card)
 
-	var action_box: VBoxContainer = VBoxContainer.new()
-	action_box.add_theme_constant_override("separation", 12)
-	action_margin.add_child(action_box)
+	var margin: MarginContainer = OverlaySceneChrome.make_content_margin(16)
+	card.add_child(margin)
 
-	var action_title: Label = Label.new()
-	action_title.text = UiText.SOCIAL_PARTY_CHEER_TITLE
-	action_title.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY_LG)
-	action_title.add_theme_color_override("font_color", OverlaySceneChrome.TITLE_TEXT_COLOR)
-	action_box.add_child(action_title)
+	var box: VBoxContainer = VBoxContainer.new()
+	box.add_theme_constant_override("separation", 12)
+	margin.add_child(box)
 
-	var cheer_grid: GridContainer = GridContainer.new()
-	cheer_grid.columns = 1
-	cheer_grid.add_theme_constant_override("h_separation", 10)
-	cheer_grid.add_theme_constant_override("v_separation", 10)
-	action_box.add_child(cheer_grid)
+	var title: Label = Label.new()
+	title.text = UiText.SOCIAL_PARTY_APPLICATIONS
+	title.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SUBHEADING)
+	title.add_theme_color_override("font_color", OverlaySceneChrome.TITLE_TEXT_COLOR)
+	box.add_child(title)
 
-	var ad_button: Button = _make_action_button(
-		UiText.SOCIAL_PARTY_AD_CHEER_DONE if bool(_party_cheer_status.get("hasCheeredAd", false)) else UiText.SOCIAL_PARTY_AD_CHEER,
-		"secondary"
+	if _party_applications.is_empty():
+		box.add_child(_make_empty_label(UiText.SOCIAL_EMPTY))
+		return
+
+	for item_variant: Variant in _party_applications:
+		if item_variant is Dictionary:
+			box.add_child(_build_party_application_row(item_variant))
+
+
+func _build_party_application_row(item_variant: Variant) -> Control:
+	var item: Dictionary = item_variant
+	var panel: PanelContainer = OverlaySceneChrome.make_card_panel()
+	panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+
+	var margin: MarginContainer = OverlaySceneChrome.make_content_margin(12)
+	panel.add_child(margin)
+
+	var row: HBoxContainer = HBoxContainer.new()
+	row.add_theme_constant_override("separation", 10)
+	margin.add_child(row)
+
+	var info: Label = Label.new()
+	info.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	info.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	info.text = str(item.get("applicantDisplayName", ""))
+	row.add_child(info)
+
+	var accept_button: Button = _make_action_button(UiText.SOCIAL_FRIEND_ACCEPT, "confirm")
+	accept_button.custom_minimum_size = Vector2(96.0, 46.0)
+	accept_button.pressed.connect(func() -> void:
+		_accept_party_application(int(item.get("applicationId", 0)), str(item.get("applicantDisplayName", "")))
 	)
-	ad_button.disabled = bool(_party_cheer_status.get("hasCheeredAd", false))
-	ad_button.pressed.connect(func() -> void:
-		_cheer_party(true)
+	row.add_child(accept_button)
+
+	var reject_button: Button = _make_action_button(UiText.SOCIAL_FRIEND_REJECT, "danger")
+	reject_button.custom_minimum_size = Vector2(96.0, 46.0)
+	reject_button.pressed.connect(func() -> void:
+		_reject_party_application(int(item.get("applicationId", 0)))
 	)
-	cheer_grid.add_child(ad_button)
+	row.add_child(reject_button)
 
-	if _is_party_leader():
-		var manage_card: PanelContainer = OverlaySceneChrome.make_card_panel()
-		manage_card.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-		_content_box.add_child(manage_card)
-
-		var manage_margin: MarginContainer = OverlaySceneChrome.make_content_margin(16)
-		manage_card.add_child(manage_margin)
-
-		var manage_box: VBoxContainer = VBoxContainer.new()
-		manage_box.add_theme_constant_override("separation", 12)
-		manage_margin.add_child(manage_box)
-
-		var manage_title: Label = Label.new()
-		manage_title.text = UiText.SOCIAL_PARTY_MANAGE
-		manage_title.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY_LG)
-		manage_title.add_theme_color_override("font_color", OverlaySceneChrome.TITLE_TEXT_COLOR)
-		manage_box.add_child(manage_title)
-
-		var manage_grid: GridContainer = GridContainer.new()
-		manage_grid.columns = 2
-		manage_grid.add_theme_constant_override("h_separation", 10)
-		manage_grid.add_theme_constant_override("v_separation", 10)
-		manage_box.add_child(manage_grid)
-
-		var applications_button: Button = _make_action_button(UiText.SOCIAL_PARTY_APPLICATIONS, "info")
-		applications_button.pressed.connect(_show_party_applications)
-		manage_grid.add_child(applications_button)
-
-		var rename_button: Button = _make_action_button(UiText.SOCIAL_PARTY_RENAME, "secondary")
-		rename_button.pressed.connect(_open_rename_party_dialog)
-		manage_grid.add_child(rename_button)
-
-		var transfer_button: Button = _make_action_button(UiText.SOCIAL_PARTY_TRANSFER, "rank")
-		transfer_button.pressed.connect(_transfer_party)
-		manage_grid.add_child(transfer_button)
-
-		var disband_button: Button = _make_action_button(UiText.SOCIAL_PARTY_DISBAND, "danger")
-		disband_button.pressed.connect(_disband_party)
-		manage_grid.add_child(disband_button)
+	return panel
 
 
 func _build_friend_row(item_variant: Variant) -> PanelContainer:
@@ -404,7 +467,7 @@ func _build_friend_row(item_variant: Variant) -> PanelContainer:
 
 	var remove_button: Button = _make_action_button(UiText.SOCIAL_FRIEND_REMOVE, "danger")
 	remove_button.pressed.connect(func() -> void:
-		_remove_friend(int(item.get("friendUserId", 0)))
+		_confirm_remove_friend(int(item.get("friendUserId", 0)), str(item.get("displayName", "")))
 	)
 	box.add_child(remove_button)
 
@@ -469,7 +532,16 @@ func _build_party_member_row(member_variant: Variant) -> PanelContainer:
 	row.add_child(name_label)
 
 	if _is_party_leader() and not _is_current_player_member(member):
+		var member_name: String = str(member.get("displayName", ""))
+		var transfer_button: Button = _make_action_button(UiText.SOCIAL_PARTY_TRANSFER, "rank")
+		transfer_button.custom_minimum_size = Vector2(132.0, 46.0)
+		transfer_button.pressed.connect(func() -> void:
+			_confirm_transfer_party(int(member.get("userId", 0)), member_name)
+		)
+		row.add_child(transfer_button)
+
 		var kick_button: Button = _make_action_button(UiText.SOCIAL_PARTY_KICK, "danger")
+		kick_button.custom_minimum_size = Vector2(96.0, 46.0)
 		kick_button.pressed.connect(func() -> void:
 			_kick_party_member(int(member.get("userId", 0)))
 		)
@@ -499,7 +571,12 @@ func _make_empty_label(text_value: String) -> Label:
 
 
 func _on_friend_gift_pressed() -> void:
+	if _friend_gift_in_flight:
+		return
 	var friend_rows: Array = _friend_list.get("friends", [])
+	if friend_rows.is_empty():
+		ToastManager.hint(UiText.SOCIAL_FRIEND_GIFT_ALL, UiText.SOCIAL_EMPTY)
+		return
 	DialogManager.show_confirm(
 		UiText.SOCIAL_FRIEND_GIFT_ALL,
 		UiText.SOCIAL_FRIEND_GIFT_CONFIRM % friend_rows.size(),
@@ -508,14 +585,40 @@ func _on_friend_gift_pressed() -> void:
 
 
 func _confirm_friend_gift() -> void:
+	if _friend_gift_in_flight:
+		return
+	_friend_gift_in_flight = true
 	var callback := func(success: bool, data: Variant, error: Dictionary) -> void:
+		_friend_gift_in_flight = false
 		if not success:
 			ToastManager.error(UiText.SOCIAL_FRIEND_GIFT_ALL, _error_message(error))
 			return
 		var payload: Dictionary = data if data is Dictionary else {}
-		ToastManager.success(UiText.SOCIAL_FRIEND_GIFT_ALL, UiText.SOCIAL_FRIEND_GIFT_SUCCESS % int(payload.get("recipientCount", 0)))
+		var recipient_count: int = int(payload.get("recipientCount", 0))
+		if recipient_count <= 0:
+			ToastManager.hint(UiText.SOCIAL_FRIEND_GIFT_ALL, "\u76ee\u524d\u6c92\u6709\u53ef\u9001\u79ae\u7684\u597d\u53cb")
+			_refresh_friend()
+			return
+		ToastManager.success(UiText.SOCIAL_FRIEND_GIFT_ALL, UiText.SOCIAL_FRIEND_GIFT_SUCCESS % recipient_count)
 		_refresh_friend()
 	ApiClient.send_friend_gifts(callback)
+
+
+func _confirm_remove_friend(friend_user_id: int, friend_name: String) -> void:
+	var target_label: String = friend_name.strip_edges()
+	if target_label == "":
+		target_label = "\u9019\u4f4d\u597d\u53cb"
+	DialogManager.show_confirm(
+		UiText.SOCIAL_FRIEND_REMOVE,
+		"\u4f60\u5c07\u79fb\u9664 %s\u3002" % target_label,
+		func() -> void:
+			DialogManager.show_confirm(
+				UiText.SOCIAL_FRIEND_REMOVE,
+				"\u78ba\u8a8d\u5f8c\u9700\u8981\u91cd\u65b0\u52a0\u597d\u53cb\uff0c\u662f\u5426\u78ba\u5b9a\u79fb\u9664 %s\uff1f" % target_label,
+				func() -> void:
+					_remove_friend(friend_user_id)
+			)
+	)
 
 
 func _remove_friend(friend_user_id: int) -> void:
@@ -642,12 +745,6 @@ func _show_my_party_applications() -> void:
 	ApiClient.get_my_party_applications(callback)
 
 
-func _open_party_chat() -> void:
-	var chat_view: Control = CHAT_SCENE.instantiate()
-	chat_view.set_initial_channel("party")
-	DialogManager.show_info_node(UiText.SOCIAL_PARTY_CHAT, chat_view, Callable(), "large")
-
-
 func _open_invite_party_dialog() -> void:
 	_open_text_input(UiText.SOCIAL_PARTY_INVITE, UiText.SOCIAL_FRIEND_UID_PLACEHOLDER, Callable(self, "_submit_invite_party"))
 
@@ -686,19 +783,8 @@ func _use_party_coupon() -> void:
 
 
 func _show_party_applications() -> void:
-	var callback := func(success: bool, data: Variant, error: Dictionary) -> void:
-		if not success:
-			ToastManager.error(UiText.SOCIAL_PARTY_APPLICATIONS, _error_message(error))
-			return
-		var info: Label = Label.new()
-		var lines: Array[String] = []
-		for item_variant: Variant in data:
-			if item_variant is Dictionary:
-				lines.append(str((item_variant as Dictionary).get("applicantDisplayName", "")))
-		info.text = "\n".join(lines) if not lines.is_empty() else UiText.SOCIAL_EMPTY
-		info.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-		DialogManager.show_info_node(UiText.SOCIAL_PARTY_APPLICATIONS, info, Callable(), "medium")
-	ApiClient.get_party_applications(int(_party_detail.get("partyId", 0)), callback)
+	_party_section = "applications"
+	_load_party_applications()
 
 
 func _open_rename_party_dialog() -> void:
@@ -711,10 +797,28 @@ func _submit_rename_party(value: String) -> void:
 	ApiClient.update_party_name(int(_party_detail.get("partyId", 0)), value, callback)
 
 
-func _transfer_party() -> void:
+func _transfer_party(target_user_id: int) -> void:
 	var callback := func(success: bool, _data: Variant, error: Dictionary) -> void:
 		_after_party_action(success, error, UiText.SOCIAL_PARTY_TRANSFER, UiText.SOCIAL_PARTY_TRANSFER_SUCCESS)
-	ApiClient.transfer_party_leadership(int(_party_detail.get("partyId", 0)), callback)
+	ApiClient.transfer_party_leadership(int(_party_detail.get("partyId", 0)), target_user_id, callback)
+
+
+func _confirm_transfer_party(target_user_id: int, member_name: String) -> void:
+	var target_label: String = member_name.strip_edges()
+	if target_label == "":
+		target_label = "\u9019\u4f4d\u968a\u54e1"
+	DialogManager.show_confirm(
+		UiText.SOCIAL_PARTY_TRANSFER,
+		"\u4f60\u5c07\u628a\u968a\u9577\u6b0a\u9650\u4ea4\u7d66 %s\u3002" % target_label,
+		func() -> void:
+			DialogManager.show_confirm(
+				UiText.SOCIAL_PARTY_TRANSFER,
+				"\u78ba\u8a8d\u5f8c\u4f60\u6703\u6539\u6210\u4e00\u822c\u968a\u54e1\uff0c\u662f\u5426\u78ba\u5b9a\u8f49\u8b93\u7d66 %s\uff1f" % target_label,
+				func() -> void:
+					_transfer_party(target_user_id)
+			)
+	)
+
 
 
 func _disband_party() -> void:
@@ -774,3 +878,55 @@ func _is_current_player_member(member: Dictionary) -> bool:
 func _get_free_cheer_button_text() -> String:
 	var remaining_count: int = 0 if bool(_party_cheer_status.get("hasCheeredFree", false)) else 1
 	return "%s(%d/1)" % [UiText.SOCIAL_PARTY_FREE_CHEER, remaining_count]
+
+
+func _build_party_cheer_button() -> Button:
+	var has_free: bool = bool(_party_cheer_status.get("hasCheeredFree", false))
+	var has_ad: bool = bool(_party_cheer_status.get("hasCheeredAd", false))
+	var button: Button
+	if not has_free:
+		button = _make_action_button("%s(1/1)" % UiText.SOCIAL_PARTY_FREE_CHEER, "confirm")
+		button.pressed.connect(func() -> void:
+			_cheer_party(false)
+		)
+	elif not has_ad:
+		button = _make_action_button("%s(1/1)" % UiText.SOCIAL_PARTY_AD_CHEER, "secondary")
+		button.pressed.connect(func() -> void:
+			_cheer_party(true)
+		)
+	else:
+		button = _make_action_button("%s(0/1)" % UiText.SOCIAL_PARTY_AD_CHEER, "secondary")
+		button.disabled = true
+	button.custom_minimum_size = Vector2(220.0, 52.0)
+	button.size_flags_horizontal = Control.SIZE_SHRINK_END
+	return button
+
+
+func _get_party_exit_button_text() -> String:
+	if bool(_party_detail.get("isUsurpationEligible", false)) and not _is_party_leader():
+		return UiText.SOCIAL_PARTY_USURP
+	var member_variants: Array = _party_detail.get("members", [])
+	if _is_party_leader() and member_variants.size() <= 1:
+		return UiText.SOCIAL_PARTY_DISBAND
+	return UiText.SOCIAL_PARTY_LEAVE
+
+
+func _accept_party_application(application_id: int, applicant_name: String) -> void:
+	var callback := func(success: bool, _data: Variant, error: Dictionary) -> void:
+		if not success:
+			ToastManager.error(UiText.SOCIAL_PARTY_APPLICATIONS, _error_message(error))
+			return
+		ToastManager.success(UiText.SOCIAL_PARTY_APPLICATIONS, UiText.SOCIAL_PARTY_APPLICATION_ACCEPT_SUCCESS % applicant_name)
+		_load_party_applications()
+		_refresh_party()
+	ApiClient.accept_party_application(application_id, callback)
+
+
+func _reject_party_application(application_id: int) -> void:
+	var callback := func(success: bool, _data: Variant, error: Dictionary) -> void:
+		if not success:
+			ToastManager.error(UiText.SOCIAL_PARTY_APPLICATIONS, _error_message(error))
+			return
+		ToastManager.success(UiText.SOCIAL_PARTY_APPLICATIONS, UiText.SOCIAL_PARTY_APPLICATION_REJECT_SUCCESS)
+		_load_party_applications()
+	ApiClient.reject_party_application(application_id, callback)

--- a/scripts/ui/content_bottom_submenu.gd
+++ b/scripts/ui/content_bottom_submenu.gd
@@ -1,0 +1,57 @@
+class_name ContentBottomSubmenu
+extends RefCounted
+
+const OverlaySceneChrome = preload("res://scripts/ui/overlay_scene_chrome.gd")
+
+
+static func build(host: Control, options: Dictionary) -> Dictionary:
+	var panel: PanelContainer = options.get("panel") as PanelContainer
+	if panel == null:
+		panel = OverlaySceneChrome.make_card_panel()
+		host.add_child(panel)
+	else:
+		for child: Node in panel.get_children():
+			child.queue_free()
+
+	var margin: MarginContainer = OverlaySceneChrome.make_content_margin(int(options.get("margin", 12)))
+	panel.add_child(margin)
+
+	var row: HBoxContainer = HBoxContainer.new()
+	row.add_theme_constant_override("separation", int(options.get("separation", 10)))
+	margin.add_child(row)
+
+	var buttons: Dictionary = {}
+	var button_pressed: Callable = options.get("button_pressed", Callable())
+	for item_variant: Variant in options.get("items", []):
+		if not (item_variant is Dictionary):
+			continue
+		var item: Dictionary = item_variant as Dictionary
+		var key: String = str(item.get("key", ""))
+		if key == "":
+			continue
+		var button: Button = Button.new()
+		button.text = str(item.get("label", key))
+		button.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		button.custom_minimum_size = Vector2(0.0, float(options.get("button_height", 50.0)))
+		button.add_theme_font_size_override("font_size", int(options.get("font_size", UiPalette.FONT_SIZE_BODY_LG)))
+		if not button_pressed.is_null():
+			button.pressed.connect(button_pressed.bind(key))
+		row.add_child(button)
+		buttons[key] = button
+
+	refresh(buttons, str(options.get("active_key", "")))
+	return {
+		"panel": panel,
+		"row": row,
+		"buttons": buttons,
+	}
+
+
+static func refresh(buttons: Dictionary, active_key: String) -> void:
+	for key: String in buttons.keys():
+		var button: Button = buttons.get(key) as Button
+		if button == null:
+			continue
+		var is_active: bool = key == active_key
+		UiPalette.apply_button_kind(button, "primary" if is_active else "secondary")
+		button.modulate = Color(1.0, 0.95, 0.84, 1.0) if is_active else Color(0.92, 0.90, 0.86, 1.0)

--- a/scripts/ui/ui_text.gd
+++ b/scripts/ui/ui_text.gd
@@ -84,7 +84,7 @@ const HOME_IDLE_NOT_READY := "乾淨貓砂盆"
 # Home navigation labels
 const NAV_SCOOPER := "鏟屎官"
 const NAV_CONFIG := "編隊"
-const NAV_ENHANCE := "強化"
+const NAV_ENHANCE := "主子"
 const NAV_ACTIVITY := "活動"
 const NAV_SHOP := "商店"
 const NAV_BACKPACK := "背包"


### PR DESCRIPTION
## 摘要
- 修正首頁 HUD、右側選單與 overlay 導航行為
- 將設定中心、背包、組隊改為底部子選單結構
- 修正好友、聊天、信箱與組隊資訊相關 UI 問題

## 驗證
- `git diff --check` 通過
- 本機沒有 Godot CLI，尚未進行 runtime 驗證

## 關聯 Issue
- Closes #148