### PR TITLE
feat: Admin Catalog P1 表格化 UI（Core + Gacha）

### DIFF
--- a/scripts/configs/AdminCatalogCoreRenderer.gd
+++ b/scripts/configs/AdminCatalogCoreRenderer.gd
@@ -1,0 +1,250 @@
+class_name AdminCatalogCoreRenderer
+extends Control
+
+signal changed
+
+var _currency_controls: Array = []
+var _consumable_controls: Array = []
+
+
+func setup(data: Dictionary) -> void:
+	for child: Node in get_children():
+		child.queue_free()
+	_currency_controls.clear()
+	_consumable_controls.clear()
+
+	var tabs := TabContainer.new()
+	tabs.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	tabs.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	add_child(tabs)
+
+	tabs.add_child(_build_currency_tab(data.get("currencies", []) as Array))
+	tabs.add_child(_build_consumable_tab(data.get("consumables", []) as Array))
+	tabs.set_tab_title(0, "貨幣 (%d)" % (data.get("currencies", []) as Array).size())
+	tabs.set_tab_title(1, "消耗品 (%d)" % (data.get("consumables", []) as Array).size())
+
+
+func get_data() -> Dictionary:
+	return {
+		"currencies": _collect_currency_data(),
+		"consumables": _collect_consumable_data(),
+	}
+
+
+# ── Currency Tab ──────────────────────────────────────────────
+
+func _build_currency_tab(entries: Array) -> ScrollContainer:
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.name = "Currencies"
+
+	var vbox := VBoxContainer.new()
+	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.add_theme_constant_override("separation", 2)
+	scroll.add_child(vbox)
+
+	vbox.add_child(_make_currency_header())
+	vbox.add_child(AdminCatalogFormHelpers.make_separator())
+
+	for i: int in range(entries.size()):
+		var entry: Dictionary = entries[i] if entries[i] is Dictionary else {}
+		var row_panel := AdminCatalogFormHelpers.make_data_row_panel(i % 2 == 0)
+		var row_controls := _build_currency_row(entry, row_panel)
+		_currency_controls.append(row_controls)
+		vbox.add_child(row_panel)
+
+	return scroll
+
+
+func _make_currency_header() -> PanelContainer:
+	var panel := AdminCatalogFormHelpers.make_header_row_panel()
+	var margin := MarginContainer.new()
+	margin.add_theme_constant_override("margin_left", 6)
+	margin.add_theme_constant_override("margin_right", 6)
+	margin.add_theme_constant_override("margin_top", 4)
+	margin.add_theme_constant_override("margin_bottom", 4)
+	panel.add_child(margin)
+
+	var hb := AdminCatalogFormHelpers.make_row_hbox()
+	margin.add_child(hb)
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("Id", 50.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("顯示名稱"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("圖片路徑"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("說明"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("排序", 80.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("啟用", 60.0, false))
+	return panel
+
+
+func _build_currency_row(entry: Dictionary, panel: PanelContainer) -> Dictionary:
+	var margin := MarginContainer.new()
+	margin.add_theme_constant_override("margin_left", 6)
+	margin.add_theme_constant_override("margin_right", 6)
+	margin.add_theme_constant_override("margin_top", 3)
+	margin.add_theme_constant_override("margin_bottom", 3)
+	panel.add_child(margin)
+
+	var hb := AdminCatalogFormHelpers.make_row_hbox()
+	margin.add_child(hb)
+
+	var name_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("displayName", "")))
+	var path_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("imagePath", "")))
+	var desc_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("description", "")))
+	var sort_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("sortOrder", 0)))
+	var enabled_cb := AdminCatalogFormHelpers.make_bool_cell(bool(entry.get("isEnabled", true)))
+
+	hb.add_child(AdminCatalogFormHelpers.make_id_cell(entry.get("id", 0)))
+	hb.add_child(name_edit)
+	hb.add_child(path_edit)
+	hb.add_child(desc_edit)
+	hb.add_child(sort_spin)
+	hb.add_child(enabled_cb)
+
+	_connect_change(name_edit, "text_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(path_edit, "text_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(desc_edit, "text_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(sort_spin, "value_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(enabled_cb, "toggled", func(_v: Variant) -> void: changed.emit())
+
+	return {
+		"id": entry.get("id", 0),
+		"name_edit": name_edit,
+		"path_edit": path_edit,
+		"desc_edit": desc_edit,
+		"sort_spin": sort_spin,
+		"enabled_cb": enabled_cb,
+	}
+
+
+func _collect_currency_data() -> Array:
+	var result: Array = []
+	for ctrl: Dictionary in _currency_controls:
+		result.append({
+			"id": ctrl["id"],
+			"displayName": (ctrl["name_edit"] as LineEdit).text,
+			"imagePath": (ctrl["path_edit"] as LineEdit).text,
+			"description": (ctrl["desc_edit"] as LineEdit).text,
+			"sortOrder": int((ctrl["sort_spin"] as SpinBox).value),
+			"isEnabled": (ctrl["enabled_cb"] as CheckBox).button_pressed,
+		})
+	return result
+
+
+# ── Consumable Tab ────────────────────────────────────────────
+
+func _build_consumable_tab(entries: Array) -> ScrollContainer:
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.name = "Consumables"
+
+	var vbox := VBoxContainer.new()
+	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.add_theme_constant_override("separation", 2)
+	scroll.add_child(vbox)
+
+	vbox.add_child(_make_consumable_header())
+	vbox.add_child(AdminCatalogFormHelpers.make_separator())
+
+	for i: int in range(entries.size()):
+		var entry: Dictionary = entries[i] if entries[i] is Dictionary else {}
+		var row_panel := AdminCatalogFormHelpers.make_data_row_panel(i % 2 == 0)
+		var row_controls := _build_consumable_row(entry, row_panel)
+		_consumable_controls.append(row_controls)
+		vbox.add_child(row_panel)
+
+	return scroll
+
+
+func _make_consumable_header() -> PanelContainer:
+	var panel := AdminCatalogFormHelpers.make_header_row_panel()
+	var margin := MarginContainer.new()
+	margin.add_theme_constant_override("margin_left", 6)
+	margin.add_theme_constant_override("margin_right", 6)
+	margin.add_theme_constant_override("margin_top", 4)
+	margin.add_theme_constant_override("margin_bottom", 4)
+	panel.add_child(margin)
+
+	var hb := AdminCatalogFormHelpers.make_row_hbox()
+	margin.add_child(hb)
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("Id", 50.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("顯示名稱"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("分類"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("最大堆疊", 90.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("圖片路徑"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("說明"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("排序", 80.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("啟用", 60.0, false))
+	return panel
+
+
+func _build_consumable_row(entry: Dictionary, panel: PanelContainer) -> Dictionary:
+	var margin := MarginContainer.new()
+	margin.add_theme_constant_override("margin_left", 6)
+	margin.add_theme_constant_override("margin_right", 6)
+	margin.add_theme_constant_override("margin_top", 3)
+	margin.add_theme_constant_override("margin_bottom", 3)
+	panel.add_child(margin)
+
+	var hb := AdminCatalogFormHelpers.make_row_hbox()
+	margin.add_child(hb)
+
+	var name_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("displayName", "")))
+	var cat_ob := AdminCatalogFormHelpers.make_enum_cell(
+		AdminCatalogFormHelpers.ITEM_CATEGORY_OPTIONS,
+		str(entry.get("itemCategoryType", "None"))
+	)
+	var stack_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("maxStack", 1)), 1, 99999, 90.0)
+	var path_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("imagePath", "")))
+	var desc_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("description", "")))
+	var sort_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("sortOrder", 0)))
+	var enabled_cb := AdminCatalogFormHelpers.make_bool_cell(bool(entry.get("isEnabled", true)))
+
+	hb.add_child(AdminCatalogFormHelpers.make_id_cell(entry.get("id", 0)))
+	hb.add_child(name_edit)
+	hb.add_child(cat_ob)
+	hb.add_child(stack_spin)
+	hb.add_child(path_edit)
+	hb.add_child(desc_edit)
+	hb.add_child(sort_spin)
+	hb.add_child(enabled_cb)
+
+	_connect_change(name_edit, "text_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(cat_ob, "item_selected", func(_v: Variant) -> void: changed.emit())
+	_connect_change(stack_spin, "value_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(path_edit, "text_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(desc_edit, "text_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(sort_spin, "value_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(enabled_cb, "toggled", func(_v: Variant) -> void: changed.emit())
+
+	return {
+		"id": entry.get("id", 0),
+		"name_edit": name_edit,
+		"cat_ob": cat_ob,
+		"stack_spin": stack_spin,
+		"path_edit": path_edit,
+		"desc_edit": desc_edit,
+		"sort_spin": sort_spin,
+		"enabled_cb": enabled_cb,
+	}
+
+
+func _collect_consumable_data() -> Array:
+	var result: Array = []
+	for ctrl: Dictionary in _consumable_controls:
+		result.append({
+			"id": ctrl["id"],
+			"displayName": (ctrl["name_edit"] as LineEdit).text,
+			"itemCategoryType": AdminCatalogFormHelpers.get_enum_value(ctrl["cat_ob"] as OptionButton),
+			"maxStack": int((ctrl["stack_spin"] as SpinBox).value),
+			"imagePath": (ctrl["path_edit"] as LineEdit).text,
+			"description": (ctrl["desc_edit"] as LineEdit).text,
+			"sortOrder": int((ctrl["sort_spin"] as SpinBox).value),
+			"isEnabled": (ctrl["enabled_cb"] as CheckBox).button_pressed,
+		})
+	return result
+
+
+# ── Helpers ───────────────────────────────────────────────────
+
+static func _connect_change(node: Node, signal_name: String, callable: Callable) -> void:
+	node.connect(signal_name, callable)

--- a/scripts/configs/AdminCatalogFormHelpers.gd
+++ b/scripts/configs/AdminCatalogFormHelpers.gd
@@ -1,0 +1,189 @@
+class_name AdminCatalogFormHelpers
+extends RefCounted
+
+const COL_TEXT_COLOR := Color(0.95, 0.93, 0.87, 1.0)
+const MUTED_COLOR := Color(0.72, 0.69, 0.63, 0.85)
+
+const ITEM_CATEGORY_OPTIONS := [
+	["None", "未知"],
+	["CurrencyLike", "貨幣型"],
+	["Material", "素材"],
+	["Ticket", "票券"],
+	["Feed", "飼料"],
+	["Shard", "碎片"],
+	["Special", "特殊"],
+]
+
+const GACHA_RARITY_OPTIONS := [
+	["None", "未知"],
+	["Common", "普通"],
+	["Uncommon", "不常見"],
+	["Fine", "精良"],
+	["Special", "特殊"],
+	["Precious", "珍貴"],
+	["Excellent", "卓越"],
+	["Rare", "稀有"],
+	["Epic", "史詩"],
+	["Legendary", "傳說"],
+]
+
+
+static func make_col_header(text: String, min_w: float = 0.0, expand: bool = true) -> Label:
+	var lbl := Label.new()
+	lbl.text = text
+	lbl.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+	lbl.add_theme_color_override("font_color", Color(0.95, 0.88, 0.62, 0.95))
+	lbl.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	if min_w > 0.0:
+		lbl.custom_minimum_size.x = min_w
+	if expand:
+		lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	return lbl
+
+
+static func make_id_cell(id_val: Variant) -> Label:
+	var lbl := Label.new()
+	lbl.text = str(id_val)
+	lbl.custom_minimum_size.x = 48.0
+	lbl.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+	lbl.add_theme_color_override("font_color", MUTED_COLOR)
+	lbl.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	return lbl
+
+
+static func make_text_cell(value: String, min_w: float = 0.0) -> LineEdit:
+	var edit := LineEdit.new()
+	edit.text = value
+	edit.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	edit.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+	if min_w > 0.0:
+		edit.custom_minimum_size.x = min_w
+	_apply_line_edit_style(edit)
+	return edit
+
+
+static func make_int_cell(value: int, min_val: int = 0, max_val: int = 999999, min_w: float = 80.0) -> SpinBox:
+	var spin := SpinBox.new()
+	spin.min_value = min_val
+	spin.max_value = max_val
+	spin.step = 1
+	spin.value = value
+	spin.custom_minimum_size.x = min_w
+	spin.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+	return spin
+
+
+static func make_float_cell(value: float, step: float = 0.001, min_w: float = 90.0) -> SpinBox:
+	var spin := SpinBox.new()
+	spin.min_value = 0.0
+	spin.max_value = 9999999.0
+	spin.step = step
+	spin.value = value
+	spin.custom_minimum_size.x = min_w
+	spin.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+	return spin
+
+
+static func make_bool_cell(value: bool, min_w: float = 60.0) -> CheckBox:
+	var cb := CheckBox.new()
+	cb.button_pressed = value
+	cb.custom_minimum_size.x = min_w
+	return cb
+
+
+static func make_enum_cell(options: Array, current_str: String) -> OptionButton:
+	var ob := OptionButton.new()
+	ob.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	ob.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+	var selected_idx := 0
+	for i: int in range(options.size()):
+		var pair: Array = options[i]
+		ob.add_item(str(pair[1]), i)
+		ob.set_item_metadata(i, str(pair[0]))
+		if str(pair[0]) == current_str:
+			selected_idx = i
+	ob.selected = selected_idx
+	return ob
+
+
+static func get_enum_value(ob: OptionButton) -> String:
+	var idx := ob.selected
+	if idx < 0:
+		return ""
+	return str(ob.get_item_metadata(idx))
+
+
+static func make_header_row_panel() -> PanelContainer:
+	var panel := PanelContainer.new()
+	var style := StyleBoxFlat.new()
+	style.bg_color = Color(0.09, 0.08, 0.11, 0.98)
+	panel.add_theme_stylebox_override("panel", style)
+	return panel
+
+
+static func make_data_row_panel(is_odd: bool) -> PanelContainer:
+	var panel := PanelContainer.new()
+	var style := StyleBoxFlat.new()
+	style.bg_color = Color(0.18, 0.17, 0.20, 0.85) if is_odd else Color(0.13, 0.12, 0.15, 0.85)
+	style.corner_radius_top_left = 3
+	style.corner_radius_top_right = 3
+	style.corner_radius_bottom_left = 3
+	style.corner_radius_bottom_right = 3
+	panel.add_theme_stylebox_override("panel", style)
+	return panel
+
+
+static func make_section_label(text: String) -> Label:
+	var lbl := Label.new()
+	lbl.text = text
+	lbl.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY_LG)
+	lbl.add_theme_color_override("font_color", Color(0.99, 0.93, 0.74, 1.0))
+	return lbl
+
+
+static func make_form_row(label_text: String, control: Control, label_min_w: float = 220.0) -> HBoxContainer:
+	var row := HBoxContainer.new()
+	row.add_theme_constant_override("separation", 12)
+	var lbl := Label.new()
+	lbl.text = label_text
+	lbl.custom_minimum_size.x = label_min_w
+	lbl.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_LABEL)
+	lbl.add_theme_color_override("font_color", MUTED_COLOR)
+	lbl.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	row.add_child(lbl)
+	row.add_child(control)
+	return row
+
+
+static func make_separator() -> HSeparator:
+	var sep := HSeparator.new()
+	sep.add_theme_color_override("color", Color(0.30, 0.26, 0.20, 0.60))
+	return sep
+
+
+static func make_row_hbox() -> HBoxContainer:
+	var hb := HBoxContainer.new()
+	hb.add_theme_constant_override("separation", 6)
+	hb.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	return hb
+
+
+static func _apply_line_edit_style(edit: LineEdit) -> void:
+	var style := StyleBoxFlat.new()
+	style.bg_color = Color(0.10, 0.09, 0.12, 0.98)
+	style.border_width_left = 1
+	style.border_width_right = 1
+	style.border_width_top = 1
+	style.border_width_bottom = 1
+	style.border_color = Color(0.38, 0.32, 0.22, 0.75)
+	style.corner_radius_top_left = 4
+	style.corner_radius_top_right = 4
+	style.corner_radius_bottom_left = 4
+	style.corner_radius_bottom_right = 4
+	style.content_margin_left = 6.0
+	style.content_margin_right = 6.0
+	style.content_margin_top = 2.0
+	style.content_margin_bottom = 2.0
+	edit.add_theme_stylebox_override("normal", style)
+	edit.add_theme_stylebox_override("focus", style)
+	edit.add_theme_color_override("font_color", COL_TEXT_COLOR)

--- a/scripts/configs/AdminCatalogGachaRenderer.gd
+++ b/scripts/configs/AdminCatalogGachaRenderer.gd
@@ -1,0 +1,477 @@
+class_name AdminCatalogGachaRenderer
+extends Control
+
+signal changed
+
+var _setting_ctrls: Dictionary = {}
+var _pull_controls: Array = []
+var _technique_controls: Array = []
+var _rarity_controls: Array = []
+
+
+func setup(data: Dictionary) -> void:
+	for child: Node in get_children():
+		child.queue_free()
+	_setting_ctrls.clear()
+	_pull_controls.clear()
+	_technique_controls.clear()
+	_rarity_controls.clear()
+
+	var tabs := TabContainer.new()
+	tabs.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	tabs.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	add_child(tabs)
+
+	var setting: Dictionary = data.get("setting", {}) if data.get("setting") is Dictionary else {}
+	var pull_options: Array = data.get("pullOptions", []) if data.get("pullOptions") is Array else []
+	var technique_levels: Array = data.get("techniqueLevels", []) if data.get("techniqueLevels") is Array else []
+	var rarity_pres: Array = data.get("rarityPresentations", []) if data.get("rarityPresentations") is Array else []
+
+	tabs.add_child(_build_setting_tab(setting))
+	tabs.add_child(_build_pull_options_tab(pull_options))
+	tabs.add_child(_build_technique_tab(technique_levels))
+	tabs.add_child(_build_rarity_tab(rarity_pres))
+
+	tabs.set_tab_title(0, "全域設定")
+	tabs.set_tab_title(1, "抽卡選項 (%d)" % pull_options.size())
+	tabs.set_tab_title(2, "技巧等級 (%d)" % technique_levels.size())
+	tabs.set_tab_title(3, "稀有度展示 (%d)" % rarity_pres.size())
+
+
+func get_data() -> Dictionary:
+	return {
+		"setting": _collect_setting(),
+		"pullOptions": _collect_pull_options(),
+		"techniqueLevels": _collect_technique_levels(),
+		"rarityPresentations": _collect_rarity_presentations(),
+	}
+
+
+# ── Settings Tab ──────────────────────────────────────────────
+
+func _build_setting_tab(s: Dictionary) -> ScrollContainer:
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.name = "Setting"
+
+	var margin := MarginContainer.new()
+	margin.add_theme_constant_override("margin_left", 16)
+	margin.add_theme_constant_override("margin_top", 16)
+	margin.add_theme_constant_override("margin_right", 16)
+	margin.add_theme_constant_override("margin_bottom", 16)
+	margin.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scroll.add_child(margin)
+
+	var vbox := VBoxContainer.new()
+	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.add_theme_constant_override("separation", 10)
+	margin.add_child(vbox)
+
+	vbox.add_child(AdminCatalogFormHelpers.make_section_label("Gacha 全域設定"))
+	vbox.add_child(AdminCatalogFormHelpers.make_separator())
+
+	var free_pull_spin := AdminCatalogFormHelpers.make_int_cell(int(s.get("dailyFreePullCap", 0)), 0, 9999, 120.0)
+	var dup_shard_spin := AdminCatalogFormHelpers.make_int_cell(int(s.get("duplicateCatShardReward", 0)), 0, 9999, 120.0)
+	var trap_extra_spin := AdminCatalogFormHelpers.make_int_cell(int(s.get("trapPointsExtraPullCost", 0)), 0, 99999, 120.0)
+	var trap_shard_spin := AdminCatalogFormHelpers.make_int_cell(int(s.get("trapPointsCatShardCost", 0)), 0, 99999, 120.0)
+	var enabled_cb := AdminCatalogFormHelpers.make_bool_cell(bool(s.get("isEnabled", true)), 0.0)
+
+	vbox.add_child(AdminCatalogFormHelpers.make_form_row("每日免費抽卡上限", free_pull_spin))
+	vbox.add_child(AdminCatalogFormHelpers.make_form_row("重複貓咪碎片獎勵", dup_shard_spin))
+	vbox.add_child(AdminCatalogFormHelpers.make_form_row("陷阱點額外抽卡費用", trap_extra_spin))
+	vbox.add_child(AdminCatalogFormHelpers.make_form_row("陷阱點貓咪碎片費用", trap_shard_spin))
+	vbox.add_child(AdminCatalogFormHelpers.make_form_row("啟用", enabled_cb))
+
+	_setting_ctrls = {
+		"id": s.get("id", 0),
+		"free_pull": free_pull_spin,
+		"dup_shard": dup_shard_spin,
+		"trap_extra": trap_extra_spin,
+		"trap_shard": trap_shard_spin,
+		"enabled": enabled_cb,
+	}
+
+	_connect_change(free_pull_spin, "value_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(dup_shard_spin, "value_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(trap_extra_spin, "value_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(trap_shard_spin, "value_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(enabled_cb, "toggled", func(_v: Variant) -> void: changed.emit())
+
+	return scroll
+
+
+func _collect_setting() -> Dictionary:
+	return {
+		"id": _setting_ctrls.get("id", 0),
+		"dailyFreePullCap": int((_setting_ctrls["free_pull"] as SpinBox).value),
+		"duplicateCatShardReward": int((_setting_ctrls["dup_shard"] as SpinBox).value),
+		"trapPointsExtraPullCost": int((_setting_ctrls["trap_extra"] as SpinBox).value),
+		"trapPointsCatShardCost": int((_setting_ctrls["trap_shard"] as SpinBox).value),
+		"isEnabled": (_setting_ctrls["enabled"] as CheckBox).button_pressed,
+	}
+
+
+# ── Pull Options Tab ──────────────────────────────────────────
+
+func _build_pull_options_tab(entries: Array) -> ScrollContainer:
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.name = "PullOptions"
+
+	var vbox := VBoxContainer.new()
+	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.add_theme_constant_override("separation", 2)
+	scroll.add_child(vbox)
+
+	vbox.add_child(_make_pull_header())
+	vbox.add_child(AdminCatalogFormHelpers.make_separator())
+
+	for i: int in range(entries.size()):
+		var entry: Dictionary = entries[i] if entries[i] is Dictionary else {}
+		var row_panel := AdminCatalogFormHelpers.make_data_row_panel(i % 2 == 0)
+		_pull_controls.append(_build_pull_row(entry, row_panel))
+		vbox.add_child(row_panel)
+
+	return scroll
+
+
+func _make_pull_header() -> PanelContainer:
+	var panel := AdminCatalogFormHelpers.make_header_row_panel()
+	var margin := _make_row_margin()
+	panel.add_child(margin)
+	var hb := AdminCatalogFormHelpers.make_row_hbox()
+	margin.add_child(hb)
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("Id", 50.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("抽卡次數", 90.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("鑽石費用", 90.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("需要陷阱籠", 100.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("排序", 80.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("啟用", 60.0, false))
+	return panel
+
+
+func _build_pull_row(entry: Dictionary, panel: PanelContainer) -> Dictionary:
+	var margin := _make_row_margin()
+	panel.add_child(margin)
+	var hb := AdminCatalogFormHelpers.make_row_hbox()
+	margin.add_child(hb)
+
+	var count_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("pullCount", 1)), 1, 999, 90.0)
+	var cost_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("diamondCost", 0)), 0, 999999, 90.0)
+	var trap_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("requiredTrapCages", 0)), 0, 999, 100.0)
+	var sort_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("sortOrder", 0)), 0, 99, 80.0)
+	var enabled_cb := AdminCatalogFormHelpers.make_bool_cell(bool(entry.get("isEnabled", true)))
+
+	hb.add_child(AdminCatalogFormHelpers.make_id_cell(entry.get("id", 0)))
+	hb.add_child(count_spin)
+	hb.add_child(cost_spin)
+	hb.add_child(trap_spin)
+	hb.add_child(sort_spin)
+	hb.add_child(enabled_cb)
+
+	for node: Node in [count_spin, cost_spin, trap_spin, sort_spin]:
+		_connect_change(node, "value_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(enabled_cb, "toggled", func(_v: Variant) -> void: changed.emit())
+
+	return {"id": entry.get("id", 0), "count": count_spin, "cost": cost_spin,
+		"trap": trap_spin, "sort": sort_spin, "enabled": enabled_cb}
+
+
+func _collect_pull_options() -> Array:
+	var result: Array = []
+	for ctrl: Dictionary in _pull_controls:
+		result.append({
+			"id": ctrl["id"],
+			"pullCount": int((ctrl["count"] as SpinBox).value),
+			"diamondCost": int((ctrl["cost"] as SpinBox).value),
+			"requiredTrapCages": int((ctrl["trap"] as SpinBox).value),
+			"sortOrder": int((ctrl["sort"] as SpinBox).value),
+			"isEnabled": (ctrl["enabled"] as CheckBox).button_pressed,
+		})
+	return result
+
+
+# ── Technique Levels Tab ──────────────────────────────────────
+
+func _build_technique_tab(entries: Array) -> ScrollContainer:
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.name = "Techniques"
+
+	var vbox := VBoxContainer.new()
+	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.add_theme_constant_override("separation", 4)
+	scroll.add_child(vbox)
+
+	for i: int in range(entries.size()):
+		var entry: Dictionary = entries[i] if entries[i] is Dictionary else {}
+		var ctrls := _build_technique_block(entry, vbox, i % 2 == 0)
+		_technique_controls.append(ctrls)
+
+	return scroll
+
+
+func _build_technique_block(entry: Dictionary, parent: VBoxContainer, is_odd: bool) -> Dictionary:
+	var block_panel := AdminCatalogFormHelpers.make_data_row_panel(is_odd)
+	block_panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	parent.add_child(block_panel)
+
+	var block_margin := _make_row_margin()
+	block_panel.add_child(block_margin)
+
+	var block_vbox := VBoxContainer.new()
+	block_vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	block_vbox.add_theme_constant_override("separation", 4)
+	block_margin.add_child(block_vbox)
+
+	# Header row: level info + controls
+	var header_hb := AdminCatalogFormHelpers.make_row_hbox()
+	block_vbox.add_child(header_hb)
+
+	var level_lbl := Label.new()
+	level_lbl.text = "Lv %d" % int(entry.get("techniqueLevel", 0))
+	level_lbl.custom_minimum_size.x = 60.0
+	level_lbl.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_LABEL)
+	level_lbl.add_theme_color_override("font_color", Color(0.95, 0.88, 0.62, 0.95))
+	level_lbl.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	header_hb.add_child(level_lbl)
+
+	var req_lbl := Label.new()
+	req_lbl.text = "需要 pull 數："
+	req_lbl.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+	req_lbl.add_theme_color_override("font_color", AdminCatalogFormHelpers.MUTED_COLOR)
+	req_lbl.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	header_hb.add_child(req_lbl)
+
+	var req_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("requiredPullCount", 0)), 0, 99999, 90.0)
+	header_hb.add_child(req_spin)
+
+	var spacer := Control.new()
+	spacer.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	header_hb.add_child(spacer)
+
+	var enabled_lbl := Label.new()
+	enabled_lbl.text = "啟用"
+	enabled_lbl.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+	enabled_lbl.add_theme_color_override("font_color", AdminCatalogFormHelpers.MUTED_COLOR)
+	enabled_lbl.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	header_hb.add_child(enabled_lbl)
+
+	var enabled_cb := AdminCatalogFormHelpers.make_bool_cell(bool(entry.get("isEnabled", true)))
+	header_hb.add_child(enabled_cb)
+
+	_connect_change(req_spin, "value_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(enabled_cb, "toggled", func(_v: Variant) -> void: changed.emit())
+
+	# Rates sub-table
+	var rates: Array = entry.get("rates", []) if entry.get("rates") is Array else []
+	var rate_controls := _build_rates_subtable(rates, block_vbox)
+
+	return {
+		"id": entry.get("id", 0),
+		"level": int(entry.get("techniqueLevel", 0)),
+		"req_spin": req_spin,
+		"enabled_cb": enabled_cb,
+		"rate_controls": rate_controls,
+	}
+
+
+func _build_rates_subtable(rates: Array, parent: VBoxContainer) -> Array:
+	if rates.is_empty():
+		return []
+
+	var rate_margin := MarginContainer.new()
+	rate_margin.add_theme_constant_override("margin_left", 20)
+	parent.add_child(rate_margin)
+
+	var rate_vbox := VBoxContainer.new()
+	rate_vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	rate_vbox.add_theme_constant_override("separation", 2)
+	rate_margin.add_child(rate_vbox)
+
+	# Rates header
+	var rate_header := AdminCatalogFormHelpers.make_header_row_panel()
+	rate_vbox.add_child(rate_header)
+	var rh_margin := _make_small_margin()
+	rate_header.add_child(rh_margin)
+	var rh_hb := AdminCatalogFormHelpers.make_row_hbox()
+	rh_margin.add_child(rh_hb)
+	rh_hb.add_child(AdminCatalogFormHelpers.make_col_header("稀有度"))
+	rh_hb.add_child(AdminCatalogFormHelpers.make_col_header("機率 %", 100.0, false))
+	rh_hb.add_child(AdminCatalogFormHelpers.make_col_header("啟用", 60.0, false))
+
+	var rate_controls: Array = []
+	for i: int in range(rates.size()):
+		var rate_entry: Dictionary = rates[i] if rates[i] is Dictionary else {}
+		var rate_row := AdminCatalogFormHelpers.make_data_row_panel(i % 2 == 0)
+		rate_vbox.add_child(rate_row)
+		var rm := _make_small_margin()
+		rate_row.add_child(rm)
+		var r_hb := AdminCatalogFormHelpers.make_row_hbox()
+		rm.add_child(r_hb)
+
+		var rarity_ob := AdminCatalogFormHelpers.make_enum_cell(
+			AdminCatalogFormHelpers.GACHA_RARITY_OPTIONS,
+			str(rate_entry.get("rarityType", "None"))
+		)
+		var rate_spin := AdminCatalogFormHelpers.make_float_cell(float(rate_entry.get("ratePercent", 0.0)), 0.001, 100.0)
+		var rate_enabled := AdminCatalogFormHelpers.make_bool_cell(bool(rate_entry.get("isEnabled", true)))
+
+		r_hb.add_child(rarity_ob)
+		r_hb.add_child(rate_spin)
+		r_hb.add_child(rate_enabled)
+
+		_connect_change(rarity_ob, "item_selected", func(_v: Variant) -> void: changed.emit())
+		_connect_change(rate_spin, "value_changed", func(_v: Variant) -> void: changed.emit())
+		_connect_change(rate_enabled, "toggled", func(_v: Variant) -> void: changed.emit())
+
+		rate_controls.append({
+			"id": rate_entry.get("id", 0),
+			"rarity_ob": rarity_ob,
+			"rate_spin": rate_spin,
+			"enabled_cb": rate_enabled,
+		})
+
+	return rate_controls
+
+
+func _collect_technique_levels() -> Array:
+	var result: Array = []
+	for ctrl: Dictionary in _technique_controls:
+		var rates_arr: Array = []
+		for rc: Dictionary in (ctrl["rate_controls"] as Array):
+			rates_arr.append({
+				"id": rc["id"],
+				"rarityType": AdminCatalogFormHelpers.get_enum_value(rc["rarity_ob"] as OptionButton),
+				"ratePercent": (rc["rate_spin"] as SpinBox).value,
+				"isEnabled": (rc["enabled_cb"] as CheckBox).button_pressed,
+			})
+		result.append({
+			"id": ctrl["id"],
+			"techniqueLevel": ctrl["level"],
+			"requiredPullCount": int((ctrl["req_spin"] as SpinBox).value),
+			"isEnabled": (ctrl["enabled_cb"] as CheckBox).button_pressed,
+			"rates": rates_arr,
+		})
+	return result
+
+
+# ── Rarity Presentations Tab ──────────────────────────────────
+
+func _build_rarity_tab(entries: Array) -> ScrollContainer:
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.name = "Rarities"
+
+	var vbox := VBoxContainer.new()
+	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.add_theme_constant_override("separation", 2)
+	scroll.add_child(vbox)
+
+	vbox.add_child(_make_rarity_header())
+	vbox.add_child(AdminCatalogFormHelpers.make_separator())
+
+	for i: int in range(entries.size()):
+		var entry: Dictionary = entries[i] if entries[i] is Dictionary else {}
+		var row_panel := AdminCatalogFormHelpers.make_data_row_panel(i % 2 == 0)
+		_rarity_controls.append(_build_rarity_row(entry, row_panel))
+		vbox.add_child(row_panel)
+
+	return scroll
+
+
+func _make_rarity_header() -> PanelContainer:
+	var panel := AdminCatalogFormHelpers.make_header_row_panel()
+	var margin := _make_row_margin()
+	panel.add_child(margin)
+	var hb := AdminCatalogFormHelpers.make_row_hbox()
+	margin.add_child(hb)
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("Id", 50.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("稀有度類型"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("Key"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("顯示名稱"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("顏色HEX", 120.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("排序", 80.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("啟用", 60.0, false))
+	return panel
+
+
+func _build_rarity_row(entry: Dictionary, panel: PanelContainer) -> Dictionary:
+	var margin := _make_row_margin()
+	panel.add_child(margin)
+	var hb := AdminCatalogFormHelpers.make_row_hbox()
+	margin.add_child(hb)
+
+	var rarity_ob := AdminCatalogFormHelpers.make_enum_cell(
+		AdminCatalogFormHelpers.GACHA_RARITY_OPTIONS,
+		str(entry.get("rarityType", "None"))
+	)
+	var key_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("rarityKey", "")))
+	var name_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("displayName", "")))
+	var color_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("colorHex", "#ffffff")), 120.0)
+	var sort_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("sortOrder", 0)), 0, 99, 80.0)
+	var enabled_cb := AdminCatalogFormHelpers.make_bool_cell(bool(entry.get("isEnabled", true)))
+
+	hb.add_child(AdminCatalogFormHelpers.make_id_cell(entry.get("id", 0)))
+	hb.add_child(rarity_ob)
+	hb.add_child(key_edit)
+	hb.add_child(name_edit)
+	hb.add_child(color_edit)
+	hb.add_child(sort_spin)
+	hb.add_child(enabled_cb)
+
+	_connect_change(rarity_ob, "item_selected", func(_v: Variant) -> void: changed.emit())
+	_connect_change(key_edit, "text_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(name_edit, "text_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(color_edit, "text_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(sort_spin, "value_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(enabled_cb, "toggled", func(_v: Variant) -> void: changed.emit())
+
+	return {
+		"id": entry.get("id", 0),
+		"rarity_ob": rarity_ob,
+		"key_edit": key_edit,
+		"name_edit": name_edit,
+		"color_edit": color_edit,
+		"sort_spin": sort_spin,
+		"enabled_cb": enabled_cb,
+	}
+
+
+func _collect_rarity_presentations() -> Array:
+	var result: Array = []
+	for ctrl: Dictionary in _rarity_controls:
+		result.append({
+			"id": ctrl["id"],
+			"rarityType": AdminCatalogFormHelpers.get_enum_value(ctrl["rarity_ob"] as OptionButton),
+			"rarityKey": (ctrl["key_edit"] as LineEdit).text,
+			"displayName": (ctrl["name_edit"] as LineEdit).text,
+			"colorHex": (ctrl["color_edit"] as LineEdit).text,
+			"sortOrder": int((ctrl["sort_spin"] as SpinBox).value),
+			"isEnabled": (ctrl["enabled_cb"] as CheckBox).button_pressed,
+		})
+	return result
+
+
+# ── Layout Helpers ────────────────────────────────────────────
+
+static func _make_row_margin() -> MarginContainer:
+	var m := MarginContainer.new()
+	m.add_theme_constant_override("margin_left", 6)
+	m.add_theme_constant_override("margin_right", 6)
+	m.add_theme_constant_override("margin_top", 3)
+	m.add_theme_constant_override("margin_bottom", 3)
+	return m
+
+
+static func _make_small_margin() -> MarginContainer:
+	var m := MarginContainer.new()
+	m.add_theme_constant_override("margin_left", 4)
+	m.add_theme_constant_override("margin_right", 4)
+	m.add_theme_constant_override("margin_top", 2)
+	m.add_theme_constant_override("margin_bottom", 2)
+	return m
+
+
+static func _connect_change(node: Node, signal_name: String, callable: Callable) -> void:
+	node.connect(signal_name, callable)

--- a/scripts/configs/AdminCatalogScene.gd
+++ b/scripts/configs/AdminCatalogScene.gd
@@ -35,6 +35,9 @@ var _reload_button: Button
 var _discard_button: Button
 var _editor: TextEdit
 var _reference_label: RichTextLabel
+var _left_panel: VBoxContainer
+var _renderer_host: VBoxContainer
+var _active_renderer: Control
 
 
 func _ready() -> void:
@@ -125,11 +128,20 @@ func _build_ui() -> void:
 	content_split.split_offset = 760
 	right_column.add_child(content_split)
 
+	_left_panel = VBoxContainer.new()
+	_left_panel.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	content_split.add_child(_left_panel)
+
 	_editor = TextEdit.new()
 	_editor.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	_editor.wrap_mode = TextEdit.LINE_WRAPPING_NONE
 	_editor.text_changed.connect(_on_editor_text_changed)
-	content_split.add_child(_editor)
+	_left_panel.add_child(_editor)
+
+	_renderer_host = VBoxContainer.new()
+	_renderer_host.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	_renderer_host.visible = false
+	_left_panel.add_child(_renderer_host)
 
 	_reference_label = RichTextLabel.new()
 	_reference_label.size_flags_vertical = Control.SIZE_EXPAND_FILL
@@ -227,9 +239,40 @@ func _load_section(section_key: String) -> void:
 
 
 func _set_editor_payload(payload: Dictionary) -> void:
-	_updating_editor = true
-	_editor.text = JSON.stringify(payload, "\t")
-	_updating_editor = false
+	if _active_renderer != null:
+		_renderer_host.remove_child(_active_renderer)
+		_active_renderer.queue_free()
+		_active_renderer = null
+
+	var renderer: Control = _create_renderer(_current_section_key)
+	if renderer != null:
+		_active_renderer = renderer
+		_active_renderer.size_flags_vertical = Control.SIZE_EXPAND_FILL
+		_active_renderer.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		_active_renderer.changed.connect(func() -> void:
+			_dirty = true
+			_refresh_action_state()
+		)
+		_renderer_host.add_child(_active_renderer)
+		_active_renderer.setup(payload)
+		_editor.visible = false
+		_renderer_host.visible = true
+	else:
+		_editor.visible = true
+		_renderer_host.visible = false
+		_updating_editor = true
+		_editor.text = JSON.stringify(payload, "\t")
+		_updating_editor = false
+
+
+func _create_renderer(section_key: String) -> Control:
+	match section_key:
+		"core":
+			return AdminCatalogCoreRenderer.new()
+		"gacha":
+			return AdminCatalogGachaRenderer.new()
+		_:
+			return null
 
 
 func _refresh_section_visuals() -> void:
@@ -314,14 +357,18 @@ func _on_save_pressed() -> void:
 
 
 func _save_current_section() -> void:
-	var parser := JSON.new()
-	if parser.parse(_editor.text) != OK:
-		DialogManager.show_info("JSON 格式錯誤", "請先修正 JSON 內容後再儲存。")
-		return
-	var payload: Variant = parser.get_data()
-	if not (payload is Dictionary):
-		DialogManager.show_info("格式錯誤", "Section payload 必須是 JSON object。")
-		return
+	var payload: Variant
+	if _active_renderer != null:
+		payload = _active_renderer.get_data()
+	else:
+		var parser := JSON.new()
+		if parser.parse(_editor.text) != OK:
+			DialogManager.show_info("JSON 格式錯誤", "請先修正 JSON 內容後再儲存。")
+			return
+		payload = parser.get_data()
+		if not (payload is Dictionary):
+			DialogManager.show_info("格式錯誤", "Section payload 必須是 JSON object。")
+			return
 
 	_saving = true
 	_refresh_action_state()
@@ -359,7 +406,8 @@ func _on_discard_pressed() -> void:
 
 func _refresh_action_state() -> void:
 	var can_edit := not _loading_access and not _loading_section and _current_section_key != ""
-	_editor.editable = can_edit and not _saving
+	if _active_renderer == null:
+		_editor.editable = can_edit and not _saving
 	_save_button.disabled = not can_edit or not _dirty or _saving
 	_reload_button.disabled = not can_edit or _saving
 	_discard_button.disabled = not can_edit or not _dirty or _saving


### PR DESCRIPTION
## 關聯 Issue

closes #158

## 變更說明

將 AdminCatalog 的 Core 與 Gacha section 從純 JSON 編輯器改為表格/表單式介面。

## 新增檔案

- `scripts/configs/AdminCatalogFormHelpers.gd` — 共用表格元件工廠（欄位標頭、行容器、LineEdit、SpinBox、CheckBox、OptionButton + enum 對應）
- `scripts/configs/AdminCatalogCoreRenderer.gd` — Core section：貨幣 / 消耗品兩個 Tab，消耗品含 ItemCategoryType 下拉
- `scripts/configs/AdminCatalogGachaRenderer.gd` — Gacha section：全域設定 / 抽卡選項 / 技巧等級（含 Rates 子表）/ 稀有度展示 四個 Tab

## 修改檔案

- `scripts/configs/AdminCatalogScene.gd` — 加入 `_create_renderer()` factory，core/gacha 自動切換表格 UI，其他 section 保留 JSON fallback

## 測試計畫

- [ ] 進入 AdminCatalog → 選 Core section → 確認貨幣與消耗品表格正確顯示
- [ ] 修改欄位 → 確認儲存按鈕啟用（dirty state）
- [ ] 儲存後 → 確認資料正確送出並重新載入
- [ ] 選其他 section（如 cats）→ 確認 JSON fallback 正常顯示
- [ ] 進入 Gacha section → 確認四個 Tab 皆正常，技巧等級 Rates 子表可見
- [ ] 切換 section 時有未儲存變更 → 確認放棄確認對話框正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)