### PR TITLE
feat: Admin Catalog P3/P4 表格化 UI（Dungeons + Achievements + Shop + Stages + Scooper + Cats + Skills）

### DIFF
--- a/docs/gdd/27_admin_catalog_ui_improvement.md
+++ b/docs/gdd/27_admin_catalog_ui_improvement.md
@@ -1,0 +1,204 @@
+# 27 - Admin Catalog UI 改版規劃
+
+> 目標：將現有純 JSON 編輯器改為表格/表單式介面，降低操作錯誤率與維護成本。
+
+---
+
+## 一、現況說明
+
+AdminCatalog 目前架構：
+- 後端：`AdminCatalogController` → `AdminCatalogService`（12 個 Section）
+- 前端：`AdminCatalogScene.gd` 以純 JSON 文字編輯器呈現，無欄位驗證、無結構提示
+
+所有資料一律顯示為原始 JSON，需手動輸入正確 key 名與型別，容易出錯且不易維護。
+
+---
+
+## 二、全部 Catalog 清單（共 22 個實體 / 12 個 Section）
+
+### 分類 A：貓咪相關
+
+| Section | Entity | 主要欄位 | 複雜度 |
+|---------|--------|----------|--------|
+| **Cats** | CatCatalog | Id, CatKey, CatType, DisplayName, RarityType, BaseHp/Atk/Def/Speed, GachaAvailable, GachaWeight, HpGrowth/AtkGrowth/DefGrowth, IsEnabled, ImagePath | ★★★ |
+| **Skills** | SkillCatalog | Id, SkillKey, DisplayName, SkillType, Description, CooldownSeconds, IsEnabled | ★★ |
+| **Skills** | （子表）SkillEffectConfig, SkillRankScalingConfig | 效果類型、數值、成長曲線 | ★★★ |
+| **Cats** | （子表）CatPassiveSkillConfig, CatActiveSkillConfig | 貓咪技能對應 | ★★ |
+
+### 分類 B：關卡／地下城相關
+
+| Section | Entity | 主要欄位 | 複雜度 |
+|---------|--------|----------|--------|
+| **Stages** | StageSettingCatalog | Id, ZoneType, EncountersPerBossStage, BossStagesPerZone, EncounterGrowthRate, BossGrowthRate, IsEnabled | ★★ |
+| **Stages** | StageWorldSettingCatalog | Id, ZonesPerTerritory, IsEnabled | ★ |
+| **Stages** | （子表）StageRewardPreviewConfig, StageWorldTerritoryConfig, StageWorldZoneSuffixConfig | 獎勵預覽、世界地圖設定 | ★★ |
+| **Dungeons** | DungeonCatalog | Id, DungeonKey, DisplayName, RewardType, DailyTicketLimit, DailyAdTicketLimit, BaseHp/Atk/Def, DifficultyMultiplier, CatFoodPerLevel, SpecialCatFoodPerLevel, DiamondsPerLevel, TrapCageDivisor, WhiskerShardDivisor, IsEnabled, ImagePath, SortOrder | ★★★ |
+
+### 分類 C：競技場相關
+
+| Section | Entity | 主要欄位 | 複雜度 |
+|---------|--------|----------|--------|
+| **Arena** | ArenaSettingCatalog | Id, DailyFreeTickets, MaxDailyPurchases, TicketsPerPurchase, IsEnabled | ★ |
+| **Arena** | ArenaRankCatalog | Id, RankKey, DisplayName, ScoreMin, ScoreMax, SortOrder, IsEnabled, ImagePath | ★★ |
+| **Arena** | ArenaBotCatalog | Id, BotKey, DisplayName, ScoreOffset, SortOrder, IsEnabled | ★★ |
+| **Arena** | （子表）ArenaTicketPurchaseCostConfig, ArenaBotMemberConfig | 購票費用、機器人成員 | ★★ |
+
+### 分類 D：抽卡相關
+
+| Section | Entity | 主要欄位 | 複雜度 |
+|---------|--------|----------|--------|
+| **Gacha** | GachaSettingCatalog | Id, DailyFreePullCap, DuplicateCatShardReward, TrapPointsExtraPullCost, TrapPointsCatShardCost, IsEnabled | ★ |
+| **Gacha** | GachaPullOptionCatalog | Id, PullCount, DiamondCost, RequiredTrapCages, SortOrder, IsEnabled | ★★ |
+| **Gacha** | GachaTechniqueLevelCatalog | Id, TechniqueLevel, RequiredPullCount, IsEnabled | ★★ |
+| **Gacha** | GachaRarityPresentationCatalog | Id, RarityType, RarityKey, DisplayName, ColorHex, SortOrder, IsEnabled | ★★ |
+| **Gacha** | （子表）GachaTechniqueRateConfig | 各等級各稀有度抽中率 | ★★★ |
+
+### 分類 E：Scooper 閒置系統
+
+| Section | Entity | 主要欄位 | 複雜度 |
+|---------|--------|----------|--------|
+| **Scooper** | ScooperIdleSettingCatalog | Id, MaxIdleHours, ScoopExpChance, ScoopExpAmount, ScoopMemoryShardBaseChance, ScoopWhiskerBaseChance, ScoopWhiskerChancePerScooperLevel, ScoopMemoryShardChancePerTwoScooperLevels, ScooperExpPerLevel, IsEnabled | ★★ |
+| **Scooper** | ScooperEquipmentCatalog | Id, DisplayName, UnlockLevel, BasePurchaseCost, BreakChance, SickChance, BaseRepairCost, BaseTreatCost, IsEnabled | ★★ |
+| **Scooper** | ScooperSpecialAbilityCatalog | Id, DisplayName, Description, EffectType, EffectValue, CategoryType, SortOrder, IsEnabled, SourceText, DuplicateCompensationDiamonds | ★★ |
+| **Scooper** | （子表）ScooperIdleBaseRateConfig, ScooperIdleStageBonusConfig, ScooperIdleScooperBonusConfig, ScooperEquipmentEffectConfig, ScooperEquipmentExpRollConfig | 掉率、加成、裝備效果 | ★★★ |
+
+### 分類 F：物品／道具相關
+
+| Section | Entity | 主要欄位 | 複雜度 |
+|---------|--------|----------|--------|
+| **Core** | CurrencyCatalog | Id, DisplayName, SortOrder, IsEnabled, ImagePath, Description | ★ |
+| **Core** | ConsumableCatalog | Id, DisplayName, ItemCategoryType, MaxStack, IsEnabled, ImagePath, Description, SortOrder | ★ |
+| **Memories** | MemoryCatalog | Id, DisplayName, Description, ImagePath, PlaceholderColor, SortOrder, UnlockCost, BonusStatType, BonusValue, IsEnabled | ★★ |
+| **Treasures** | TreasureCatalog | Id, DisplayName, Description, SourceText, ImagePath, PlaceholderColor, SortOrder, IsEnabled | ★★ |
+| **Treasures** | （子表）TreasureEffectConfig | 效果類型與數值 | ★ |
+
+### 分類 G：成就／商店相關
+
+| Section | Entity | 主要欄位 | 複雜度 |
+|---------|--------|----------|--------|
+| **Achievements** | AchievementCatalog | Id, DisplayName, CategoryType, SortOrder, IsEnabled, ConditionType, ConditionValue | ★★ |
+| **Achievements** | （子表）AchievementRewardConfig | 獎勵內容 | ★ |
+| **Shop** | ShopBundleGroupCatalog | Id, CategoryType, GroupType, DisplayName, SortOrder, IsEnabled | ★ |
+| **Shop** | ShopBundleCatalog | Id, DisplayName, Description, CategoryType, GroupType, PriceCurrencyId, PriceAmount, DiscountPercent, PurchaseLimit, SortOrder, IsEnabled | ★★ |
+| **Shop** | （子表）ShopBundleRewardConfig | 商品內含物品與數量 | ★ |
+
+---
+
+## 三、複雜度說明
+
+| 複雜度 | 說明 |
+|--------|------|
+| ★ | 單一扁平表，欄位少且皆為基礎型別（string/int/bool） |
+| ★★ | 欄位稍多，或含 Enum 下拉選單、SortOrder 排序 |
+| ★★★ | 含子表（一對多關聯），或數值較多需要數字驗證 |
+
+---
+
+## 四、目前缺少的功能（JSON 編輯器痛點）
+
+1. **無欄位型別提示** — bool 填成 0/1 或 "true" 字串都可能出錯
+2. **無 Enum 下拉** — CatType、RarityType、ItemCategoryType 等需記憶常數
+3. **無 SortOrder 拖拉排序** — 只能手動改數字
+4. **無圖片預覽** — ImagePath 無法確認圖檔是否存在
+5. **無子表 UI** — SkillEffectConfig、GachaTechniqueRateConfig 等子表在 JSON 中很難維護
+6. **無搜尋 / 篩選** — 貓咪數量多時難以快速找到目標
+7. **無 IsEnabled 快速切換** — 需進 JSON 內找欄位修改
+
+---
+
+## 五、建議開發優先順序
+
+依照「改版效益高」×「開發難度低」排序：
+
+| 優先 | Section | 狀態 | 理由 |
+|------|---------|------|------|
+| P1 | **Core**（Currency / Consumable） | ✅ 已完成 | 欄位最少最簡單，適合作為 UI 框架的 MVP |
+| P1 | **Gacha**（全部） | ✅ 已完成 | 設定表 + 抽卡選項 + 技巧等級（含 Rates 子表）+ 稀有度展示 |
+| P2 | **Arena**（全部） | ✅ 已完成 | 有子表但不複雜，排名清單 + 機器人清單是標準表格 |
+| P2 | **Memories** | ✅ 已完成 | 扁平表，有 PlaceholderColor 可加色票選擇器 |
+| P2 | **Treasures** | ✅ 已完成 | 結構與 Memories 類似，子表只有效果 |
+| P3 | **Dungeons** | ✅ 已完成 | 數值多，但全是數字 input，無複雜子表 |
+| P3 | **Achievements** | ✅ 已完成 | Enum 多，子表簡單（獎勵清單） |
+| P3 | **Shop** | ✅ 已完成 | 兩層結構（Group → Bundle），需 parent-child UI |
+| P4 | **Cats** | ✅ 已完成 | 欄位最多 + 子表（技能配置），留到 UI 框架穩定後 |
+| P4 | **Skills** | ✅ 已完成 | 子表 SkillEffect 有多種效果類型，需動態表單 |
+| P4 | **Scooper** | ✅ 已完成 | 子表最複雜，掉率設定需特殊 UI |
+| P4 | **Stages** | ✅ 已完成 | 世界設定有多層結構，留最後 |
+
+### P1 完成紀錄（2026-04-19）
+
+**Branch:** `feature/admin-catalog-p1-ui`（MeowPartyDashClient）
+**PR:** [#159](https://github.com/ChiangDean/MeowPartyDashClient/pull/159)
+
+**新增檔案：**
+- `scripts/configs/AdminCatalogFormHelpers.gd` — 共用表格/表單元件工廠
+- `scripts/configs/AdminCatalogCoreRenderer.gd` — Core section（貨幣 + 消耗品表格）
+- `scripts/configs/AdminCatalogGachaRenderer.gd` — Gacha section（4 個 Tab：設定表單 + 抽卡選項 + 技巧等級 + 稀有度展示）
+
+**修改檔案：**
+- `scripts/configs/AdminCatalogScene.gd` — 加入 renderer factory，core/gacha 自動切換表格 UI，其他 section 保留 JSON fallback
+
+**後端：** 無需修改（所有 DTO 已完備，enum 以字串序列化）
+
+---
+
+### P2 完成紀錄（2026-04-19）
+
+**Branch:** `feature/admin-catalog-p2-ui`（MeowPartyDashClient）
+**PR:** [#161](https://github.com/ChiangDean/MeowPartyDashClient/pull/161)
+
+**新增檔案：**
+- `scripts/configs/AdminCatalogArenaRenderer.gd` — Arena section（3 Tab：Setting 表單 + Ranks 表格 + Bots 區塊含 Members 子表）
+- `scripts/configs/AdminCatalogMemoriesRenderer.gd` — Memories section（扁平表格，含 BonusStatType 下拉）
+- `scripts/configs/AdminCatalogTreasuresRenderer.gd` — Treasures section（Treasure 區塊 + TreasureEffect 子表）
+
+**修改檔案：**
+- `scripts/configs/AdminCatalogFormHelpers.gd` — 新增 STAT_TYPE、VALUE_MODE、TARGET_SCOPE 等 Enum 選項
+- `scripts/configs/AdminCatalogScene.gd` — `_create_renderer()` 加入 arena / memories / treasures
+
+---
+
+### P3/P4 完成紀錄（2026-04-19）
+
+**Branch:** `feature/admin-catalog-p3-ui`（MeowPartyDashClient）
+**PR:** [#163](https://github.com/ChiangDean/MeowPartyDashClient/pull/163)
+
+**新增檔案：**
+- `scripts/configs/AdminCatalogDungeonsRenderer.gd` — Dungeons section（3 行區塊：基本資訊 + 11 數值欄位 + 圖片描述）
+- `scripts/configs/AdminCatalogAchievementsRenderer.gd` — Achievements section（成就區塊 + 獎勵子表）
+- `scripts/configs/AdminCatalogShopRenderer.gd` — Shop section（3 Tab：Categories / Groups / Bundles 含獎勵子表）
+- `scripts/configs/AdminCatalogStagesRenderer.gd` — Stages section（2 Tab：StageSetting + WorldSetting 含多層子表）
+- `scripts/configs/AdminCatalogScooperRenderer.gd` — Scooper section（3 Tab：IdleSetting + Equipment 區塊 + Abilities 表格）
+- `scripts/configs/AdminCatalogCatsRenderer.gd` — Cats section（3 行貓咪區塊 + PassiveSkills / ActiveSkills 子表）
+- `scripts/configs/AdminCatalogSkillsRenderer.gd` — Skills section（技能區塊 + Effects 子表 + RankScaling 子表）
+
+**修改檔案：**
+- `scripts/configs/AdminCatalogFormHelpers.gd` — 補齊全部 Enum 選項陣列（共 14 組）
+- `scripts/configs/AdminCatalogScene.gd` — `_create_renderer()` 涵蓋全部 12 個 section
+
+**後端：** 無需修改
+
+---
+
+## 六、建議 UI 元件清單
+
+改版時需要的共用元件：
+
+- `CatalogTable` — 可排序、可篩選的主清單表格
+- `CatalogFormModal` — 新增 / 編輯單筆資料的 Modal 表單
+- `EnumDropdown` — 從後端 Enum 清單動態生成下拉選單
+- `SubTableEditor` — 一對多子表的嵌入式清單編輯器（用於技能效果、商品內容等）
+- `ColorPickerField` — 針對 ColorHex / PlaceholderColor 欄位
+- `ImagePathField` — 顯示 ImagePath 並嘗試預覽對應圖檔
+- `SortOrderDragList` — 拖拉調整 SortOrder 的清單
+
+---
+
+## 七、後端現況確認
+
+- 所有 22 個實體均已有對應的 `EntityConfigure` 與資料庫 Migration
+- `AdminCatalogController` 已支援全部 12 個 Section 的 Get/Save
+- `AdminCatalogContracts.cs`（608 行）定義完整 DTO，前端改版無需後端變更
+- 資料快取透過 `StaticCatalogCacheKeys`（23 個常數）管理，Save 後自動失效
+
+**結論：UI 改版完全是前端工作，後端無需任何修改。**

--- a/scripts/configs/AdminCatalogAchievementsRenderer.gd
+++ b/scripts/configs/AdminCatalogAchievementsRenderer.gd
@@ -1,0 +1,262 @@
+class_name AdminCatalogAchievementsRenderer
+extends Control
+
+signal changed
+
+var _achievement_controls: Array = []
+
+
+func setup(data: Dictionary) -> void:
+	for child: Node in get_children():
+		child.queue_free()
+	_achievement_controls.clear()
+
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	add_child(scroll)
+
+	var vbox := VBoxContainer.new()
+	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.add_theme_constant_override("separation", 4)
+	scroll.add_child(vbox)
+
+	var entries: Array = data.get("achievements", []) if data.get("achievements") is Array else []
+
+	for i: int in range(entries.size()):
+		var entry: Dictionary = entries[i] if entries[i] is Dictionary else {}
+		var ctrls := _build_achievement_block(entry, vbox, i % 2 == 0)
+		_achievement_controls.append(ctrls)
+
+
+func get_data() -> Dictionary:
+	var result: Array = []
+	for ctrl: Dictionary in _achievement_controls:
+		var rewards_arr: Array = []
+		for rc: Dictionary in (ctrl["reward_controls"] as Array):
+			var dup_ob := rc["dup_type_ob"] as OptionButton
+			var dup_type_str := AdminCatalogFormHelpers.get_enum_value(dup_ob)
+			var dup_type_val: Variant = null if dup_type_str == "None" else dup_type_str
+			var dup_qty_val: Variant = null if dup_type_str == "None" else int((rc["dup_qty"] as SpinBox).value)
+			rewards_arr.append({
+				"id": rc["id"],
+				"rewardOrder": rc["order"],
+				"rewardType": AdminCatalogFormHelpers.get_enum_value(rc["reward_ob"] as OptionButton),
+				"quantity": int((rc["qty"] as SpinBox).value),
+				"duplicateRewardType": dup_type_val,
+				"duplicateRewardQuantity": dup_qty_val,
+				"isEnabled": (rc["enabled"] as CheckBox).button_pressed,
+			})
+		result.append({
+			"id": ctrl["id"],
+			"displayName": (ctrl["name"] as LineEdit).text,
+			"categoryType": AdminCatalogFormHelpers.get_enum_value(ctrl["category_ob"] as OptionButton),
+			"sortOrder": int((ctrl["sort"] as SpinBox).value),
+			"isEnabled": (ctrl["enabled"] as CheckBox).button_pressed,
+			"conditionType": AdminCatalogFormHelpers.get_enum_value(ctrl["condition_ob"] as OptionButton),
+			"conditionValue": (ctrl["condition_val"] as LineEdit).text,
+			"rewards": rewards_arr,
+		})
+	return {"achievements": result}
+
+
+func _build_achievement_block(entry: Dictionary, parent: VBoxContainer, is_odd: bool) -> Dictionary:
+	var block := AdminCatalogFormHelpers.make_data_row_panel(is_odd)
+	block.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	parent.add_child(block)
+
+	var margin := _make_row_margin()
+	block.add_child(margin)
+
+	var vbox := VBoxContainer.new()
+	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.add_theme_constant_override("separation", 4)
+	margin.add_child(vbox)
+
+	# ── Main row ──────────────────────────────────────────────
+	var main_hb := AdminCatalogFormHelpers.make_row_hbox()
+	vbox.add_child(main_hb)
+
+	main_hb.add_child(AdminCatalogFormHelpers.make_id_cell(entry.get("id", 0)))
+
+	var name_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("displayName", "")))
+	var category_ob := AdminCatalogFormHelpers.make_enum_cell(
+		AdminCatalogFormHelpers.ACHIEVEMENT_CATEGORY_OPTIONS,
+		str(entry.get("categoryType", "None"))
+	)
+	category_ob.custom_minimum_size.x = 100.0
+	category_ob.size_flags_horizontal = Control.SIZE_SHRINK_BEGIN
+
+	var condition_ob := AdminCatalogFormHelpers.make_enum_cell(
+		AdminCatalogFormHelpers.ACHIEVEMENT_CONDITION_OPTIONS,
+		str(entry.get("conditionType", "None"))
+	)
+	condition_ob.custom_minimum_size.x = 140.0
+	condition_ob.size_flags_horizontal = Control.SIZE_SHRINK_BEGIN
+
+	var condition_val_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("conditionValue", "")), 80.0)
+	var sort_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("sortOrder", 0)), 0, 999, 75.0)
+	var enabled_cb := AdminCatalogFormHelpers.make_bool_cell(bool(entry.get("isEnabled", true)))
+
+	_add_labeled(main_hb, "名稱:", name_edit)
+	_add_labeled(main_hb, "類別:", category_ob)
+	_add_labeled(main_hb, "條件:", condition_ob)
+	_add_labeled(main_hb, "條件值:", condition_val_edit)
+	_add_labeled(main_hb, "排序:", sort_spin)
+	_add_labeled(main_hb, "啟用:", enabled_cb)
+
+	for node: Node in [name_edit, condition_val_edit]:
+		_connect_change(node, "text_changed", func(_v: Variant) -> void: changed.emit())
+	for node: Node in [category_ob, condition_ob]:
+		_connect_change(node, "item_selected", func(_v: Variant) -> void: changed.emit())
+	_connect_change(sort_spin, "value_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(enabled_cb, "toggled", func(_v: Variant) -> void: changed.emit())
+
+	# ── Rewards sub-table ─────────────────────────────────────
+	var rewards: Array = entry.get("rewards", []) if entry.get("rewards") is Array else []
+	var reward_controls := _build_rewards_subtable(rewards, vbox)
+
+	return {
+		"id": entry.get("id", 0),
+		"name": name_edit,
+		"category_ob": category_ob,
+		"condition_ob": condition_ob,
+		"condition_val": condition_val_edit,
+		"sort": sort_spin,
+		"enabled": enabled_cb,
+		"reward_controls": reward_controls,
+	}
+
+
+func _build_rewards_subtable(rewards: Array, parent: VBoxContainer) -> Array:
+	if rewards.is_empty():
+		return []
+
+	var sub_margin := MarginContainer.new()
+	sub_margin.add_theme_constant_override("margin_left", 20)
+	parent.add_child(sub_margin)
+
+	var sub_vbox := VBoxContainer.new()
+	sub_vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	sub_vbox.add_theme_constant_override("separation", 2)
+	sub_margin.add_child(sub_vbox)
+
+	# Header
+	var header := AdminCatalogFormHelpers.make_header_row_panel()
+	sub_vbox.add_child(header)
+	var hm := _make_small_margin()
+	header.add_child(hm)
+	var h_hb := AdminCatalogFormHelpers.make_row_hbox()
+	hm.add_child(h_hb)
+	h_hb.add_child(AdminCatalogFormHelpers.make_col_header("順序", 50.0, false))
+	h_hb.add_child(AdminCatalogFormHelpers.make_col_header("獎勵類型", 120.0, false))
+	h_hb.add_child(AdminCatalogFormHelpers.make_col_header("數量", 80.0, false))
+	h_hb.add_child(AdminCatalogFormHelpers.make_col_header("重複獎勵類型", 130.0, false))
+	h_hb.add_child(AdminCatalogFormHelpers.make_col_header("重複數量", 80.0, false))
+	h_hb.add_child(AdminCatalogFormHelpers.make_col_header("啟用", 60.0, false))
+
+	var controls: Array = []
+	for i: int in range(rewards.size()):
+		var rw: Dictionary = rewards[i] if rewards[i] is Dictionary else {}
+
+		var row := AdminCatalogFormHelpers.make_data_row_panel(i % 2 == 0)
+		sub_vbox.add_child(row)
+		var rm := _make_small_margin()
+		row.add_child(rm)
+		var r_hb := AdminCatalogFormHelpers.make_row_hbox()
+		rm.add_child(r_hb)
+
+		# RewardOrder — readonly label
+		var order_lbl := Label.new()
+		order_lbl.text = "#%d" % int(rw.get("rewardOrder", i + 1))
+		order_lbl.custom_minimum_size.x = 50.0
+		order_lbl.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+		order_lbl.add_theme_color_override("font_color", AdminCatalogFormHelpers.MUTED_COLOR)
+		order_lbl.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+		r_hb.add_child(order_lbl)
+
+		# RewardType
+		var reward_ob := AdminCatalogFormHelpers.make_enum_cell(
+			AdminCatalogFormHelpers.REWARD_TYPE_OPTIONS,
+			str(rw.get("rewardType", "None"))
+		)
+		reward_ob.custom_minimum_size.x = 120.0
+		reward_ob.size_flags_horizontal = Control.SIZE_SHRINK_BEGIN
+
+		# Quantity
+		var qty_spin := AdminCatalogFormHelpers.make_int_cell(int(rw.get("quantity", 0)), 0, 999999, 80.0)
+
+		# DuplicateRewardType — "None" when null
+		var dup_type_raw: Variant = rw.get("duplicateRewardType", null)
+		var dup_type_str := "None" if dup_type_raw == null else str(dup_type_raw)
+		var dup_type_ob := AdminCatalogFormHelpers.make_enum_cell(
+			AdminCatalogFormHelpers.REWARD_TYPE_OPTIONS,
+			dup_type_str
+		)
+		dup_type_ob.custom_minimum_size.x = 130.0
+		dup_type_ob.size_flags_horizontal = Control.SIZE_SHRINK_BEGIN
+
+		# DuplicateRewardQuantity — 0 when null
+		var dup_qty_raw: Variant = rw.get("duplicateRewardQuantity", null)
+		var dup_qty_val := 0 if dup_qty_raw == null else int(dup_qty_raw)
+		var dup_qty_spin := AdminCatalogFormHelpers.make_int_cell(dup_qty_val, 0, 999999, 80.0)
+
+		var rw_enabled := AdminCatalogFormHelpers.make_bool_cell(bool(rw.get("isEnabled", true)))
+
+		r_hb.add_child(reward_ob)
+		r_hb.add_child(qty_spin)
+		r_hb.add_child(dup_type_ob)
+		r_hb.add_child(dup_qty_spin)
+		r_hb.add_child(rw_enabled)
+
+		for node: Node in [reward_ob, dup_type_ob]:
+			_connect_change(node, "item_selected", func(_v: Variant) -> void: changed.emit())
+		for node: Node in [qty_spin, dup_qty_spin]:
+			_connect_change(node, "value_changed", func(_v: Variant) -> void: changed.emit())
+		_connect_change(rw_enabled, "toggled", func(_v: Variant) -> void: changed.emit())
+
+		controls.append({
+			"id": rw.get("id", 0),
+			"order": int(rw.get("rewardOrder", i + 1)),
+			"reward_ob": reward_ob,
+			"qty": qty_spin,
+			"dup_type_ob": dup_type_ob,
+			"dup_qty": dup_qty_spin,
+			"enabled": rw_enabled,
+		})
+
+	return controls
+
+
+# ── Layout Helpers ────────────────────────────────────────────
+
+static func _add_labeled(hb: HBoxContainer, label_text: String, control: Control) -> void:
+	var lbl := Label.new()
+	lbl.text = label_text
+	lbl.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+	lbl.add_theme_color_override("font_color", AdminCatalogFormHelpers.MUTED_COLOR)
+	lbl.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	hb.add_child(lbl)
+	hb.add_child(control)
+
+
+static func _make_row_margin() -> MarginContainer:
+	var m := MarginContainer.new()
+	m.add_theme_constant_override("margin_left", 6)
+	m.add_theme_constant_override("margin_right", 6)
+	m.add_theme_constant_override("margin_top", 3)
+	m.add_theme_constant_override("margin_bottom", 3)
+	return m
+
+
+static func _make_small_margin() -> MarginContainer:
+	var m := MarginContainer.new()
+	m.add_theme_constant_override("margin_left", 4)
+	m.add_theme_constant_override("margin_right", 4)
+	m.add_theme_constant_override("margin_top", 2)
+	m.add_theme_constant_override("margin_bottom", 2)
+	return m
+
+
+static func _connect_change(node: Node, signal_name: String, callable: Callable) -> void:
+	node.connect(signal_name, callable)

--- a/scripts/configs/AdminCatalogCatsRenderer.gd
+++ b/scripts/configs/AdminCatalogCatsRenderer.gd
@@ -1,0 +1,342 @@
+class_name AdminCatalogCatsRenderer
+extends Control
+
+signal changed
+
+# ── State ────────────────────────────────────────────────────────
+
+var _cat_controls: Array = []
+
+
+# ── Public API ───────────────────────────────────────────────────
+
+func setup(data: Dictionary) -> void:
+	for child: Node in get_children():
+		child.queue_free()
+	_cat_controls.clear()
+
+	var cats: Array = data.get("cats", []) if data.get("cats") is Array else []
+
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	add_child(scroll)
+
+	var vbox := VBoxContainer.new()
+	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.add_theme_constant_override("separation", 4)
+	scroll.add_child(vbox)
+
+	for i: int in range(cats.size()):
+		var entry: Dictionary = cats[i] if cats[i] is Dictionary else {}
+		var ctrls := _build_cat_block(entry, vbox, i % 2 == 0)
+		_cat_controls.append(ctrls)
+
+
+func get_data() -> Dictionary:
+	return {"cats": _collect_cats()}
+
+
+# ── Cat Block ────────────────────────────────────────────────────
+
+func _build_cat_block(entry: Dictionary, parent: VBoxContainer, is_odd: bool) -> Dictionary:
+	var block_panel := AdminCatalogFormHelpers.make_data_row_panel(is_odd)
+	block_panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	parent.add_child(block_panel)
+
+	var block_margin := _make_row_margin()
+	block_panel.add_child(block_margin)
+
+	var block_vbox := VBoxContainer.new()
+	block_vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	block_vbox.add_theme_constant_override("separation", 4)
+	block_margin.add_child(block_vbox)
+
+	# ── Row 1: Identity ───────────────────────────────────────────
+	var row1 := AdminCatalogFormHelpers.make_row_hbox()
+	block_vbox.add_child(row1)
+
+	var cat_key_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("catKey", "")))
+	var cat_type_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("catType", "")))
+	var display_name_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("displayName", "")))
+	var rarity_ob := AdminCatalogFormHelpers.make_enum_cell(AdminCatalogFormHelpers.GACHA_RARITY_OPTIONS, str(entry.get("rarityType", "Common")))
+	var en_cb := AdminCatalogFormHelpers.make_bool_cell(bool(entry.get("isEnabled", true)), 60.0)
+	var image_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("imagePath", "")), 140.0)
+
+	row1.add_child(AdminCatalogFormHelpers.make_id_cell(entry.get("id", 0)))
+	row1.add_child(_add_labeled("Key", cat_key_edit))
+	row1.add_child(_add_labeled("類型", cat_type_edit))
+	row1.add_child(_add_labeled("顯示名稱", display_name_edit))
+	row1.add_child(_add_labeled("稀有度", rarity_ob))
+	row1.add_child(_add_labeled("啟用", en_cb))
+	row1.add_child(_add_labeled("圖片路徑", image_edit))
+
+	_connect_change(rarity_ob, "item_selected", func(_v: Variant) -> void: changed.emit())
+	for edit: Node in [cat_key_edit, cat_type_edit, display_name_edit, image_edit]:
+		_connect_change(edit, "text_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(en_cb, "toggled", func(_v: Variant) -> void: changed.emit())
+
+	# ── Row 2: Base Stats ─────────────────────────────────────────
+	var row2 := AdminCatalogFormHelpers.make_row_hbox()
+	block_vbox.add_child(row2)
+
+	var hp_spin := AdminCatalogFormHelpers.make_float_cell(float(entry.get("baseHp", 100.0)), 0.1, 90.0)
+	var atk_spin := AdminCatalogFormHelpers.make_float_cell(float(entry.get("baseAtk", 10.0)), 0.1, 90.0)
+	var def_spin := AdminCatalogFormHelpers.make_float_cell(float(entry.get("baseDef", 5.0)), 0.1, 90.0)
+	var spd_spin := AdminCatalogFormHelpers.make_float_cell(float(entry.get("baseSpeed", 3.0)), 0.1, 90.0)
+	var gacha_cb := CheckBox.new()
+	gacha_cb.button_pressed = bool(entry.get("gachaAvailable", true))
+	gacha_cb.custom_minimum_size.x = 24.0
+	var gacha_w_spin := AdminCatalogFormHelpers.make_float_cell(float(entry.get("gachaWeight", 1.0)), 0.001, 90.0)
+
+	row2.add_child(_add_labeled("基礎HP", hp_spin))
+	row2.add_child(_add_labeled("基礎ATK", atk_spin))
+	row2.add_child(_add_labeled("基礎DEF", def_spin))
+	row2.add_child(_add_labeled("基礎速度", spd_spin))
+	row2.add_child(_add_labeled("可抽卡", gacha_cb))
+	row2.add_child(_add_labeled("抽卡權重", gacha_w_spin))
+
+	for node: Node in [hp_spin, atk_spin, def_spin, spd_spin, gacha_w_spin]:
+		_connect_change(node, "value_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(gacha_cb, "toggled", func(_v: Variant) -> void: changed.emit())
+
+	# ── Row 3: Growth + Description ───────────────────────────────
+	var row3 := AdminCatalogFormHelpers.make_row_hbox()
+	block_vbox.add_child(row3)
+
+	var hp_g_spin := AdminCatalogFormHelpers.make_float_cell(float(entry.get("hpGrowth", 1.0)), 0.001, 90.0)
+	var atk_g_spin := AdminCatalogFormHelpers.make_float_cell(float(entry.get("atkGrowth", 1.0)), 0.001, 90.0)
+	var def_g_spin := AdminCatalogFormHelpers.make_float_cell(float(entry.get("defGrowth", 1.0)), 0.001, 90.0)
+	var desc_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("description", "")))
+
+	row3.add_child(_add_labeled("HP成長", hp_g_spin))
+	row3.add_child(_add_labeled("ATK成長", atk_g_spin))
+	row3.add_child(_add_labeled("DEF成長", def_g_spin))
+	row3.add_child(_add_labeled("描述", desc_edit))
+
+	for node: Node in [hp_g_spin, atk_g_spin, def_g_spin]:
+		_connect_change(node, "value_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(desc_edit, "text_changed", func(_v: Variant) -> void: changed.emit())
+
+	# ── PassiveSkills Sub-table ───────────────────────────────────
+	var passive_skills: Array = entry.get("passiveSkills", []) if entry.get("passiveSkills") is Array else []
+	var passive_controls := _build_passive_skills_subtable(passive_skills, block_vbox)
+
+	# ── ActiveSkills Sub-table ────────────────────────────────────
+	var active_skills: Array = entry.get("activeSkills", []) if entry.get("activeSkills") is Array else []
+	var active_controls := _build_active_skills_subtable(active_skills, block_vbox)
+
+	return {
+		"id": entry.get("id", 0),
+		"cat_key_edit": cat_key_edit,
+		"cat_type_edit": cat_type_edit,
+		"display_name_edit": display_name_edit,
+		"rarity_ob": rarity_ob,
+		"enabled_cb": en_cb,
+		"image_edit": image_edit,
+		"hp_spin": hp_spin, "atk_spin": atk_spin,
+		"def_spin": def_spin, "spd_spin": spd_spin,
+		"gacha_cb": gacha_cb, "gacha_w_spin": gacha_w_spin,
+		"hp_g_spin": hp_g_spin, "atk_g_spin": atk_g_spin, "def_g_spin": def_g_spin,
+		"desc_edit": desc_edit,
+		"passive_controls": passive_controls,
+		"active_controls": active_controls,
+	}
+
+
+func _build_passive_skills_subtable(skills: Array, parent: VBoxContainer) -> Array:
+	var sub_margin := MarginContainer.new()
+	sub_margin.add_theme_constant_override("margin_left", 20)
+	parent.add_child(sub_margin)
+
+	var sub_vbox := VBoxContainer.new()
+	sub_vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	sub_vbox.add_theme_constant_override("separation", 2)
+	sub_margin.add_child(sub_vbox)
+
+	var label := AdminCatalogFormHelpers.make_section_label("被動技能")
+	label.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_LABEL)
+	sub_vbox.add_child(label)
+
+	var header := AdminCatalogFormHelpers.make_header_row_panel()
+	sub_vbox.add_child(header)
+	var hm := _make_small_margin()
+	header.add_child(hm)
+	var hb := AdminCatalogFormHelpers.make_row_hbox()
+	hm.add_child(hb)
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("技能順序 (readonly)", 160.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("技能 Id"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("啟用", 60.0, false))
+
+	var result: Array = []
+	for i: int in range(skills.size()):
+		var sk: Dictionary = skills[i] if skills[i] is Dictionary else {}
+		var row := AdminCatalogFormHelpers.make_data_row_panel(i % 2 == 0)
+		sub_vbox.add_child(row)
+		var rm := _make_small_margin()
+		row.add_child(rm)
+		var rb := AdminCatalogFormHelpers.make_row_hbox()
+		rm.add_child(rb)
+
+		var order_lbl := AdminCatalogFormHelpers.make_id_cell(sk.get("skillOrder", i + 1))
+		order_lbl.custom_minimum_size.x = 160.0
+		var skill_id_spin := AdminCatalogFormHelpers.make_int_cell(int(sk.get("skillId", 1)), 1, 999999)
+		var en_cb := AdminCatalogFormHelpers.make_bool_cell(bool(sk.get("isEnabled", true)), 60.0)
+
+		rb.add_child(order_lbl)
+		rb.add_child(skill_id_spin)
+		rb.add_child(en_cb)
+
+		_connect_change(skill_id_spin, "value_changed", func(_v: Variant) -> void: changed.emit())
+		_connect_change(en_cb, "toggled", func(_v: Variant) -> void: changed.emit())
+
+		result.append({
+			"id": sk.get("id", 0),
+			"skill_order": int(sk.get("skillOrder", i + 1)),
+			"skill_id_spin": skill_id_spin,
+			"enabled_cb": en_cb,
+		})
+	return result
+
+
+func _build_active_skills_subtable(skills: Array, parent: VBoxContainer) -> Array:
+	var sub_margin := MarginContainer.new()
+	sub_margin.add_theme_constant_override("margin_left", 20)
+	parent.add_child(sub_margin)
+
+	var sub_vbox := VBoxContainer.new()
+	sub_vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	sub_vbox.add_theme_constant_override("separation", 2)
+	sub_margin.add_child(sub_vbox)
+
+	var label := AdminCatalogFormHelpers.make_section_label("主動技能")
+	label.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_LABEL)
+	sub_vbox.add_child(label)
+
+	var header := AdminCatalogFormHelpers.make_header_row_panel()
+	sub_vbox.add_child(header)
+	var hm := _make_small_margin()
+	header.add_child(hm)
+	var hb := AdminCatalogFormHelpers.make_row_hbox()
+	hm.add_child(hb)
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("技能順序 (readonly)", 160.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("技能 Id"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("初始延遲(秒)", 110.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("啟用", 60.0, false))
+
+	var result: Array = []
+	for i: int in range(skills.size()):
+		var sk: Dictionary = skills[i] if skills[i] is Dictionary else {}
+		var row := AdminCatalogFormHelpers.make_data_row_panel(i % 2 == 0)
+		sub_vbox.add_child(row)
+		var rm := _make_small_margin()
+		row.add_child(rm)
+		var rb := AdminCatalogFormHelpers.make_row_hbox()
+		rm.add_child(rb)
+
+		var order_lbl := AdminCatalogFormHelpers.make_id_cell(sk.get("skillOrder", i + 1))
+		order_lbl.custom_minimum_size.x = 160.0
+		var skill_id_spin := AdminCatalogFormHelpers.make_int_cell(int(sk.get("skillId", 1)), 1, 999999)
+		var delay_spin := AdminCatalogFormHelpers.make_int_cell(int(sk.get("initialDelaySeconds", 0)), 0, 9999, 110.0)
+		var en_cb := AdminCatalogFormHelpers.make_bool_cell(bool(sk.get("isEnabled", true)), 60.0)
+
+		rb.add_child(order_lbl)
+		rb.add_child(skill_id_spin)
+		rb.add_child(delay_spin)
+		rb.add_child(en_cb)
+
+		for node: Node in [skill_id_spin, delay_spin]:
+			_connect_change(node, "value_changed", func(_v: Variant) -> void: changed.emit())
+		_connect_change(en_cb, "toggled", func(_v: Variant) -> void: changed.emit())
+
+		result.append({
+			"id": sk.get("id", 0),
+			"skill_order": int(sk.get("skillOrder", i + 1)),
+			"skill_id_spin": skill_id_spin,
+			"delay_spin": delay_spin,
+			"enabled_cb": en_cb,
+		})
+	return result
+
+
+# ── Collect ──────────────────────────────────────────────────────
+
+func _collect_cats() -> Array:
+	var result: Array = []
+	for ctrl: Dictionary in _cat_controls:
+		var passive_arr: Array = []
+		for pc: Dictionary in (ctrl["passive_controls"] as Array):
+			passive_arr.append({
+				"id": pc["id"],
+				"skillId": int((pc["skill_id_spin"] as SpinBox).value),
+				"skillOrder": pc["skill_order"],
+				"isEnabled": (pc["enabled_cb"] as CheckBox).button_pressed,
+			})
+		var active_arr: Array = []
+		for ac: Dictionary in (ctrl["active_controls"] as Array):
+			active_arr.append({
+				"id": ac["id"],
+				"skillId": int((ac["skill_id_spin"] as SpinBox).value),
+				"skillOrder": ac["skill_order"],
+				"initialDelaySeconds": int((ac["delay_spin"] as SpinBox).value),
+				"isEnabled": (ac["enabled_cb"] as CheckBox).button_pressed,
+			})
+		result.append({
+			"id": ctrl["id"],
+			"catKey": (ctrl["cat_key_edit"] as LineEdit).text,
+			"catType": (ctrl["cat_type_edit"] as LineEdit).text,
+			"displayName": (ctrl["display_name_edit"] as LineEdit).text,
+			"rarityType": AdminCatalogFormHelpers.get_enum_value(ctrl["rarity_ob"] as OptionButton),
+			"baseHp": (ctrl["hp_spin"] as SpinBox).value,
+			"baseAtk": (ctrl["atk_spin"] as SpinBox).value,
+			"baseDef": (ctrl["def_spin"] as SpinBox).value,
+			"baseSpeed": (ctrl["spd_spin"] as SpinBox).value,
+			"gachaAvailable": (ctrl["gacha_cb"] as CheckBox).button_pressed,
+			"gachaWeight": (ctrl["gacha_w_spin"] as SpinBox).value,
+			"hpGrowth": (ctrl["hp_g_spin"] as SpinBox).value,
+			"atkGrowth": (ctrl["atk_g_spin"] as SpinBox).value,
+			"defGrowth": (ctrl["def_g_spin"] as SpinBox).value,
+			"isEnabled": (ctrl["enabled_cb"] as CheckBox).button_pressed,
+			"imagePath": (ctrl["image_edit"] as LineEdit).text,
+			"description": (ctrl["desc_edit"] as LineEdit).text,
+			"passiveSkills": passive_arr,
+			"activeSkills": active_arr,
+		})
+	return result
+
+
+# ── Layout Helpers ────────────────────────────────────────────────
+
+static func _add_labeled(label_text: String, control: Control) -> HBoxContainer:
+	var hb := HBoxContainer.new()
+	hb.add_theme_constant_override("separation", 4)
+	var lbl := Label.new()
+	lbl.text = label_text
+	lbl.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+	lbl.add_theme_color_override("font_color", AdminCatalogFormHelpers.MUTED_COLOR)
+	lbl.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	hb.add_child(lbl)
+	hb.add_child(control)
+	return hb
+
+
+static func _make_row_margin() -> MarginContainer:
+	var m := MarginContainer.new()
+	m.add_theme_constant_override("margin_left", 6)
+	m.add_theme_constant_override("margin_right", 6)
+	m.add_theme_constant_override("margin_top", 3)
+	m.add_theme_constant_override("margin_bottom", 3)
+	return m
+
+
+static func _make_small_margin() -> MarginContainer:
+	var m := MarginContainer.new()
+	m.add_theme_constant_override("margin_left", 4)
+	m.add_theme_constant_override("margin_right", 4)
+	m.add_theme_constant_override("margin_top", 2)
+	m.add_theme_constant_override("margin_bottom", 2)
+	return m
+
+
+static func _connect_change(node: Node, signal_name: String, callable: Callable) -> void:
+	node.connect(signal_name, callable)

--- a/scripts/configs/AdminCatalogDungeonsRenderer.gd
+++ b/scripts/configs/AdminCatalogDungeonsRenderer.gd
@@ -1,0 +1,200 @@
+class_name AdminCatalogDungeonsRenderer
+extends Control
+
+signal changed
+
+var _dungeon_controls: Array = []
+
+
+func setup(data: Dictionary) -> void:
+	for child: Node in get_children():
+		child.queue_free()
+	_dungeon_controls.clear()
+
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	add_child(scroll)
+
+	var vbox := VBoxContainer.new()
+	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.add_theme_constant_override("separation", 4)
+	scroll.add_child(vbox)
+
+	var entries: Array = data.get("dungeons", []) if data.get("dungeons") is Array else []
+
+	for i: int in range(entries.size()):
+		var entry: Dictionary = entries[i] if entries[i] is Dictionary else {}
+		var ctrls := _build_dungeon_block(entry, vbox, i % 2 == 0)
+		_dungeon_controls.append(ctrls)
+
+
+func get_data() -> Dictionary:
+	var result: Array = []
+	for ctrl: Dictionary in _dungeon_controls:
+		result.append({
+			"id": ctrl["id"],
+			"dungeonKey": (ctrl["key"] as LineEdit).text,
+			"displayName": (ctrl["name"] as LineEdit).text,
+			"rewardType": AdminCatalogFormHelpers.get_enum_value(ctrl["reward_ob"] as OptionButton),
+			"dailyTicketLimit": int((ctrl["ticket"] as SpinBox).value),
+			"dailyAdTicketLimit": int((ctrl["ad_ticket"] as SpinBox).value),
+			"baseHp": (ctrl["base_hp"] as SpinBox).value,
+			"baseAtk": (ctrl["base_atk"] as SpinBox).value,
+			"baseDef": (ctrl["base_def"] as SpinBox).value,
+			"difficultyMultiplier": (ctrl["diff_mult"] as SpinBox).value,
+			"catFoodPerLevel": int((ctrl["cat_food"] as SpinBox).value),
+			"specialCatFoodPerLevel": int((ctrl["special_food"] as SpinBox).value),
+			"diamondsPerLevel": int((ctrl["diamonds"] as SpinBox).value),
+			"trapCageDivisor": int((ctrl["trap_cage"] as SpinBox).value),
+			"whiskerShardDivisor": int((ctrl["whisker"] as SpinBox).value),
+			"isEnabled": (ctrl["enabled"] as CheckBox).button_pressed,
+			"imagePath": (ctrl["path"] as LineEdit).text,
+			"sortOrder": int((ctrl["sort"] as SpinBox).value),
+			"description": (ctrl["desc"] as LineEdit).text,
+		})
+	return {"dungeons": result}
+
+
+func _build_dungeon_block(entry: Dictionary, parent: VBoxContainer, is_odd: bool) -> Dictionary:
+	var block := AdminCatalogFormHelpers.make_data_row_panel(is_odd)
+	block.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	parent.add_child(block)
+
+	var margin := _make_row_margin()
+	block.add_child(margin)
+
+	var vbox := VBoxContainer.new()
+	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.add_theme_constant_override("separation", 4)
+	margin.add_child(vbox)
+
+	# ── Row 1: Identification ─────────────────────────────────
+	var row1 := AdminCatalogFormHelpers.make_row_hbox()
+	vbox.add_child(row1)
+
+	row1.add_child(AdminCatalogFormHelpers.make_id_cell(entry.get("id", 0)))
+
+	var key_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("dungeonKey", "")))
+	var name_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("displayName", "")))
+	var reward_ob := AdminCatalogFormHelpers.make_enum_cell(
+		AdminCatalogFormHelpers.REWARD_TYPE_OPTIONS,
+		str(entry.get("rewardType", "None"))
+	)
+	reward_ob.custom_minimum_size.x = 110.0
+	reward_ob.size_flags_horizontal = Control.SIZE_SHRINK_BEGIN
+	var enabled_cb := AdminCatalogFormHelpers.make_bool_cell(bool(entry.get("isEnabled", true)))
+	var sort_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("sortOrder", 0)), 0, 999, 75.0)
+
+	_add_labeled(row1, "Key:", key_edit)
+	_add_labeled(row1, "名稱:", name_edit)
+	_add_labeled(row1, "獎勵:", reward_ob)
+	_add_labeled(row1, "啟用:", enabled_cb)
+	_add_labeled(row1, "排序:", sort_spin)
+
+	for node: Node in [key_edit, name_edit]:
+		_connect_change(node, "text_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(reward_ob, "item_selected", func(_v: Variant) -> void: changed.emit())
+	_connect_change(enabled_cb, "toggled", func(_v: Variant) -> void: changed.emit())
+	_connect_change(sort_spin, "value_changed", func(_v: Variant) -> void: changed.emit())
+
+	# ── Row 2: Numeric Stats ──────────────────────────────────
+	var row2 := AdminCatalogFormHelpers.make_row_hbox()
+	vbox.add_child(row2)
+
+	var ticket_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("dailyTicketLimit", 3)), 0, 99, 70.0)
+	var ad_ticket_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("dailyAdTicketLimit", 2)), 0, 99, 70.0)
+	var base_hp_spin := AdminCatalogFormHelpers.make_float_cell(float(entry.get("baseHp", 100.0)), 0.1, 90.0)
+	var base_atk_spin := AdminCatalogFormHelpers.make_float_cell(float(entry.get("baseAtk", 10.0)), 0.1, 90.0)
+	var base_def_spin := AdminCatalogFormHelpers.make_float_cell(float(entry.get("baseDef", 5.0)), 0.1, 90.0)
+	var diff_mult_spin := AdminCatalogFormHelpers.make_float_cell(float(entry.get("difficultyMultiplier", 1.0)), 0.01, 90.0)
+	var cat_food_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("catFoodPerLevel", 0)), 0, 99999, 75.0)
+	var special_food_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("specialCatFoodPerLevel", 0)), 0, 99999, 75.0)
+	var diamonds_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("diamondsPerLevel", 0)), 0, 99999, 75.0)
+	var trap_cage_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("trapCageDivisor", 0)), 0, 99999, 75.0)
+	var whisker_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("whiskerShardDivisor", 0)), 0, 99999, 75.0)
+
+	_add_labeled(row2, "每日票:", ticket_spin)
+	_add_labeled(row2, "每日廣告票:", ad_ticket_spin)
+	_add_labeled(row2, "基礎HP:", base_hp_spin)
+	_add_labeled(row2, "基礎ATK:", base_atk_spin)
+	_add_labeled(row2, "基礎DEF:", base_def_spin)
+	_add_labeled(row2, "難度倍率:", diff_mult_spin)
+	_add_labeled(row2, "貓糧/層:", cat_food_spin)
+	_add_labeled(row2, "特製貓糧/層:", special_food_spin)
+	_add_labeled(row2, "鑽石/層:", diamonds_spin)
+	_add_labeled(row2, "誘捕籠除數:", trap_cage_spin)
+	_add_labeled(row2, "鬍鬚碎片除數:", whisker_spin)
+
+	for node: Node in [ticket_spin, ad_ticket_spin, base_hp_spin, base_atk_spin, base_def_spin,
+			diff_mult_spin, cat_food_spin, special_food_spin, diamonds_spin, trap_cage_spin, whisker_spin]:
+		_connect_change(node, "value_changed", func(_v: Variant) -> void: changed.emit())
+
+	# ── Row 3: Text Fields ────────────────────────────────────
+	var row3 := AdminCatalogFormHelpers.make_row_hbox()
+	vbox.add_child(row3)
+
+	var path_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("imagePath", "")))
+	var desc_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("description", "")))
+
+	_add_labeled(row3, "圖片路徑:", path_edit)
+	_add_labeled(row3, "說明:", desc_edit)
+
+	for node: Node in [path_edit, desc_edit]:
+		_connect_change(node, "text_changed", func(_v: Variant) -> void: changed.emit())
+
+	return {
+		"id": entry.get("id", 0),
+		"key": key_edit,
+		"name": name_edit,
+		"reward_ob": reward_ob,
+		"enabled": enabled_cb,
+		"sort": sort_spin,
+		"ticket": ticket_spin,
+		"ad_ticket": ad_ticket_spin,
+		"base_hp": base_hp_spin,
+		"base_atk": base_atk_spin,
+		"base_def": base_def_spin,
+		"diff_mult": diff_mult_spin,
+		"cat_food": cat_food_spin,
+		"special_food": special_food_spin,
+		"diamonds": diamonds_spin,
+		"trap_cage": trap_cage_spin,
+		"whisker": whisker_spin,
+		"path": path_edit,
+		"desc": desc_edit,
+	}
+
+
+# ── Layout Helpers ────────────────────────────────────────────
+
+static func _add_labeled(hb: HBoxContainer, label_text: String, control: Control) -> void:
+	var lbl := Label.new()
+	lbl.text = label_text
+	lbl.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+	lbl.add_theme_color_override("font_color", AdminCatalogFormHelpers.MUTED_COLOR)
+	lbl.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	hb.add_child(lbl)
+	hb.add_child(control)
+
+
+static func _make_row_margin() -> MarginContainer:
+	var m := MarginContainer.new()
+	m.add_theme_constant_override("margin_left", 6)
+	m.add_theme_constant_override("margin_right", 6)
+	m.add_theme_constant_override("margin_top", 3)
+	m.add_theme_constant_override("margin_bottom", 3)
+	return m
+
+
+static func _make_small_margin() -> MarginContainer:
+	var m := MarginContainer.new()
+	m.add_theme_constant_override("margin_left", 4)
+	m.add_theme_constant_override("margin_right", 4)
+	m.add_theme_constant_override("margin_top", 2)
+	m.add_theme_constant_override("margin_bottom", 2)
+	return m
+
+
+static func _connect_change(node: Node, signal_name: String, callable: Callable) -> void:
+	node.connect(signal_name, callable)

--- a/scripts/configs/AdminCatalogFormHelpers.gd
+++ b/scripts/configs/AdminCatalogFormHelpers.gd
@@ -4,6 +4,57 @@ extends RefCounted
 const COL_TEXT_COLOR := Color(0.95, 0.93, 0.87, 1.0)
 const MUTED_COLOR := Color(0.72, 0.69, 0.63, 0.85)
 
+const REWARD_TYPE_OPTIONS := [
+	["None", "無"], ["Gold", "金幣"], ["Diamond", "鑽石"],
+	["TrapPoint", "捕獲點"], ["CatFood", "貓糧"], ["SpecialCatFood", "特製貓糧"],
+	["TrapCage", "誘捕籠"], ["PoopCount", "便便"], ["MemoryShard", "記憶碎片"],
+	["WhiskerShard", "鬍鬚碎片"], ["SpecialAbility", "特殊能力"], ["Treasure", "寶物"],
+	["Memory", "記憶"], ["Equipment", "裝備"], ["Cat", "貓咪"], ["Consumable", "消耗品"],
+]
+
+const ACHIEVEMENT_CATEGORY_OPTIONS := [
+	["None", "未知"], ["Small", "小成就"], ["Big", "大成就"],
+]
+
+const ACHIEVEMENT_CONDITION_OPTIONS := [
+	["None", "未知"], ["ScooperLevelReached", "鏟屎官等級"],
+	["AnyCatLevelReached", "貓咪等級"], ["AnyCatRankReached", "貓咪階級"],
+	["EquipmentOwnedCountReached", "裝備持有數"], ["StageReached", "關卡達成"],
+	["MemoryUnlockedCountReached", "記憶解鎖數"], ["OwnedCatCountReached", "貓咪持有數"],
+]
+
+const SKILL_TYPE_OPTIONS := [
+	["None", "未知"], ["Active", "主動技能"], ["Passive", "被動技能"],
+]
+
+const SKILL_EFFECT_TYPE_OPTIONS := [
+	["None", "未知"], ["Damage", "傷害"], ["Heal", "治療"], ["Shield", "護盾"],
+	["BuffStat", "增益"], ["DebuffStat", "減益"], ["StatBoost", "能力提升"],
+	["DamageReduction", "減傷"], ["CooldownReduction", "冷卻縮減"], ["Reflect", "反傷"],
+]
+
+const SPECIAL_ABILITY_EFFECT_OPTIONS := [
+	["None", "未知"], ["IdleRewardMultiplier", "放置獎勵倍率"],
+	["IdleMaxHoursBonus", "放置上限時數"], ["UnlockBattleSpeed", "解鎖戰鬥加速"],
+	["UnlockBattleSkip", "解鎖戰鬥跳過"], ["BossSpeedMultiplier", "首領速度倍率"],
+]
+
+const SHOP_CATEGORY_OPTIONS := [
+	["None", "未知"], ["ValuePack", "超值禮包"], ["GrowthPack", "成長禮包"],
+	["DailyPack", "每日禮包"], ["LimitedPack", "限時禮包"],
+]
+
+const SHOP_GROUP_OPTIONS := [
+	["None", "未知"], ["StarterPack", "新手禮包"], ["LaunchBoostPackI", "衝刺禮包I"],
+	["LaunchBoostPackII", "衝刺禮包II"], ["PermanentPack", "常設禮包"],
+	["DailyPack", "每日禮包"], ["FreePack", "免費禮包"],
+]
+
+const ZONE_TYPE_OPTIONS := [
+	["None", "未知"], ["Beginner", "新手區"], ["Forest", "森林區"],
+	["Town", "城鎮區"], ["Ruins", "遺跡區"], ["Castle", "城堡區"],
+]
+
 const ITEM_CATEGORY_OPTIONS := [
 	["None", "未知"],
 	["CurrencyLike", "貨幣型"],

--- a/scripts/configs/AdminCatalogScene.gd
+++ b/scripts/configs/AdminCatalogScene.gd
@@ -277,6 +277,20 @@ func _create_renderer(section_key: String) -> Control:
 			return AdminCatalogMemoriesRenderer.new()
 		"treasures":
 			return AdminCatalogTreasuresRenderer.new()
+		"dungeons":
+			return AdminCatalogDungeonsRenderer.new()
+		"achievements":
+			return AdminCatalogAchievementsRenderer.new()
+		"shop":
+			return AdminCatalogShopRenderer.new()
+		"stages":
+			return AdminCatalogStagesRenderer.new()
+		"scooper":
+			return AdminCatalogScooperRenderer.new()
+		"cats":
+			return AdminCatalogCatsRenderer.new()
+		"skills":
+			return AdminCatalogSkillsRenderer.new()
 		_:
 			return null
 

--- a/scripts/configs/AdminCatalogScooperRenderer.gd
+++ b/scripts/configs/AdminCatalogScooperRenderer.gd
@@ -1,0 +1,714 @@
+class_name AdminCatalogScooperRenderer
+extends Control
+
+signal changed
+
+# ── State ────────────────────────────────────────────────────────
+
+var _idle_ctrls: Dictionary = {}
+var _base_rate_controls: Array = []
+var _stage_bonus_controls: Array = []
+var _scooper_bonus_controls: Array = []
+var _equipment_controls: Array = []
+var _ability_controls: Array = []
+
+
+# ── Public API ───────────────────────────────────────────────────
+
+func setup(data: Dictionary) -> void:
+	for child: Node in get_children():
+		child.queue_free()
+	_idle_ctrls.clear()
+	_base_rate_controls.clear()
+	_stage_bonus_controls.clear()
+	_scooper_bonus_controls.clear()
+	_equipment_controls.clear()
+	_ability_controls.clear()
+
+	var idle_setting: Dictionary = data.get("idleSetting", {}) if data.get("idleSetting") is Dictionary else {}
+	var equipments: Array = data.get("equipments", []) if data.get("equipments") is Array else []
+	var abilities: Array = data.get("abilities", []) if data.get("abilities") is Array else []
+
+	var tabs := TabContainer.new()
+	tabs.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	tabs.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	add_child(tabs)
+
+	tabs.add_child(_build_idle_tab(idle_setting))
+	tabs.add_child(_build_equipment_tab(equipments))
+	tabs.add_child(_build_ability_tab(abilities))
+
+	tabs.set_tab_title(0, "閒置設定")
+	tabs.set_tab_title(1, "裝備 (%d)" % equipments.size())
+	tabs.set_tab_title(2, "特殊能力 (%d)" % abilities.size())
+
+
+func get_data() -> Dictionary:
+	return {
+		"idleSetting": _collect_idle_setting(),
+		"equipments": _collect_equipments(),
+		"abilities": _collect_abilities(),
+	}
+
+
+# ── Tab: 閒置設定 ─────────────────────────────────────────────────
+
+func _build_idle_tab(s: Dictionary) -> ScrollContainer:
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.name = "IdleSetting"
+
+	var margin := MarginContainer.new()
+	margin.add_theme_constant_override("margin_left", 16)
+	margin.add_theme_constant_override("margin_top", 16)
+	margin.add_theme_constant_override("margin_right", 16)
+	margin.add_theme_constant_override("margin_bottom", 16)
+	margin.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scroll.add_child(margin)
+
+	var vbox := VBoxContainer.new()
+	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.add_theme_constant_override("separation", 10)
+	margin.add_child(vbox)
+
+	vbox.add_child(AdminCatalogFormHelpers.make_section_label("閒置設定"))
+	vbox.add_child(AdminCatalogFormHelpers.make_separator())
+
+	var max_hours_spin := AdminCatalogFormHelpers.make_int_cell(int(s.get("maxIdleHours", 8)), 0, 999, 120.0)
+	var exp_chance_spin := AdminCatalogFormHelpers.make_float_cell(float(s.get("scoopExpChance", 0.0)), 0.001, 120.0)
+	var exp_amount_spin := AdminCatalogFormHelpers.make_int_cell(int(s.get("scoopExpAmount", 0)), 0, 99999, 120.0)
+	var mem_base_spin := AdminCatalogFormHelpers.make_float_cell(float(s.get("scoopMemoryShardBaseChance", 0.0)), 0.001, 120.0)
+	var wsk_base_spin := AdminCatalogFormHelpers.make_float_cell(float(s.get("scoopWhiskerBaseChance", 0.0)), 0.001, 120.0)
+	var wsk_per_spin := AdminCatalogFormHelpers.make_float_cell(float(s.get("scoopWhiskerChancePerScooperLevel", 0.0)), 0.001, 120.0)
+	var mem_per_spin := AdminCatalogFormHelpers.make_float_cell(float(s.get("scoopMemoryShardChancePerTwoScooperLevels", 0.0)), 0.001, 120.0)
+	var exp_per_lv_spin := AdminCatalogFormHelpers.make_int_cell(int(s.get("scooperExpPerLevel", 100)), 1, 999999, 120.0)
+	var enabled_cb := AdminCatalogFormHelpers.make_bool_cell(bool(s.get("isEnabled", true)), 0.0)
+
+	vbox.add_child(AdminCatalogFormHelpers.make_form_row("最大閒置時數", max_hours_spin))
+	vbox.add_child(AdminCatalogFormHelpers.make_form_row("鏟屎經驗機率", exp_chance_spin))
+	vbox.add_child(AdminCatalogFormHelpers.make_form_row("鏟屎經驗數量", exp_amount_spin))
+	vbox.add_child(AdminCatalogFormHelpers.make_form_row("記憶碎片基礎機率", mem_base_spin))
+	vbox.add_child(AdminCatalogFormHelpers.make_form_row("鬍鬚基礎機率", wsk_base_spin))
+	vbox.add_child(AdminCatalogFormHelpers.make_form_row("鬍鬚每級機率", wsk_per_spin))
+	vbox.add_child(AdminCatalogFormHelpers.make_form_row("記憶碎片每兩級機率", mem_per_spin))
+	vbox.add_child(AdminCatalogFormHelpers.make_form_row("每級所需經驗", exp_per_lv_spin))
+	vbox.add_child(AdminCatalogFormHelpers.make_form_row("啟用", enabled_cb))
+
+	_idle_ctrls = {
+		"id": s.get("id", 0),
+		"max_hours": max_hours_spin,
+		"exp_chance": exp_chance_spin,
+		"exp_amount": exp_amount_spin,
+		"mem_base": mem_base_spin,
+		"wsk_base": wsk_base_spin,
+		"wsk_per": wsk_per_spin,
+		"mem_per": mem_per_spin,
+		"exp_per_lv": exp_per_lv_spin,
+		"enabled": enabled_cb,
+	}
+
+	for node: Node in [max_hours_spin, exp_chance_spin, exp_amount_spin, mem_base_spin,
+			wsk_base_spin, wsk_per_spin, mem_per_spin, exp_per_lv_spin]:
+		_connect_change(node, "value_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(enabled_cb, "toggled", func(_v: Variant) -> void: changed.emit())
+
+	# Sub-tables
+	vbox.add_child(AdminCatalogFormHelpers.make_separator())
+	vbox.add_child(AdminCatalogFormHelpers.make_section_label("基礎掉落率"))
+	var base_rates: Array = s.get("baseRates", []) if s.get("baseRates") is Array else []
+	_build_base_rates_table(base_rates, vbox)
+
+	vbox.add_child(AdminCatalogFormHelpers.make_separator())
+	vbox.add_child(AdminCatalogFormHelpers.make_section_label("關卡加成"))
+	var stage_bonuses: Array = s.get("stageBonuses", []) if s.get("stageBonuses") is Array else []
+	_build_stage_bonuses_table(stage_bonuses, vbox)
+
+	vbox.add_child(AdminCatalogFormHelpers.make_separator())
+	vbox.add_child(AdminCatalogFormHelpers.make_section_label("Scooper 加成"))
+	var scooper_bonuses: Array = s.get("scooperBonuses", []) if s.get("scooperBonuses") is Array else []
+	_build_scooper_bonuses_table(scooper_bonuses, vbox)
+
+	return scroll
+
+
+func _build_base_rates_table(entries: Array, parent: VBoxContainer) -> void:
+	# Header
+	var header := AdminCatalogFormHelpers.make_header_row_panel()
+	parent.add_child(header)
+	var hm := _make_row_margin()
+	header.add_child(hm)
+	var hb := AdminCatalogFormHelpers.make_row_hbox()
+	hm.add_child(hb)
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("Id", 48.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("獎勵類型"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("每小時掉落率", 130.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("排序", 70.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("啟用", 60.0, false))
+
+	for i: int in range(entries.size()):
+		var entry: Dictionary = entries[i] if entries[i] is Dictionary else {}
+		var row_panel := AdminCatalogFormHelpers.make_data_row_panel(i % 2 == 0)
+		parent.add_child(row_panel)
+		var rm := _make_row_margin()
+		row_panel.add_child(rm)
+		var rb := AdminCatalogFormHelpers.make_row_hbox()
+		rm.add_child(rb)
+
+		var reward_ob := AdminCatalogFormHelpers.make_enum_cell(AdminCatalogFormHelpers.REWARD_TYPE_OPTIONS, str(entry.get("rewardType", "None")))
+		var rate_spin := AdminCatalogFormHelpers.make_float_cell(float(entry.get("ratePerHour", 0.0)), 0.001, 130.0)
+		var sort_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("sortOrder", 1)), 0, 9999, 70.0)
+		var en_cb := AdminCatalogFormHelpers.make_bool_cell(bool(entry.get("isEnabled", true)), 60.0)
+
+		rb.add_child(AdminCatalogFormHelpers.make_id_cell(entry.get("id", 0)))
+		rb.add_child(reward_ob)
+		rb.add_child(rate_spin)
+		rb.add_child(sort_spin)
+		rb.add_child(en_cb)
+
+		_connect_change(reward_ob, "item_selected", func(_v: Variant) -> void: changed.emit())
+		_connect_change(rate_spin, "value_changed", func(_v: Variant) -> void: changed.emit())
+		_connect_change(sort_spin, "value_changed", func(_v: Variant) -> void: changed.emit())
+		_connect_change(en_cb, "toggled", func(_v: Variant) -> void: changed.emit())
+
+		_base_rate_controls.append({
+			"id": entry.get("id", 0),
+			"reward_ob": reward_ob, "rate_spin": rate_spin,
+			"sort_spin": sort_spin, "enabled_cb": en_cb,
+		})
+
+
+func _build_stage_bonuses_table(entries: Array, parent: VBoxContainer) -> void:
+	var header := AdminCatalogFormHelpers.make_header_row_panel()
+	parent.add_child(header)
+	var hm := _make_row_margin()
+	header.add_child(hm)
+	var hb := AdminCatalogFormHelpers.make_row_hbox()
+	hm.add_child(hb)
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("Id", 48.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("獎勵類型"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("關卡間隔", 90.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("每間隔加成值", 110.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("數值模式", 110.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("啟用", 60.0, false))
+
+	for i: int in range(entries.size()):
+		var entry: Dictionary = entries[i] if entries[i] is Dictionary else {}
+		var row_panel := AdminCatalogFormHelpers.make_data_row_panel(i % 2 == 0)
+		parent.add_child(row_panel)
+		var rm := _make_row_margin()
+		row_panel.add_child(rm)
+		var rb := AdminCatalogFormHelpers.make_row_hbox()
+		rm.add_child(rb)
+
+		var reward_ob := AdminCatalogFormHelpers.make_enum_cell(AdminCatalogFormHelpers.REWARD_TYPE_OPTIONS, str(entry.get("rewardType", "None")))
+		var interval_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("stageInterval", 10)), 1, 99999, 90.0)
+		var bonus_spin := AdminCatalogFormHelpers.make_float_cell(float(entry.get("bonusValuePerInterval", 0.0)), 0.001, 110.0)
+		var vtype_ob := AdminCatalogFormHelpers.make_enum_cell(AdminCatalogFormHelpers.VALUE_MODE_OPTIONS, str(entry.get("valueType", "Flat")))
+		var en_cb := AdminCatalogFormHelpers.make_bool_cell(bool(entry.get("isEnabled", true)), 60.0)
+
+		rb.add_child(AdminCatalogFormHelpers.make_id_cell(entry.get("id", 0)))
+		rb.add_child(reward_ob)
+		rb.add_child(interval_spin)
+		rb.add_child(bonus_spin)
+		rb.add_child(vtype_ob)
+		rb.add_child(en_cb)
+
+		_connect_change(reward_ob, "item_selected", func(_v: Variant) -> void: changed.emit())
+		_connect_change(interval_spin, "value_changed", func(_v: Variant) -> void: changed.emit())
+		_connect_change(bonus_spin, "value_changed", func(_v: Variant) -> void: changed.emit())
+		_connect_change(vtype_ob, "item_selected", func(_v: Variant) -> void: changed.emit())
+		_connect_change(en_cb, "toggled", func(_v: Variant) -> void: changed.emit())
+
+		_stage_bonus_controls.append({
+			"id": entry.get("id", 0),
+			"reward_ob": reward_ob, "interval_spin": interval_spin,
+			"bonus_spin": bonus_spin, "vtype_ob": vtype_ob, "enabled_cb": en_cb,
+		})
+
+
+func _build_scooper_bonuses_table(entries: Array, parent: VBoxContainer) -> void:
+	var header := AdminCatalogFormHelpers.make_header_row_panel()
+	parent.add_child(header)
+	var hm := _make_row_margin()
+	header.add_child(hm)
+	var hb := AdminCatalogFormHelpers.make_row_hbox()
+	hm.add_child(hb)
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("Id", 48.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("獎勵類型"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("每級加成值", 110.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("數值模式", 110.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("啟用", 60.0, false))
+
+	for i: int in range(entries.size()):
+		var entry: Dictionary = entries[i] if entries[i] is Dictionary else {}
+		var row_panel := AdminCatalogFormHelpers.make_data_row_panel(i % 2 == 0)
+		parent.add_child(row_panel)
+		var rm := _make_row_margin()
+		row_panel.add_child(rm)
+		var rb := AdminCatalogFormHelpers.make_row_hbox()
+		rm.add_child(rb)
+
+		var reward_ob := AdminCatalogFormHelpers.make_enum_cell(AdminCatalogFormHelpers.REWARD_TYPE_OPTIONS, str(entry.get("rewardType", "None")))
+		var per_lv_spin := AdminCatalogFormHelpers.make_float_cell(float(entry.get("perLevelBonusValue", 0.0)), 0.001, 110.0)
+		var vtype_ob := AdminCatalogFormHelpers.make_enum_cell(AdminCatalogFormHelpers.VALUE_MODE_OPTIONS, str(entry.get("valueType", "Flat")))
+		var en_cb := AdminCatalogFormHelpers.make_bool_cell(bool(entry.get("isEnabled", true)), 60.0)
+
+		rb.add_child(AdminCatalogFormHelpers.make_id_cell(entry.get("id", 0)))
+		rb.add_child(reward_ob)
+		rb.add_child(per_lv_spin)
+		rb.add_child(vtype_ob)
+		rb.add_child(en_cb)
+
+		_connect_change(reward_ob, "item_selected", func(_v: Variant) -> void: changed.emit())
+		_connect_change(per_lv_spin, "value_changed", func(_v: Variant) -> void: changed.emit())
+		_connect_change(vtype_ob, "item_selected", func(_v: Variant) -> void: changed.emit())
+		_connect_change(en_cb, "toggled", func(_v: Variant) -> void: changed.emit())
+
+		_scooper_bonus_controls.append({
+			"id": entry.get("id", 0),
+			"reward_ob": reward_ob, "per_lv_spin": per_lv_spin,
+			"vtype_ob": vtype_ob, "enabled_cb": en_cb,
+		})
+
+
+func _collect_idle_setting() -> Dictionary:
+	return {
+		"id": _idle_ctrls.get("id", 0),
+		"maxIdleHours": int((_idle_ctrls["max_hours"] as SpinBox).value),
+		"scoopExpChance": (_idle_ctrls["exp_chance"] as SpinBox).value,
+		"scoopExpAmount": int((_idle_ctrls["exp_amount"] as SpinBox).value),
+		"scoopMemoryShardBaseChance": (_idle_ctrls["mem_base"] as SpinBox).value,
+		"scoopWhiskerBaseChance": (_idle_ctrls["wsk_base"] as SpinBox).value,
+		"scoopWhiskerChancePerScooperLevel": (_idle_ctrls["wsk_per"] as SpinBox).value,
+		"scoopMemoryShardChancePerTwoScooperLevels": (_idle_ctrls["mem_per"] as SpinBox).value,
+		"scooperExpPerLevel": int((_idle_ctrls["exp_per_lv"] as SpinBox).value),
+		"isEnabled": (_idle_ctrls["enabled"] as CheckBox).button_pressed,
+		"baseRates": _collect_base_rates(),
+		"stageBonuses": _collect_stage_bonuses(),
+		"scooperBonuses": _collect_scooper_bonuses(),
+	}
+
+
+func _collect_base_rates() -> Array:
+	var result: Array = []
+	for ctrl: Dictionary in _base_rate_controls:
+		result.append({
+			"id": ctrl["id"],
+			"rewardType": AdminCatalogFormHelpers.get_enum_value(ctrl["reward_ob"] as OptionButton),
+			"ratePerHour": (ctrl["rate_spin"] as SpinBox).value,
+			"sortOrder": int((ctrl["sort_spin"] as SpinBox).value),
+			"isEnabled": (ctrl["enabled_cb"] as CheckBox).button_pressed,
+		})
+	return result
+
+
+func _collect_stage_bonuses() -> Array:
+	var result: Array = []
+	for ctrl: Dictionary in _stage_bonus_controls:
+		result.append({
+			"id": ctrl["id"],
+			"rewardType": AdminCatalogFormHelpers.get_enum_value(ctrl["reward_ob"] as OptionButton),
+			"stageInterval": int((ctrl["interval_spin"] as SpinBox).value),
+			"bonusValuePerInterval": (ctrl["bonus_spin"] as SpinBox).value,
+			"valueType": AdminCatalogFormHelpers.get_enum_value(ctrl["vtype_ob"] as OptionButton),
+			"isEnabled": (ctrl["enabled_cb"] as CheckBox).button_pressed,
+		})
+	return result
+
+
+func _collect_scooper_bonuses() -> Array:
+	var result: Array = []
+	for ctrl: Dictionary in _scooper_bonus_controls:
+		result.append({
+			"id": ctrl["id"],
+			"rewardType": AdminCatalogFormHelpers.get_enum_value(ctrl["reward_ob"] as OptionButton),
+			"perLevelBonusValue": (ctrl["per_lv_spin"] as SpinBox).value,
+			"valueType": AdminCatalogFormHelpers.get_enum_value(ctrl["vtype_ob"] as OptionButton),
+			"isEnabled": (ctrl["enabled_cb"] as CheckBox).button_pressed,
+		})
+	return result
+
+
+# ── Tab: 裝備 ─────────────────────────────────────────────────────
+
+func _build_equipment_tab(entries: Array) -> ScrollContainer:
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.name = "Equipments"
+
+	var vbox := VBoxContainer.new()
+	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.add_theme_constant_override("separation", 4)
+	scroll.add_child(vbox)
+
+	for i: int in range(entries.size()):
+		var entry: Dictionary = entries[i] if entries[i] is Dictionary else {}
+		var ctrls := _build_equipment_block(entry, vbox, i % 2 == 0)
+		_equipment_controls.append(ctrls)
+
+	return scroll
+
+
+func _build_equipment_block(entry: Dictionary, parent: VBoxContainer, is_odd: bool) -> Dictionary:
+	var block_panel := AdminCatalogFormHelpers.make_data_row_panel(is_odd)
+	block_panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	parent.add_child(block_panel)
+
+	var block_margin := _make_row_margin()
+	block_panel.add_child(block_margin)
+
+	var block_vbox := VBoxContainer.new()
+	block_vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	block_vbox.add_theme_constant_override("separation", 4)
+	block_margin.add_child(block_vbox)
+
+	# Main row
+	var main_hb := AdminCatalogFormHelpers.make_row_hbox()
+	block_vbox.add_child(main_hb)
+
+	var name_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("displayName", "")))
+	var unlock_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("unlockLevel", 1)), 1, 9999, 80.0)
+	var purchase_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("basePurchaseCost", 0)), 0, 9999999, 90.0)
+	var break_spin := AdminCatalogFormHelpers.make_float_cell(float(entry.get("breakChance", 0.0)), 0.001, 90.0)
+	var sick_spin := AdminCatalogFormHelpers.make_float_cell(float(entry.get("sickChance", 0.0)), 0.001, 90.0)
+	var repair_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("baseRepairCost", 0)), 0, 9999999, 90.0)
+	var treat_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("baseTreatCost", 0)), 0, 9999999, 90.0)
+	var en_cb := AdminCatalogFormHelpers.make_bool_cell(bool(entry.get("isEnabled", true)), 60.0)
+
+	main_hb.add_child(AdminCatalogFormHelpers.make_id_cell(entry.get("id", 0)))
+	main_hb.add_child(name_edit)
+	main_hb.add_child(_add_labeled("解鎖等級", unlock_spin))
+	main_hb.add_child(_add_labeled("購買費用", purchase_spin))
+	main_hb.add_child(_add_labeled("損壞機率", break_spin))
+	main_hb.add_child(_add_labeled("生病機率", sick_spin))
+	main_hb.add_child(_add_labeled("修復費用", repair_spin))
+	main_hb.add_child(_add_labeled("治療費用", treat_spin))
+	main_hb.add_child(en_cb)
+
+	for node: Node in [unlock_spin, purchase_spin, break_spin, sick_spin, repair_spin, treat_spin]:
+		_connect_change(node, "value_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(name_edit, "text_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(en_cb, "toggled", func(_v: Variant) -> void: changed.emit())
+
+	# Effects sub-table
+	var effects: Array = entry.get("effects", []) if entry.get("effects") is Array else []
+	var effect_controls := _build_equipment_effects_subtable(effects, block_vbox)
+
+	# ExpRolls sub-table
+	var exp_rolls: Array = entry.get("expRolls", []) if entry.get("expRolls") is Array else []
+	var exp_roll_controls := _build_exp_rolls_subtable(exp_rolls, block_vbox)
+
+	return {
+		"id": entry.get("id", 0),
+		"name_edit": name_edit,
+		"unlock_spin": unlock_spin,
+		"purchase_spin": purchase_spin,
+		"break_spin": break_spin,
+		"sick_spin": sick_spin,
+		"repair_spin": repair_spin,
+		"treat_spin": treat_spin,
+		"enabled_cb": en_cb,
+		"effect_controls": effect_controls,
+		"exp_roll_controls": exp_roll_controls,
+	}
+
+
+func _build_equipment_effects_subtable(effects: Array, parent: VBoxContainer) -> Array:
+	var sub_margin := MarginContainer.new()
+	sub_margin.add_theme_constant_override("margin_left", 20)
+	parent.add_child(sub_margin)
+
+	var sub_vbox := VBoxContainer.new()
+	sub_vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	sub_vbox.add_theme_constant_override("separation", 2)
+	sub_margin.add_child(sub_vbox)
+
+	var header := AdminCatalogFormHelpers.make_header_row_panel()
+	sub_vbox.add_child(header)
+	var hm := _make_small_margin()
+	header.add_child(hm)
+	var hb := AdminCatalogFormHelpers.make_row_hbox()
+	hm.add_child(hb)
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("順序", 60.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("目標範圍"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("效果類型"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("能力類型"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("數值模式"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("基礎值", 90.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("啟用", 60.0, false))
+
+	var result: Array = []
+	for i: int in range(effects.size()):
+		var eff: Dictionary = effects[i] if effects[i] is Dictionary else {}
+		var row := AdminCatalogFormHelpers.make_data_row_panel(i % 2 == 0)
+		sub_vbox.add_child(row)
+		var rm := _make_small_margin()
+		row.add_child(rm)
+		var rb := AdminCatalogFormHelpers.make_row_hbox()
+		rm.add_child(rb)
+
+		var order_spin := AdminCatalogFormHelpers.make_int_cell(int(eff.get("effectOrder", 1)), 1, 99, 60.0)
+		var scope_ob := AdminCatalogFormHelpers.make_enum_cell(AdminCatalogFormHelpers.TARGET_SCOPE_OPTIONS, str(eff.get("targetScopeType", "Self")))
+		var etype_ob := AdminCatalogFormHelpers.make_enum_cell(AdminCatalogFormHelpers.SKILL_EFFECT_TYPE_OPTIONS, str(eff.get("effectType", "StatBoost")))
+		var stat_ob := AdminCatalogFormHelpers.make_enum_cell(AdminCatalogFormHelpers.STAT_TYPE_OPTIONS, str(eff.get("statType", "None")))
+		var vtype_ob := AdminCatalogFormHelpers.make_enum_cell(AdminCatalogFormHelpers.VALUE_MODE_OPTIONS, str(eff.get("valueType", "Flat")))
+		var base_spin := AdminCatalogFormHelpers.make_float_cell(float(eff.get("baseValue", 0.0)), 0.001, 90.0)
+		var en_cb := AdminCatalogFormHelpers.make_bool_cell(bool(eff.get("isEnabled", true)), 60.0)
+
+		rb.add_child(order_spin)
+		rb.add_child(scope_ob)
+		rb.add_child(etype_ob)
+		rb.add_child(stat_ob)
+		rb.add_child(vtype_ob)
+		rb.add_child(base_spin)
+		rb.add_child(en_cb)
+
+		for node: Node in [order_spin, base_spin]:
+			_connect_change(node, "value_changed", func(_v: Variant) -> void: changed.emit())
+		for ob: Node in [scope_ob, etype_ob, stat_ob, vtype_ob]:
+			_connect_change(ob, "item_selected", func(_v: Variant) -> void: changed.emit())
+		_connect_change(en_cb, "toggled", func(_v: Variant) -> void: changed.emit())
+
+		result.append({
+			"id": eff.get("id", 0),
+			"order_spin": order_spin, "scope_ob": scope_ob,
+			"etype_ob": etype_ob, "stat_ob": stat_ob,
+			"vtype_ob": vtype_ob, "base_spin": base_spin, "enabled_cb": en_cb,
+		})
+	return result
+
+
+func _build_exp_rolls_subtable(rolls: Array, parent: VBoxContainer) -> Array:
+	var sub_margin := MarginContainer.new()
+	sub_margin.add_theme_constant_override("margin_left", 20)
+	parent.add_child(sub_margin)
+
+	var sub_vbox := VBoxContainer.new()
+	sub_vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	sub_vbox.add_theme_constant_override("separation", 2)
+	sub_margin.add_child(sub_vbox)
+
+	var header := AdminCatalogFormHelpers.make_header_row_panel()
+	sub_vbox.add_child(header)
+	var hm := _make_small_margin()
+	header.add_child(hm)
+	var hb := AdminCatalogFormHelpers.make_row_hbox()
+	hm.add_child(hb)
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("順序", 60.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("最小經驗", 90.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("最大經驗", 90.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("權重", 90.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("啟用", 60.0, false))
+
+	var result: Array = []
+	for i: int in range(rolls.size()):
+		var roll: Dictionary = rolls[i] if rolls[i] is Dictionary else {}
+		var row := AdminCatalogFormHelpers.make_data_row_panel(i % 2 == 0)
+		sub_vbox.add_child(row)
+		var rm := _make_small_margin()
+		row.add_child(rm)
+		var rb := AdminCatalogFormHelpers.make_row_hbox()
+		rm.add_child(rb)
+
+		var order_spin := AdminCatalogFormHelpers.make_int_cell(int(roll.get("rollOrder", 1)), 1, 99, 60.0)
+		var min_spin := AdminCatalogFormHelpers.make_int_cell(int(roll.get("expMin", 0)), 0, 999999, 90.0)
+		var max_spin := AdminCatalogFormHelpers.make_int_cell(int(roll.get("expMax", 0)), 0, 999999, 90.0)
+		var weight_spin := AdminCatalogFormHelpers.make_float_cell(float(roll.get("weight", 1.0)), 0.001, 90.0)
+		var en_cb := AdminCatalogFormHelpers.make_bool_cell(bool(roll.get("isEnabled", true)), 60.0)
+
+		rb.add_child(order_spin)
+		rb.add_child(min_spin)
+		rb.add_child(max_spin)
+		rb.add_child(weight_spin)
+		rb.add_child(en_cb)
+
+		for node: Node in [order_spin, min_spin, max_spin, weight_spin]:
+			_connect_change(node, "value_changed", func(_v: Variant) -> void: changed.emit())
+		_connect_change(en_cb, "toggled", func(_v: Variant) -> void: changed.emit())
+
+		result.append({
+			"id": roll.get("id", 0),
+			"order_spin": order_spin, "min_spin": min_spin,
+			"max_spin": max_spin, "weight_spin": weight_spin, "enabled_cb": en_cb,
+		})
+	return result
+
+
+func _collect_equipments() -> Array:
+	var result: Array = []
+	for ctrl: Dictionary in _equipment_controls:
+		var effects_arr: Array = []
+		for ec: Dictionary in (ctrl["effect_controls"] as Array):
+			effects_arr.append({
+				"id": ec["id"],
+				"effectOrder": int((ec["order_spin"] as SpinBox).value),
+				"targetScopeType": AdminCatalogFormHelpers.get_enum_value(ec["scope_ob"] as OptionButton),
+				"effectType": AdminCatalogFormHelpers.get_enum_value(ec["etype_ob"] as OptionButton),
+				"statType": AdminCatalogFormHelpers.get_enum_value(ec["stat_ob"] as OptionButton),
+				"valueType": AdminCatalogFormHelpers.get_enum_value(ec["vtype_ob"] as OptionButton),
+				"baseValue": (ec["base_spin"] as SpinBox).value,
+				"isEnabled": (ec["enabled_cb"] as CheckBox).button_pressed,
+			})
+		var rolls_arr: Array = []
+		for rc: Dictionary in (ctrl["exp_roll_controls"] as Array):
+			rolls_arr.append({
+				"id": rc["id"],
+				"rollOrder": int((rc["order_spin"] as SpinBox).value),
+				"expMin": int((rc["min_spin"] as SpinBox).value),
+				"expMax": int((rc["max_spin"] as SpinBox).value),
+				"weight": (rc["weight_spin"] as SpinBox).value,
+				"isEnabled": (rc["enabled_cb"] as CheckBox).button_pressed,
+			})
+		result.append({
+			"id": ctrl["id"],
+			"displayName": (ctrl["name_edit"] as LineEdit).text,
+			"unlockLevel": int((ctrl["unlock_spin"] as SpinBox).value),
+			"basePurchaseCost": int((ctrl["purchase_spin"] as SpinBox).value),
+			"breakChance": (ctrl["break_spin"] as SpinBox).value,
+			"sickChance": (ctrl["sick_spin"] as SpinBox).value,
+			"baseRepairCost": int((ctrl["repair_spin"] as SpinBox).value),
+			"baseTreatCost": int((ctrl["treat_spin"] as SpinBox).value),
+			"isEnabled": (ctrl["enabled_cb"] as CheckBox).button_pressed,
+			"effects": effects_arr,
+			"expRolls": rolls_arr,
+		})
+	return result
+
+
+# ── Tab: 特殊能力 ─────────────────────────────────────────────────
+
+func _build_ability_tab(entries: Array) -> ScrollContainer:
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.name = "Abilities"
+
+	var vbox := VBoxContainer.new()
+	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.add_theme_constant_override("separation", 2)
+	scroll.add_child(vbox)
+
+	# Header
+	var header := AdminCatalogFormHelpers.make_header_row_panel()
+	vbox.add_child(header)
+	var hm := _make_row_margin()
+	header.add_child(hm)
+	var hb := AdminCatalogFormHelpers.make_row_hbox()
+	hm.add_child(hb)
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("Id", 48.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("顯示名稱", 120.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("描述"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("效果類型", 140.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("效果值", 90.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("分類", 70.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("排序", 70.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("補償鑽石", 90.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("來源說明", 110.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("啟用", 60.0, false))
+
+	for i: int in range(entries.size()):
+		var entry: Dictionary = entries[i] if entries[i] is Dictionary else {}
+		var row_panel := AdminCatalogFormHelpers.make_data_row_panel(i % 2 == 0)
+		vbox.add_child(row_panel)
+		_ability_controls.append(_build_ability_row(entry, row_panel))
+
+	return scroll
+
+
+func _build_ability_row(entry: Dictionary, panel: PanelContainer) -> Dictionary:
+	var rm := _make_row_margin()
+	panel.add_child(rm)
+	var rb := AdminCatalogFormHelpers.make_row_hbox()
+	rm.add_child(rb)
+
+	var name_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("displayName", "")), 120.0)
+	var desc_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("description", "")))
+	var etype_ob := AdminCatalogFormHelpers.make_enum_cell(AdminCatalogFormHelpers.SPECIAL_ABILITY_EFFECT_OPTIONS, str(entry.get("effectType", "None")))
+	etype_ob.custom_minimum_size.x = 140.0
+	etype_ob.size_flags_horizontal = Control.SIZE_SHRINK_BEGIN
+	var effect_spin := AdminCatalogFormHelpers.make_float_cell(float(entry.get("effectValue", 0.0)), 0.001, 90.0)
+	var category_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("categoryType", 1)), 0, 99, 70.0)
+	var sort_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("sortOrder", 1)), 0, 9999, 70.0)
+	var comp_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("duplicateCompensationDiamonds", 0)), 0, 99999, 90.0)
+	var source_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("sourceText", "")), 110.0)
+	var en_cb := AdminCatalogFormHelpers.make_bool_cell(bool(entry.get("isEnabled", true)), 60.0)
+
+	rb.add_child(AdminCatalogFormHelpers.make_id_cell(entry.get("id", 0)))
+	rb.add_child(name_edit)
+	rb.add_child(desc_edit)
+	rb.add_child(etype_ob)
+	rb.add_child(effect_spin)
+	rb.add_child(category_spin)
+	rb.add_child(sort_spin)
+	rb.add_child(comp_spin)
+	rb.add_child(source_edit)
+	rb.add_child(en_cb)
+
+	for node: Node in [effect_spin, category_spin, sort_spin, comp_spin]:
+		_connect_change(node, "value_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(etype_ob, "item_selected", func(_v: Variant) -> void: changed.emit())
+	for edit: Node in [name_edit, desc_edit, source_edit]:
+		_connect_change(edit, "text_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(en_cb, "toggled", func(_v: Variant) -> void: changed.emit())
+
+	return {
+		"id": entry.get("id", 0),
+		"name_edit": name_edit, "desc_edit": desc_edit,
+		"etype_ob": etype_ob, "effect_spin": effect_spin,
+		"category_spin": category_spin, "sort_spin": sort_spin,
+		"comp_spin": comp_spin, "source_edit": source_edit, "enabled_cb": en_cb,
+	}
+
+
+func _collect_abilities() -> Array:
+	var result: Array = []
+	for ctrl: Dictionary in _ability_controls:
+		result.append({
+			"id": ctrl["id"],
+			"displayName": (ctrl["name_edit"] as LineEdit).text,
+			"description": (ctrl["desc_edit"] as LineEdit).text,
+			"effectType": AdminCatalogFormHelpers.get_enum_value(ctrl["etype_ob"] as OptionButton),
+			"effectValue": (ctrl["effect_spin"] as SpinBox).value,
+			"categoryType": int((ctrl["category_spin"] as SpinBox).value),
+			"sortOrder": int((ctrl["sort_spin"] as SpinBox).value),
+			"duplicateCompensationDiamonds": int((ctrl["comp_spin"] as SpinBox).value),
+			"sourceText": (ctrl["source_edit"] as LineEdit).text,
+			"isEnabled": (ctrl["enabled_cb"] as CheckBox).button_pressed,
+		})
+	return result
+
+
+# ── Layout Helpers ────────────────────────────────────────────────
+
+static func _add_labeled(label_text: String, control: Control) -> HBoxContainer:
+	var hb := HBoxContainer.new()
+	hb.add_theme_constant_override("separation", 4)
+	var lbl := Label.new()
+	lbl.text = label_text
+	lbl.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+	lbl.add_theme_color_override("font_color", AdminCatalogFormHelpers.MUTED_COLOR)
+	lbl.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	hb.add_child(lbl)
+	hb.add_child(control)
+	return hb
+
+
+static func _make_row_margin() -> MarginContainer:
+	var m := MarginContainer.new()
+	m.add_theme_constant_override("margin_left", 6)
+	m.add_theme_constant_override("margin_right", 6)
+	m.add_theme_constant_override("margin_top", 3)
+	m.add_theme_constant_override("margin_bottom", 3)
+	return m
+
+
+static func _make_small_margin() -> MarginContainer:
+	var m := MarginContainer.new()
+	m.add_theme_constant_override("margin_left", 4)
+	m.add_theme_constant_override("margin_right", 4)
+	m.add_theme_constant_override("margin_top", 2)
+	m.add_theme_constant_override("margin_bottom", 2)
+	return m
+
+
+static func _connect_change(node: Node, signal_name: String, callable: Callable) -> void:
+	node.connect(signal_name, callable)

--- a/scripts/configs/AdminCatalogShopRenderer.gd
+++ b/scripts/configs/AdminCatalogShopRenderer.gd
@@ -1,0 +1,468 @@
+class_name AdminCatalogShopRenderer
+extends Control
+
+signal changed
+
+var _category_controls: Array = []
+var _group_controls: Array = []
+var _bundle_controls: Array = []
+
+
+func setup(data: Dictionary) -> void:
+	for child: Node in get_children():
+		child.queue_free()
+	_category_controls.clear()
+	_group_controls.clear()
+	_bundle_controls.clear()
+
+	var tabs := TabContainer.new()
+	tabs.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	tabs.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	add_child(tabs)
+
+	var categories: Array = data.get("categories", []) if data.get("categories") is Array else []
+	var groups: Array = data.get("groups", []) if data.get("groups") is Array else []
+	var bundles: Array = data.get("bundles", []) if data.get("bundles") is Array else []
+
+	tabs.add_child(_build_categories_tab(categories))
+	tabs.add_child(_build_groups_tab(groups))
+	tabs.add_child(_build_bundles_tab(bundles))
+
+	tabs.set_tab_title(0, "商品分類")
+	tabs.set_tab_title(1, "商品群組")
+	tabs.set_tab_title(2, "商品包 (%d)" % bundles.size())
+
+
+func get_data() -> Dictionary:
+	return {
+		"categories": _collect_categories(),
+		"groups": _collect_groups(),
+		"bundles": _collect_bundles(),
+	}
+
+
+# ── Categories Tab ────────────────────────────────────────────
+
+func _build_categories_tab(entries: Array) -> ScrollContainer:
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.name = "Categories"
+
+	var vbox := VBoxContainer.new()
+	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.add_theme_constant_override("separation", 2)
+	scroll.add_child(vbox)
+
+	vbox.add_child(_make_category_header())
+	vbox.add_child(AdminCatalogFormHelpers.make_separator())
+
+	for i: int in range(entries.size()):
+		var entry: Dictionary = entries[i] if entries[i] is Dictionary else {}
+		var row_panel := AdminCatalogFormHelpers.make_data_row_panel(i % 2 == 0)
+		_category_controls.append(_build_category_row(entry, row_panel))
+		vbox.add_child(row_panel)
+
+	return scroll
+
+
+func _make_category_header() -> PanelContainer:
+	var panel := AdminCatalogFormHelpers.make_header_row_panel()
+	var margin := _make_row_margin()
+	panel.add_child(margin)
+	var hb := AdminCatalogFormHelpers.make_row_hbox()
+	margin.add_child(hb)
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("Id", 50.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("CategoryType"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("DisplayName"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("SortOrder", 90.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("IsEnabled", 70.0, false))
+	return panel
+
+
+func _build_category_row(entry: Dictionary, panel: PanelContainer) -> Dictionary:
+	var margin := _make_row_margin()
+	panel.add_child(margin)
+	var hb := AdminCatalogFormHelpers.make_row_hbox()
+	margin.add_child(hb)
+
+	var cat_ob := AdminCatalogFormHelpers.make_enum_cell(
+		AdminCatalogFormHelpers.SHOP_CATEGORY_OPTIONS,
+		str(entry.get("categoryType", "None"))
+	)
+	var name_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("displayName", "")))
+	var sort_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("sortOrder", 0)), 0, 9999, 90.0)
+	var enabled_cb := AdminCatalogFormHelpers.make_bool_cell(bool(entry.get("isEnabled", true)))
+
+	hb.add_child(AdminCatalogFormHelpers.make_id_cell(entry.get("id", 0)))
+	hb.add_child(cat_ob)
+	hb.add_child(name_edit)
+	hb.add_child(sort_spin)
+	hb.add_child(enabled_cb)
+
+	_connect_change(cat_ob, "item_selected", func(_v: Variant) -> void: changed.emit())
+	_connect_change(name_edit, "text_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(sort_spin, "value_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(enabled_cb, "toggled", func(_v: Variant) -> void: changed.emit())
+
+	return {
+		"id": entry.get("id", 0),
+		"cat_ob": cat_ob,
+		"name_edit": name_edit,
+		"sort_spin": sort_spin,
+		"enabled_cb": enabled_cb,
+	}
+
+
+func _collect_categories() -> Array:
+	var result: Array = []
+	for ctrl: Dictionary in _category_controls:
+		result.append({
+			"id": ctrl["id"],
+			"categoryType": AdminCatalogFormHelpers.get_enum_value(ctrl["cat_ob"] as OptionButton),
+			"displayName": (ctrl["name_edit"] as LineEdit).text,
+			"sortOrder": int((ctrl["sort_spin"] as SpinBox).value),
+			"isEnabled": (ctrl["enabled_cb"] as CheckBox).button_pressed,
+		})
+	return result
+
+
+# ── Groups Tab ────────────────────────────────────────────────
+
+func _build_groups_tab(entries: Array) -> ScrollContainer:
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.name = "Groups"
+
+	var vbox := VBoxContainer.new()
+	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.add_theme_constant_override("separation", 2)
+	scroll.add_child(vbox)
+
+	vbox.add_child(_make_group_header())
+	vbox.add_child(AdminCatalogFormHelpers.make_separator())
+
+	for i: int in range(entries.size()):
+		var entry: Dictionary = entries[i] if entries[i] is Dictionary else {}
+		var row_panel := AdminCatalogFormHelpers.make_data_row_panel(i % 2 == 0)
+		_group_controls.append(_build_group_row(entry, row_panel))
+		vbox.add_child(row_panel)
+
+	return scroll
+
+
+func _make_group_header() -> PanelContainer:
+	var panel := AdminCatalogFormHelpers.make_header_row_panel()
+	var margin := _make_row_margin()
+	panel.add_child(margin)
+	var hb := AdminCatalogFormHelpers.make_row_hbox()
+	margin.add_child(hb)
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("Id", 50.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("CategoryType"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("GroupType"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("DisplayName"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("SortOrder", 90.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("IsEnabled", 70.0, false))
+	return panel
+
+
+func _build_group_row(entry: Dictionary, panel: PanelContainer) -> Dictionary:
+	var margin := _make_row_margin()
+	panel.add_child(margin)
+	var hb := AdminCatalogFormHelpers.make_row_hbox()
+	margin.add_child(hb)
+
+	var cat_ob := AdminCatalogFormHelpers.make_enum_cell(
+		AdminCatalogFormHelpers.SHOP_CATEGORY_OPTIONS,
+		str(entry.get("categoryType", "None"))
+	)
+	var group_ob := AdminCatalogFormHelpers.make_enum_cell(
+		AdminCatalogFormHelpers.SHOP_GROUP_OPTIONS,
+		str(entry.get("groupType", "None"))
+	)
+	var name_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("displayName", "")))
+	var sort_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("sortOrder", 0)), 0, 9999, 90.0)
+	var enabled_cb := AdminCatalogFormHelpers.make_bool_cell(bool(entry.get("isEnabled", true)))
+
+	hb.add_child(AdminCatalogFormHelpers.make_id_cell(entry.get("id", 0)))
+	hb.add_child(cat_ob)
+	hb.add_child(group_ob)
+	hb.add_child(name_edit)
+	hb.add_child(sort_spin)
+	hb.add_child(enabled_cb)
+
+	_connect_change(cat_ob, "item_selected", func(_v: Variant) -> void: changed.emit())
+	_connect_change(group_ob, "item_selected", func(_v: Variant) -> void: changed.emit())
+	_connect_change(name_edit, "text_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(sort_spin, "value_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(enabled_cb, "toggled", func(_v: Variant) -> void: changed.emit())
+
+	return {
+		"id": entry.get("id", 0),
+		"cat_ob": cat_ob,
+		"group_ob": group_ob,
+		"name_edit": name_edit,
+		"sort_spin": sort_spin,
+		"enabled_cb": enabled_cb,
+	}
+
+
+func _collect_groups() -> Array:
+	var result: Array = []
+	for ctrl: Dictionary in _group_controls:
+		result.append({
+			"id": ctrl["id"],
+			"categoryType": AdminCatalogFormHelpers.get_enum_value(ctrl["cat_ob"] as OptionButton),
+			"groupType": AdminCatalogFormHelpers.get_enum_value(ctrl["group_ob"] as OptionButton),
+			"displayName": (ctrl["name_edit"] as LineEdit).text,
+			"sortOrder": int((ctrl["sort_spin"] as SpinBox).value),
+			"isEnabled": (ctrl["enabled_cb"] as CheckBox).button_pressed,
+		})
+	return result
+
+
+# ── Bundles Tab ───────────────────────────────────────────────
+
+func _build_bundles_tab(entries: Array) -> ScrollContainer:
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.name = "Bundles"
+
+	var vbox := VBoxContainer.new()
+	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.add_theme_constant_override("separation", 6)
+	scroll.add_child(vbox)
+
+	for i: int in range(entries.size()):
+		var entry: Dictionary = entries[i] if entries[i] is Dictionary else {}
+		var ctrls := _build_bundle_block(entry, vbox, i % 2 == 0)
+		_bundle_controls.append(ctrls)
+
+	return scroll
+
+
+func _build_bundle_block(entry: Dictionary, parent: VBoxContainer, is_odd: bool) -> Dictionary:
+	var block := AdminCatalogFormHelpers.make_data_row_panel(is_odd)
+	block.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	parent.add_child(block)
+
+	var margin := _make_row_margin()
+	block.add_child(margin)
+
+	var vbox := VBoxContainer.new()
+	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.add_theme_constant_override("separation", 4)
+	margin.add_child(vbox)
+
+	# Row 1: Id | DisplayName | Description | CategoryType | GroupType | IsEnabled
+	var row1 := AdminCatalogFormHelpers.make_row_hbox()
+	vbox.add_child(row1)
+
+	row1.add_child(AdminCatalogFormHelpers.make_id_cell(entry.get("id", 0)))
+
+	var name_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("displayName", "")))
+	var desc_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("description", "")))
+	var cat_ob := AdminCatalogFormHelpers.make_enum_cell(
+		AdminCatalogFormHelpers.SHOP_CATEGORY_OPTIONS,
+		str(entry.get("categoryType", "None"))
+	)
+	var group_ob := AdminCatalogFormHelpers.make_enum_cell(
+		AdminCatalogFormHelpers.SHOP_GROUP_OPTIONS,
+		str(entry.get("groupType", "None"))
+	)
+	var enabled_cb := AdminCatalogFormHelpers.make_bool_cell(bool(entry.get("isEnabled", true)))
+
+	row1.add_child(name_edit)
+	row1.add_child(desc_edit)
+	row1.add_child(cat_ob)
+	row1.add_child(group_ob)
+	row1.add_child(enabled_cb)
+
+	# Row 2: PriceCurrencyId | PriceAmount | DiscountPercent | PurchaseLimit | SortOrder
+	var row2 := AdminCatalogFormHelpers.make_row_hbox()
+	vbox.add_child(row2)
+
+	var currency_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("priceCurrencyId", 1)), 1, 9999, 110.0)
+	var amount_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("priceAmount", 0)), 0, 9999999, 110.0)
+	var discount_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("discountPercent", 0)), 0, 100, 100.0)
+	var limit_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("purchaseLimit", 0)), 0, 9999, 100.0)
+	var sort_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("sortOrder", 0)), 0, 9999, 90.0)
+
+	var _add_labeled_row2 := func(label_text: String, ctrl: Control) -> void:
+		var lbl := Label.new()
+		lbl.text = label_text
+		lbl.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+		lbl.add_theme_color_override("font_color", AdminCatalogFormHelpers.MUTED_COLOR)
+		lbl.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+		row2.add_child(lbl)
+		row2.add_child(ctrl)
+
+	_add_labeled_row2.call("幣種:", currency_spin)
+	_add_labeled_row2.call("價格:", amount_spin)
+	_add_labeled_row2.call("折扣%:", discount_spin)
+	_add_labeled_row2.call("購買上限:", limit_spin)
+	_add_labeled_row2.call("排序:", sort_spin)
+
+	var spacer := Control.new()
+	spacer.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	row2.add_child(spacer)
+
+	# Connect signals
+	for node: Node in [name_edit, desc_edit]:
+		_connect_change(node, "text_changed", func(_v: Variant) -> void: changed.emit())
+	for node: Node in [cat_ob, group_ob]:
+		_connect_change(node, "item_selected", func(_v: Variant) -> void: changed.emit())
+	_connect_change(enabled_cb, "toggled", func(_v: Variant) -> void: changed.emit())
+	for node: Node in [currency_spin, amount_spin, discount_spin, limit_spin, sort_spin]:
+		_connect_change(node, "value_changed", func(_v: Variant) -> void: changed.emit())
+
+	# Rewards sub-table
+	var rewards: Array = entry.get("rewards", []) if entry.get("rewards") is Array else []
+	var reward_controls := _build_rewards_subtable(rewards, vbox)
+
+	return {
+		"id": entry.get("id", 0),
+		"name_edit": name_edit,
+		"desc_edit": desc_edit,
+		"cat_ob": cat_ob,
+		"group_ob": group_ob,
+		"enabled_cb": enabled_cb,
+		"currency_spin": currency_spin,
+		"amount_spin": amount_spin,
+		"discount_spin": discount_spin,
+		"limit_spin": limit_spin,
+		"sort_spin": sort_spin,
+		"reward_controls": reward_controls,
+	}
+
+
+func _build_rewards_subtable(rewards: Array, parent: VBoxContainer) -> Array:
+	if rewards.is_empty():
+		return []
+
+	var reward_margin := MarginContainer.new()
+	reward_margin.add_theme_constant_override("margin_left", 20)
+	reward_margin.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	parent.add_child(reward_margin)
+
+	var reward_vbox := VBoxContainer.new()
+	reward_vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	reward_vbox.add_theme_constant_override("separation", 2)
+	reward_margin.add_child(reward_vbox)
+
+	# Rewards header
+	var rh_panel := AdminCatalogFormHelpers.make_header_row_panel()
+	reward_vbox.add_child(rh_panel)
+	var rh_margin := _make_small_margin()
+	rh_panel.add_child(rh_margin)
+	var rh_hb := AdminCatalogFormHelpers.make_row_hbox()
+	rh_margin.add_child(rh_hb)
+	rh_hb.add_child(AdminCatalogFormHelpers.make_col_header("Order", 60.0, false))
+	rh_hb.add_child(AdminCatalogFormHelpers.make_col_header("RewardType"))
+	rh_hb.add_child(AdminCatalogFormHelpers.make_col_header("RefId (0=null)", 110.0, false))
+	rh_hb.add_child(AdminCatalogFormHelpers.make_col_header("Quantity", 90.0, false))
+	rh_hb.add_child(AdminCatalogFormHelpers.make_col_header("IsEnabled", 70.0, false))
+
+	var reward_controls: Array = []
+	for i: int in range(rewards.size()):
+		var rw: Dictionary = rewards[i] if rewards[i] is Dictionary else {}
+		var row_panel := AdminCatalogFormHelpers.make_data_row_panel(i % 2 == 0)
+		reward_vbox.add_child(row_panel)
+		var rm := _make_small_margin()
+		row_panel.add_child(rm)
+		var r_hb := AdminCatalogFormHelpers.make_row_hbox()
+		rm.add_child(r_hb)
+
+		var order_lbl := Label.new()
+		order_lbl.text = "#%d" % int(rw.get("rewardOrder", i + 1))
+		order_lbl.custom_minimum_size.x = 60.0
+		order_lbl.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+		order_lbl.add_theme_color_override("font_color", AdminCatalogFormHelpers.MUTED_COLOR)
+		order_lbl.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+
+		var ref_id_raw: Variant = rw.get("rewardReferenceId", null)
+		var ref_id_val: int = int(ref_id_raw) if ref_id_raw != null else 0
+
+		var type_ob := AdminCatalogFormHelpers.make_enum_cell(
+			AdminCatalogFormHelpers.REWARD_TYPE_OPTIONS,
+			str(rw.get("rewardType", "None"))
+		)
+		var ref_spin := AdminCatalogFormHelpers.make_int_cell(ref_id_val, 0, 9999999, 110.0)
+		var qty_spin := AdminCatalogFormHelpers.make_int_cell(int(rw.get("quantity", 0)), 0, 9999999, 90.0)
+		var rw_enabled := AdminCatalogFormHelpers.make_bool_cell(bool(rw.get("isEnabled", true)))
+
+		r_hb.add_child(order_lbl)
+		r_hb.add_child(type_ob)
+		r_hb.add_child(ref_spin)
+		r_hb.add_child(qty_spin)
+		r_hb.add_child(rw_enabled)
+
+		_connect_change(type_ob, "item_selected", func(_v: Variant) -> void: changed.emit())
+		_connect_change(ref_spin, "value_changed", func(_v: Variant) -> void: changed.emit())
+		_connect_change(qty_spin, "value_changed", func(_v: Variant) -> void: changed.emit())
+		_connect_change(rw_enabled, "toggled", func(_v: Variant) -> void: changed.emit())
+
+		reward_controls.append({
+			"id": rw.get("id", 0),
+			"reward_order": int(rw.get("rewardOrder", i + 1)),
+			"type_ob": type_ob,
+			"ref_spin": ref_spin,
+			"qty_spin": qty_spin,
+			"enabled_cb": rw_enabled,
+		})
+
+	return reward_controls
+
+
+func _collect_bundles() -> Array:
+	var result: Array = []
+	for ctrl: Dictionary in _bundle_controls:
+		var rewards_arr: Array = []
+		for rc: Dictionary in (ctrl["reward_controls"] as Array):
+			var ref_val: int = int((rc["ref_spin"] as SpinBox).value)
+			rewards_arr.append({
+				"id": rc["id"],
+				"rewardOrder": rc["reward_order"],
+				"rewardType": AdminCatalogFormHelpers.get_enum_value(rc["type_ob"] as OptionButton),
+				"rewardReferenceId": null if ref_val == 0 else ref_val,
+				"quantity": int((rc["qty_spin"] as SpinBox).value),
+				"isEnabled": (rc["enabled_cb"] as CheckBox).button_pressed,
+			})
+		result.append({
+			"id": ctrl["id"],
+			"displayName": (ctrl["name_edit"] as LineEdit).text,
+			"description": (ctrl["desc_edit"] as LineEdit).text,
+			"categoryType": AdminCatalogFormHelpers.get_enum_value(ctrl["cat_ob"] as OptionButton),
+			"groupType": AdminCatalogFormHelpers.get_enum_value(ctrl["group_ob"] as OptionButton),
+			"priceCurrencyId": int((ctrl["currency_spin"] as SpinBox).value),
+			"priceAmount": int((ctrl["amount_spin"] as SpinBox).value),
+			"discountPercent": int((ctrl["discount_spin"] as SpinBox).value),
+			"purchaseLimit": int((ctrl["limit_spin"] as SpinBox).value),
+			"sortOrder": int((ctrl["sort_spin"] as SpinBox).value),
+			"isEnabled": (ctrl["enabled_cb"] as CheckBox).button_pressed,
+			"rewards": rewards_arr,
+		})
+	return result
+
+
+# ── Layout Helpers ────────────────────────────────────────────
+
+static func _make_row_margin() -> MarginContainer:
+	var m := MarginContainer.new()
+	m.add_theme_constant_override("margin_left", 6)
+	m.add_theme_constant_override("margin_right", 6)
+	m.add_theme_constant_override("margin_top", 3)
+	m.add_theme_constant_override("margin_bottom", 3)
+	return m
+
+
+static func _make_small_margin() -> MarginContainer:
+	var m := MarginContainer.new()
+	m.add_theme_constant_override("margin_left", 4)
+	m.add_theme_constant_override("margin_right", 4)
+	m.add_theme_constant_override("margin_top", 2)
+	m.add_theme_constant_override("margin_bottom", 2)
+	return m
+
+
+static func _connect_change(node: Node, signal_name: String, callable: Callable) -> void:
+	node.connect(signal_name, callable)

--- a/scripts/configs/AdminCatalogSkillsRenderer.gd
+++ b/scripts/configs/AdminCatalogSkillsRenderer.gd
@@ -1,0 +1,338 @@
+class_name AdminCatalogSkillsRenderer
+extends Control
+
+signal changed
+
+# ── State ────────────────────────────────────────────────────────
+
+var _skill_controls: Array = []
+
+
+# ── Public API ───────────────────────────────────────────────────
+
+func setup(data: Dictionary) -> void:
+	for child: Node in get_children():
+		child.queue_free()
+	_skill_controls.clear()
+
+	var skills: Array = data.get("skills", []) if data.get("skills") is Array else []
+
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	add_child(scroll)
+
+	var vbox := VBoxContainer.new()
+	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.add_theme_constant_override("separation", 4)
+	scroll.add_child(vbox)
+
+	for i: int in range(skills.size()):
+		var entry: Dictionary = skills[i] if skills[i] is Dictionary else {}
+		var ctrls := _build_skill_block(entry, vbox, i % 2 == 0)
+		_skill_controls.append(ctrls)
+
+
+func get_data() -> Dictionary:
+	return {"skills": _collect_skills()}
+
+
+# ── Skill Block ───────────────────────────────────────────────────
+
+func _build_skill_block(entry: Dictionary, parent: VBoxContainer, is_odd: bool) -> Dictionary:
+	var block_panel := AdminCatalogFormHelpers.make_data_row_panel(is_odd)
+	block_panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	parent.add_child(block_panel)
+
+	var block_margin := _make_row_margin()
+	block_panel.add_child(block_margin)
+
+	var block_vbox := VBoxContainer.new()
+	block_vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	block_vbox.add_theme_constant_override("separation", 4)
+	block_margin.add_child(block_vbox)
+
+	# ── Main Row ──────────────────────────────────────────────────
+	var main_hb := AdminCatalogFormHelpers.make_row_hbox()
+	block_vbox.add_child(main_hb)
+
+	var skill_key_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("skillKey", "")))
+	var display_name_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("displayName", "")))
+	var stype_ob := AdminCatalogFormHelpers.make_enum_cell(AdminCatalogFormHelpers.SKILL_TYPE_OPTIONS, str(entry.get("skillType", "Active")))
+	var cooldown_spin := AdminCatalogFormHelpers.make_int_cell(int(entry.get("cooldownSeconds", 0)), 0, 99999, 90.0)
+	var en_cb := AdminCatalogFormHelpers.make_bool_cell(bool(entry.get("isEnabled", true)), 60.0)
+	var desc_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("description", "")))
+
+	main_hb.add_child(AdminCatalogFormHelpers.make_id_cell(entry.get("id", 0)))
+	main_hb.add_child(_add_labeled("Key", skill_key_edit))
+	main_hb.add_child(_add_labeled("顯示名稱", display_name_edit))
+	main_hb.add_child(_add_labeled("技能類型", stype_ob))
+	main_hb.add_child(_add_labeled("冷卻(秒)", cooldown_spin))
+	main_hb.add_child(_add_labeled("啟用", en_cb))
+	main_hb.add_child(_add_labeled("描述", desc_edit))
+
+	_connect_change(stype_ob, "item_selected", func(_v: Variant) -> void: changed.emit())
+	_connect_change(cooldown_spin, "value_changed", func(_v: Variant) -> void: changed.emit())
+	for edit: Node in [skill_key_edit, display_name_edit, desc_edit]:
+		_connect_change(edit, "text_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(en_cb, "toggled", func(_v: Variant) -> void: changed.emit())
+
+	# ── Effects Sub-table ─────────────────────────────────────────
+	var effects: Array = entry.get("effects", []) if entry.get("effects") is Array else []
+	var effect_controls := _build_effects_subtable(effects, block_vbox)
+
+	# ── RankScaling Sub-table ─────────────────────────────────────
+	var rank_scaling: Array = entry.get("rankScaling", []) if entry.get("rankScaling") is Array else []
+	var rank_controls := _build_rank_scaling_subtable(rank_scaling, block_vbox)
+
+	return {
+		"id": entry.get("id", 0),
+		"skill_key_edit": skill_key_edit,
+		"display_name_edit": display_name_edit,
+		"stype_ob": stype_ob,
+		"cooldown_spin": cooldown_spin,
+		"enabled_cb": en_cb,
+		"desc_edit": desc_edit,
+		"effect_controls": effect_controls,
+		"rank_controls": rank_controls,
+	}
+
+
+func _build_effects_subtable(effects: Array, parent: VBoxContainer) -> Array:
+	var sub_margin := MarginContainer.new()
+	sub_margin.add_theme_constant_override("margin_left", 20)
+	parent.add_child(sub_margin)
+
+	var sub_vbox := VBoxContainer.new()
+	sub_vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	sub_vbox.add_theme_constant_override("separation", 2)
+	sub_margin.add_child(sub_vbox)
+
+	var label := AdminCatalogFormHelpers.make_section_label("技能效果")
+	label.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_LABEL)
+	sub_vbox.add_child(label)
+
+	var header := AdminCatalogFormHelpers.make_header_row_panel()
+	sub_vbox.add_child(header)
+	var hm := _make_small_margin()
+	header.add_child(hm)
+	var hb := AdminCatalogFormHelpers.make_row_hbox()
+	hm.add_child(hb)
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("順序", 60.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("目標範圍"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("效果類型"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("能力類型"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("數值模式"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("基礎值", 90.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("持續時間", 90.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("最大疊加", 90.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("啟用", 60.0, false))
+
+	var result: Array = []
+	for i: int in range(effects.size()):
+		var eff: Dictionary = effects[i] if effects[i] is Dictionary else {}
+		var row := AdminCatalogFormHelpers.make_data_row_panel(i % 2 == 0)
+		sub_vbox.add_child(row)
+		var rm := _make_small_margin()
+		row.add_child(rm)
+		var rb := AdminCatalogFormHelpers.make_row_hbox()
+		rm.add_child(rb)
+
+		var order_spin := AdminCatalogFormHelpers.make_int_cell(int(eff.get("effectOrder", 1)), 1, 99, 60.0)
+		var scope_ob := AdminCatalogFormHelpers.make_enum_cell(AdminCatalogFormHelpers.TARGET_SCOPE_OPTIONS, str(eff.get("targetScopeType", "Self")))
+		var etype_ob := AdminCatalogFormHelpers.make_enum_cell(AdminCatalogFormHelpers.SKILL_EFFECT_TYPE_OPTIONS, str(eff.get("effectType", "Damage")))
+		# statType may be null — treat null as "None"
+		var stat_str := str(eff.get("statType", "None")) if eff.get("statType") != null else "None"
+		var stat_ob := AdminCatalogFormHelpers.make_enum_cell(AdminCatalogFormHelpers.STAT_TYPE_OPTIONS, stat_str)
+		var vtype_ob := AdminCatalogFormHelpers.make_enum_cell(AdminCatalogFormHelpers.VALUE_MODE_OPTIONS, str(eff.get("valueType", "Flat")))
+		var base_spin := AdminCatalogFormHelpers.make_float_cell(float(eff.get("baseValue", 0.0)), 0.001, 90.0)
+		# durationSeconds: null → 0
+		var dur_val: float = float(eff.get("durationSeconds", 0.0)) if eff.get("durationSeconds") != null else 0.0
+		var dur_spin := AdminCatalogFormHelpers.make_float_cell(dur_val, 0.1, 90.0)
+		# maxStack: null → 0
+		var stack_val: int = int(eff.get("maxStack", 0)) if eff.get("maxStack") != null else 0
+		var stack_spin := AdminCatalogFormHelpers.make_int_cell(stack_val, 0, 999, 90.0)
+		var en_cb := AdminCatalogFormHelpers.make_bool_cell(bool(eff.get("isEnabled", true)), 60.0)
+
+		rb.add_child(order_spin)
+		rb.add_child(scope_ob)
+		rb.add_child(etype_ob)
+		rb.add_child(stat_ob)
+		rb.add_child(vtype_ob)
+		rb.add_child(base_spin)
+		rb.add_child(dur_spin)
+		rb.add_child(stack_spin)
+		rb.add_child(en_cb)
+
+		for node: Node in [order_spin, base_spin, dur_spin, stack_spin]:
+			_connect_change(node, "value_changed", func(_v: Variant) -> void: changed.emit())
+		for ob: Node in [scope_ob, etype_ob, stat_ob, vtype_ob]:
+			_connect_change(ob, "item_selected", func(_v: Variant) -> void: changed.emit())
+		_connect_change(en_cb, "toggled", func(_v: Variant) -> void: changed.emit())
+
+		result.append({
+			"id": eff.get("id", 0),
+			"order_spin": order_spin,
+			"scope_ob": scope_ob,
+			"etype_ob": etype_ob,
+			"stat_ob": stat_ob,
+			"vtype_ob": vtype_ob,
+			"base_spin": base_spin,
+			"dur_spin": dur_spin,
+			"stack_spin": stack_spin,
+			"enabled_cb": en_cb,
+		})
+	return result
+
+
+func _build_rank_scaling_subtable(scalings: Array, parent: VBoxContainer) -> Array:
+	var sub_margin := MarginContainer.new()
+	sub_margin.add_theme_constant_override("margin_left", 20)
+	parent.add_child(sub_margin)
+
+	var sub_vbox := VBoxContainer.new()
+	sub_vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	sub_vbox.add_theme_constant_override("separation", 2)
+	sub_margin.add_child(sub_vbox)
+
+	var label := AdminCatalogFormHelpers.make_section_label("階級縮放")
+	label.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_LABEL)
+	sub_vbox.add_child(label)
+
+	var header := AdminCatalogFormHelpers.make_header_row_panel()
+	sub_vbox.add_child(header)
+	var hm := _make_small_margin()
+	header.add_child(hm)
+	var hb := AdminCatalogFormHelpers.make_row_hbox()
+	hm.add_child(hb)
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("階級", 70.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("效果順序", 80.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("縮放類型"))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("縮放值", 100.0, false))
+	hb.add_child(AdminCatalogFormHelpers.make_col_header("啟用", 60.0, false))
+
+	var result: Array = []
+	for i: int in range(scalings.size()):
+		var sc: Dictionary = scalings[i] if scalings[i] is Dictionary else {}
+		var row := AdminCatalogFormHelpers.make_data_row_panel(i % 2 == 0)
+		sub_vbox.add_child(row)
+		var rm := _make_small_margin()
+		row.add_child(rm)
+		var rb := AdminCatalogFormHelpers.make_row_hbox()
+		rm.add_child(rb)
+
+		var rank_spin := AdminCatalogFormHelpers.make_int_cell(int(sc.get("rank", 1)), 1, 99, 70.0)
+		var effect_order_spin := AdminCatalogFormHelpers.make_int_cell(int(sc.get("effectOrder", 1)), 1, 99, 80.0)
+		var scaling_type_edit := AdminCatalogFormHelpers.make_text_cell(str(sc.get("scalingType", "")))
+		var scaling_val_spin := AdminCatalogFormHelpers.make_float_cell(float(sc.get("scalingValue", 1.0)), 0.001, 100.0)
+		var en_cb := AdminCatalogFormHelpers.make_bool_cell(bool(sc.get("isEnabled", true)), 60.0)
+
+		rb.add_child(rank_spin)
+		rb.add_child(effect_order_spin)
+		rb.add_child(scaling_type_edit)
+		rb.add_child(scaling_val_spin)
+		rb.add_child(en_cb)
+
+		for node: Node in [rank_spin, effect_order_spin, scaling_val_spin]:
+			_connect_change(node, "value_changed", func(_v: Variant) -> void: changed.emit())
+		_connect_change(scaling_type_edit, "text_changed", func(_v: Variant) -> void: changed.emit())
+		_connect_change(en_cb, "toggled", func(_v: Variant) -> void: changed.emit())
+
+		result.append({
+			"id": sc.get("id", 0),
+			"rank_spin": rank_spin,
+			"effect_order_spin": effect_order_spin,
+			"scaling_type_edit": scaling_type_edit,
+			"scaling_val_spin": scaling_val_spin,
+			"enabled_cb": en_cb,
+		})
+	return result
+
+
+# ── Collect ──────────────────────────────────────────────────────
+
+func _collect_skills() -> Array:
+	var result: Array = []
+	for ctrl: Dictionary in _skill_controls:
+		var effects_arr: Array = []
+		for ec: Dictionary in (ctrl["effect_controls"] as Array):
+			# statType: "None" key → null
+			var stat_key := AdminCatalogFormHelpers.get_enum_value(ec["stat_ob"] as OptionButton)
+			var stat_out: Variant = null if stat_key == "None" else stat_key
+			# durationSeconds: 0 → null
+			var dur_val: float = (ec["dur_spin"] as SpinBox).value
+			var dur_out: Variant = null if dur_val == 0.0 else dur_val
+			# maxStack: 0 → null
+			var stack_val: int = int((ec["stack_spin"] as SpinBox).value)
+			var stack_out: Variant = null if stack_val == 0 else stack_val
+			effects_arr.append({
+				"id": ec["id"],
+				"effectOrder": int((ec["order_spin"] as SpinBox).value),
+				"targetScopeType": AdminCatalogFormHelpers.get_enum_value(ec["scope_ob"] as OptionButton),
+				"effectType": AdminCatalogFormHelpers.get_enum_value(ec["etype_ob"] as OptionButton),
+				"statType": stat_out,
+				"valueType": AdminCatalogFormHelpers.get_enum_value(ec["vtype_ob"] as OptionButton),
+				"baseValue": (ec["base_spin"] as SpinBox).value,
+				"durationSeconds": dur_out,
+				"maxStack": stack_out,
+				"isEnabled": (ec["enabled_cb"] as CheckBox).button_pressed,
+			})
+		var rank_arr: Array = []
+		for rc: Dictionary in (ctrl["rank_controls"] as Array):
+			rank_arr.append({
+				"id": rc["id"],
+				"rank": int((rc["rank_spin"] as SpinBox).value),
+				"effectOrder": int((rc["effect_order_spin"] as SpinBox).value),
+				"scalingType": (rc["scaling_type_edit"] as LineEdit).text,
+				"scalingValue": (rc["scaling_val_spin"] as SpinBox).value,
+				"isEnabled": (rc["enabled_cb"] as CheckBox).button_pressed,
+			})
+		result.append({
+			"id": ctrl["id"],
+			"skillKey": (ctrl["skill_key_edit"] as LineEdit).text,
+			"displayName": (ctrl["display_name_edit"] as LineEdit).text,
+			"skillType": AdminCatalogFormHelpers.get_enum_value(ctrl["stype_ob"] as OptionButton),
+			"description": (ctrl["desc_edit"] as LineEdit).text,
+			"cooldownSeconds": int((ctrl["cooldown_spin"] as SpinBox).value),
+			"isEnabled": (ctrl["enabled_cb"] as CheckBox).button_pressed,
+			"effects": effects_arr,
+			"rankScaling": rank_arr,
+		})
+	return result
+
+
+# ── Layout Helpers ────────────────────────────────────────────────
+
+static func _add_labeled(label_text: String, control: Control) -> HBoxContainer:
+	var hb := HBoxContainer.new()
+	hb.add_theme_constant_override("separation", 4)
+	var lbl := Label.new()
+	lbl.text = label_text
+	lbl.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+	lbl.add_theme_color_override("font_color", AdminCatalogFormHelpers.MUTED_COLOR)
+	lbl.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	hb.add_child(lbl)
+	hb.add_child(control)
+	return hb
+
+
+static func _make_row_margin() -> MarginContainer:
+	var m := MarginContainer.new()
+	m.add_theme_constant_override("margin_left", 6)
+	m.add_theme_constant_override("margin_right", 6)
+	m.add_theme_constant_override("margin_top", 3)
+	m.add_theme_constant_override("margin_bottom", 3)
+	return m
+
+
+static func _make_small_margin() -> MarginContainer:
+	var m := MarginContainer.new()
+	m.add_theme_constant_override("margin_left", 4)
+	m.add_theme_constant_override("margin_right", 4)
+	m.add_theme_constant_override("margin_top", 2)
+	m.add_theme_constant_override("margin_bottom", 2)
+	return m
+
+
+static func _connect_change(node: Node, signal_name: String, callable: Callable) -> void:
+	node.connect(signal_name, callable)

--- a/scripts/configs/AdminCatalogStagesRenderer.gd
+++ b/scripts/configs/AdminCatalogStagesRenderer.gd
@@ -1,0 +1,404 @@
+class_name AdminCatalogStagesRenderer
+extends Control
+
+signal changed
+
+var _stage_ctrls: Dictionary = {}
+var _reward_preview_controls: Array = []
+var _world_ctrls: Dictionary = {}
+var _territory_controls: Array = []
+var _suffix_controls: Array = []
+
+
+func setup(data: Dictionary) -> void:
+	for child: Node in get_children():
+		child.queue_free()
+	_stage_ctrls.clear()
+	_reward_preview_controls.clear()
+	_world_ctrls.clear()
+	_territory_controls.clear()
+	_suffix_controls.clear()
+
+	var tabs := TabContainer.new()
+	tabs.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	tabs.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	add_child(tabs)
+
+	var stage_setting: Dictionary = data.get("stageSetting", {}) if data.get("stageSetting") is Dictionary else {}
+	var world_setting: Dictionary = data.get("worldSetting", {}) if data.get("worldSetting") is Dictionary else {}
+
+	tabs.add_child(_build_stage_tab(stage_setting))
+	tabs.add_child(_build_world_tab(world_setting))
+
+	tabs.set_tab_title(0, "關卡設定")
+	tabs.set_tab_title(1, "世界設定")
+
+
+func get_data() -> Dictionary:
+	return {
+		"stageSetting": _collect_stage_setting(),
+		"worldSetting": _collect_world_setting(),
+	}
+
+
+# ── Stage Setting Tab ─────────────────────────────────────────
+
+func _build_stage_tab(s: Dictionary) -> ScrollContainer:
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.name = "StageSetting"
+
+	var margin := MarginContainer.new()
+	margin.add_theme_constant_override("margin_left", 16)
+	margin.add_theme_constant_override("margin_top", 16)
+	margin.add_theme_constant_override("margin_right", 16)
+	margin.add_theme_constant_override("margin_bottom", 16)
+	margin.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scroll.add_child(margin)
+
+	var vbox := VBoxContainer.new()
+	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.add_theme_constant_override("separation", 10)
+	margin.add_child(vbox)
+
+	vbox.add_child(AdminCatalogFormHelpers.make_section_label("關卡設定"))
+	vbox.add_child(AdminCatalogFormHelpers.make_separator())
+
+	var enc_spin := AdminCatalogFormHelpers.make_int_cell(int(s.get("encountersPerBossStage", 5)), 1, 999, 120.0)
+	var boss_stages_spin := AdminCatalogFormHelpers.make_int_cell(int(s.get("bossStagesPerZone", 3)), 1, 999, 120.0)
+	var enc_growth_spin := AdminCatalogFormHelpers.make_float_cell(float(s.get("encounterGrowthRate", 1.0)), 0.001, 120.0)
+	var boss_growth_spin := AdminCatalogFormHelpers.make_float_cell(float(s.get("bossGrowthRate", 1.0)), 0.001, 120.0)
+	var zone_ob := AdminCatalogFormHelpers.make_enum_cell(
+		AdminCatalogFormHelpers.ZONE_TYPE_OPTIONS,
+		str(s.get("zoneType", "None"))
+	)
+	var enabled_cb := AdminCatalogFormHelpers.make_bool_cell(bool(s.get("isEnabled", true)))
+
+	vbox.add_child(AdminCatalogFormHelpers.make_form_row("遭遇數/首領關", enc_spin))
+	vbox.add_child(AdminCatalogFormHelpers.make_form_row("首領關/區域", boss_stages_spin))
+	vbox.add_child(AdminCatalogFormHelpers.make_form_row("遭遇成長率", enc_growth_spin))
+	vbox.add_child(AdminCatalogFormHelpers.make_form_row("首領成長率", boss_growth_spin))
+	vbox.add_child(AdminCatalogFormHelpers.make_form_row("區域類型", zone_ob))
+	vbox.add_child(AdminCatalogFormHelpers.make_form_row("啟用", enabled_cb))
+
+	_stage_ctrls = {
+		"id": s.get("id", 0),
+		"enc_spin": enc_spin,
+		"boss_stages_spin": boss_stages_spin,
+		"enc_growth_spin": enc_growth_spin,
+		"boss_growth_spin": boss_growth_spin,
+		"zone_ob": zone_ob,
+		"enabled_cb": enabled_cb,
+	}
+
+	for node: Node in [enc_spin, boss_stages_spin, enc_growth_spin, boss_growth_spin]:
+		_connect_change(node, "value_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(zone_ob, "item_selected", func(_v: Variant) -> void: changed.emit())
+	_connect_change(enabled_cb, "toggled", func(_v: Variant) -> void: changed.emit())
+
+	# Reward previews section
+	vbox.add_child(AdminCatalogFormHelpers.make_separator())
+	vbox.add_child(AdminCatalogFormHelpers.make_section_label("獎勵預覽"))
+
+	var reward_previews: Array = s.get("rewardPreviews", []) if s.get("rewardPreviews") is Array else []
+	_build_reward_previews_table(reward_previews, vbox)
+
+	return scroll
+
+
+func _build_reward_previews_table(entries: Array, parent: VBoxContainer) -> void:
+	# Header
+	var header_panel := AdminCatalogFormHelpers.make_header_row_panel()
+	parent.add_child(header_panel)
+	var hm := _make_row_margin()
+	header_panel.add_child(hm)
+	var h_hb := AdminCatalogFormHelpers.make_row_hbox()
+	hm.add_child(h_hb)
+	h_hb.add_child(AdminCatalogFormHelpers.make_col_header("Order", 60.0, false))
+	h_hb.add_child(AdminCatalogFormHelpers.make_col_header("RewardType"))
+	h_hb.add_child(AdminCatalogFormHelpers.make_col_header("Quantity", 110.0, false))
+	h_hb.add_child(AdminCatalogFormHelpers.make_col_header("SortOrder", 90.0, false))
+	h_hb.add_child(AdminCatalogFormHelpers.make_col_header("IsEnabled", 70.0, false))
+
+	var rows_vbox := VBoxContainer.new()
+	rows_vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	rows_vbox.add_theme_constant_override("separation", 2)
+	parent.add_child(rows_vbox)
+
+	for i: int in range(entries.size()):
+		var rw: Dictionary = entries[i] if entries[i] is Dictionary else {}
+		var row_panel := AdminCatalogFormHelpers.make_data_row_panel(i % 2 == 0)
+		rows_vbox.add_child(row_panel)
+		var rm := _make_row_margin()
+		row_panel.add_child(rm)
+		var r_hb := AdminCatalogFormHelpers.make_row_hbox()
+		rm.add_child(r_hb)
+
+		var order_lbl := Label.new()
+		order_lbl.text = "#%d" % int(rw.get("rewardOrder", i + 1))
+		order_lbl.custom_minimum_size.x = 60.0
+		order_lbl.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+		order_lbl.add_theme_color_override("font_color", AdminCatalogFormHelpers.MUTED_COLOR)
+		order_lbl.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+
+		var type_ob := AdminCatalogFormHelpers.make_enum_cell(
+			AdminCatalogFormHelpers.REWARD_TYPE_OPTIONS,
+			str(rw.get("rewardType", "None"))
+		)
+		var qty_spin := AdminCatalogFormHelpers.make_float_cell(float(rw.get("rewardQuantity", 0.0)), 0.001, 110.0)
+		var sort_spin := AdminCatalogFormHelpers.make_int_cell(int(rw.get("sortOrder", 0)), 0, 9999, 90.0)
+		var rw_enabled := AdminCatalogFormHelpers.make_bool_cell(bool(rw.get("isEnabled", true)))
+
+		r_hb.add_child(order_lbl)
+		r_hb.add_child(type_ob)
+		r_hb.add_child(qty_spin)
+		r_hb.add_child(sort_spin)
+		r_hb.add_child(rw_enabled)
+
+		_connect_change(type_ob, "item_selected", func(_v: Variant) -> void: changed.emit())
+		_connect_change(qty_spin, "value_changed", func(_v: Variant) -> void: changed.emit())
+		_connect_change(sort_spin, "value_changed", func(_v: Variant) -> void: changed.emit())
+		_connect_change(rw_enabled, "toggled", func(_v: Variant) -> void: changed.emit())
+
+		_reward_preview_controls.append({
+			"id": rw.get("id", 0),
+			"reward_order": int(rw.get("rewardOrder", i + 1)),
+			"type_ob": type_ob,
+			"qty_spin": qty_spin,
+			"sort_spin": sort_spin,
+			"enabled_cb": rw_enabled,
+		})
+
+
+func _collect_stage_setting() -> Dictionary:
+	return {
+		"id": _stage_ctrls.get("id", 0),
+		"encountersPerBossStage": int((_stage_ctrls["enc_spin"] as SpinBox).value),
+		"bossStagesPerZone": int((_stage_ctrls["boss_stages_spin"] as SpinBox).value),
+		"encounterGrowthRate": (_stage_ctrls["enc_growth_spin"] as SpinBox).value,
+		"bossGrowthRate": (_stage_ctrls["boss_growth_spin"] as SpinBox).value,
+		"zoneType": AdminCatalogFormHelpers.get_enum_value(_stage_ctrls["zone_ob"] as OptionButton),
+		"isEnabled": (_stage_ctrls["enabled_cb"] as CheckBox).button_pressed,
+		"rewardPreviews": _collect_reward_previews(),
+	}
+
+
+func _collect_reward_previews() -> Array:
+	var result: Array = []
+	for ctrl: Dictionary in _reward_preview_controls:
+		result.append({
+			"id": ctrl["id"],
+			"rewardOrder": ctrl["reward_order"],
+			"rewardType": AdminCatalogFormHelpers.get_enum_value(ctrl["type_ob"] as OptionButton),
+			"rewardQuantity": (ctrl["qty_spin"] as SpinBox).value,
+			"sortOrder": int((ctrl["sort_spin"] as SpinBox).value),
+			"isEnabled": (ctrl["enabled_cb"] as CheckBox).button_pressed,
+		})
+	return result
+
+
+# ── World Setting Tab ─────────────────────────────────────────
+
+func _build_world_tab(w: Dictionary) -> ScrollContainer:
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.name = "WorldSetting"
+
+	var margin := MarginContainer.new()
+	margin.add_theme_constant_override("margin_left", 16)
+	margin.add_theme_constant_override("margin_top", 16)
+	margin.add_theme_constant_override("margin_right", 16)
+	margin.add_theme_constant_override("margin_bottom", 16)
+	margin.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scroll.add_child(margin)
+
+	var vbox := VBoxContainer.new()
+	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.add_theme_constant_override("separation", 10)
+	margin.add_child(vbox)
+
+	vbox.add_child(AdminCatalogFormHelpers.make_section_label("世界設定"))
+	vbox.add_child(AdminCatalogFormHelpers.make_separator())
+
+	var zones_spin := AdminCatalogFormHelpers.make_int_cell(int(w.get("zonesPerTerritory", 5)), 1, 999, 120.0)
+	var enabled_cb := AdminCatalogFormHelpers.make_bool_cell(bool(w.get("isEnabled", true)))
+
+	vbox.add_child(AdminCatalogFormHelpers.make_form_row("區域數/地域", zones_spin))
+	vbox.add_child(AdminCatalogFormHelpers.make_form_row("啟用", enabled_cb))
+
+	_world_ctrls = {
+		"id": w.get("id", 0),
+		"zones_spin": zones_spin,
+		"enabled_cb": enabled_cb,
+	}
+
+	_connect_change(zones_spin, "value_changed", func(_v: Variant) -> void: changed.emit())
+	_connect_change(enabled_cb, "toggled", func(_v: Variant) -> void: changed.emit())
+
+	# Territories section
+	vbox.add_child(AdminCatalogFormHelpers.make_separator())
+	vbox.add_child(AdminCatalogFormHelpers.make_section_label("地域列表"))
+
+	var territories: Array = w.get("territories", []) if w.get("territories") is Array else []
+	_build_territories_table(territories, vbox)
+
+	# Zone Suffixes section
+	vbox.add_child(AdminCatalogFormHelpers.make_separator())
+	vbox.add_child(AdminCatalogFormHelpers.make_section_label("Zone 後綴"))
+
+	var zone_suffixes: Array = w.get("zoneSuffixes", []) if w.get("zoneSuffixes") is Array else []
+	_build_suffixes_table(zone_suffixes, vbox)
+
+	return scroll
+
+
+func _build_territories_table(entries: Array, parent: VBoxContainer) -> void:
+	var header_panel := AdminCatalogFormHelpers.make_header_row_panel()
+	parent.add_child(header_panel)
+	var hm := _make_row_margin()
+	header_panel.add_child(hm)
+	var h_hb := AdminCatalogFormHelpers.make_row_hbox()
+	hm.add_child(h_hb)
+	h_hb.add_child(AdminCatalogFormHelpers.make_col_header("Order", 60.0, false))
+	h_hb.add_child(AdminCatalogFormHelpers.make_col_header("DisplayName"))
+	h_hb.add_child(AdminCatalogFormHelpers.make_col_header("IsEnabled", 70.0, false))
+
+	var rows_vbox := VBoxContainer.new()
+	rows_vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	rows_vbox.add_theme_constant_override("separation", 2)
+	parent.add_child(rows_vbox)
+
+	for i: int in range(entries.size()):
+		var entry: Dictionary = entries[i] if entries[i] is Dictionary else {}
+		var row_panel := AdminCatalogFormHelpers.make_data_row_panel(i % 2 == 0)
+		rows_vbox.add_child(row_panel)
+		var rm := _make_row_margin()
+		row_panel.add_child(rm)
+		var r_hb := AdminCatalogFormHelpers.make_row_hbox()
+		rm.add_child(r_hb)
+
+		var order_lbl := Label.new()
+		order_lbl.text = "#%d" % int(entry.get("territoryOrder", i + 1))
+		order_lbl.custom_minimum_size.x = 60.0
+		order_lbl.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+		order_lbl.add_theme_color_override("font_color", AdminCatalogFormHelpers.MUTED_COLOR)
+		order_lbl.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+
+		var name_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("displayName", "")))
+		var t_enabled := AdminCatalogFormHelpers.make_bool_cell(bool(entry.get("isEnabled", true)))
+
+		r_hb.add_child(order_lbl)
+		r_hb.add_child(name_edit)
+		r_hb.add_child(t_enabled)
+
+		_connect_change(name_edit, "text_changed", func(_v: Variant) -> void: changed.emit())
+		_connect_change(t_enabled, "toggled", func(_v: Variant) -> void: changed.emit())
+
+		_territory_controls.append({
+			"id": entry.get("id", 0),
+			"territory_order": int(entry.get("territoryOrder", i + 1)),
+			"name_edit": name_edit,
+			"enabled_cb": t_enabled,
+		})
+
+
+func _build_suffixes_table(entries: Array, parent: VBoxContainer) -> void:
+	var header_panel := AdminCatalogFormHelpers.make_header_row_panel()
+	parent.add_child(header_panel)
+	var hm := _make_row_margin()
+	header_panel.add_child(hm)
+	var h_hb := AdminCatalogFormHelpers.make_row_hbox()
+	hm.add_child(h_hb)
+	h_hb.add_child(AdminCatalogFormHelpers.make_col_header("Order", 60.0, false))
+	h_hb.add_child(AdminCatalogFormHelpers.make_col_header("DisplayName"))
+	h_hb.add_child(AdminCatalogFormHelpers.make_col_header("IsEnabled", 70.0, false))
+
+	var rows_vbox := VBoxContainer.new()
+	rows_vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	rows_vbox.add_theme_constant_override("separation", 2)
+	parent.add_child(rows_vbox)
+
+	for i: int in range(entries.size()):
+		var entry: Dictionary = entries[i] if entries[i] is Dictionary else {}
+		var row_panel := AdminCatalogFormHelpers.make_data_row_panel(i % 2 == 0)
+		rows_vbox.add_child(row_panel)
+		var rm := _make_row_margin()
+		row_panel.add_child(rm)
+		var r_hb := AdminCatalogFormHelpers.make_row_hbox()
+		rm.add_child(r_hb)
+
+		var order_lbl := Label.new()
+		order_lbl.text = "#%d" % int(entry.get("suffixOrder", i + 1))
+		order_lbl.custom_minimum_size.x = 60.0
+		order_lbl.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
+		order_lbl.add_theme_color_override("font_color", AdminCatalogFormHelpers.MUTED_COLOR)
+		order_lbl.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+
+		var name_edit := AdminCatalogFormHelpers.make_text_cell(str(entry.get("displayName", "")))
+		var s_enabled := AdminCatalogFormHelpers.make_bool_cell(bool(entry.get("isEnabled", true)))
+
+		r_hb.add_child(order_lbl)
+		r_hb.add_child(name_edit)
+		r_hb.add_child(s_enabled)
+
+		_connect_change(name_edit, "text_changed", func(_v: Variant) -> void: changed.emit())
+		_connect_change(s_enabled, "toggled", func(_v: Variant) -> void: changed.emit())
+
+		_suffix_controls.append({
+			"id": entry.get("id", 0),
+			"suffix_order": int(entry.get("suffixOrder", i + 1)),
+			"name_edit": name_edit,
+			"enabled_cb": s_enabled,
+		})
+
+
+func _collect_world_setting() -> Dictionary:
+	var territories_arr: Array = []
+	for ctrl: Dictionary in _territory_controls:
+		territories_arr.append({
+			"id": ctrl["id"],
+			"territoryOrder": ctrl["territory_order"],
+			"displayName": (ctrl["name_edit"] as LineEdit).text,
+			"isEnabled": (ctrl["enabled_cb"] as CheckBox).button_pressed,
+		})
+
+	var suffixes_arr: Array = []
+	for ctrl: Dictionary in _suffix_controls:
+		suffixes_arr.append({
+			"id": ctrl["id"],
+			"suffixOrder": ctrl["suffix_order"],
+			"displayName": (ctrl["name_edit"] as LineEdit).text,
+			"isEnabled": (ctrl["enabled_cb"] as CheckBox).button_pressed,
+		})
+
+	return {
+		"id": _world_ctrls.get("id", 0),
+		"zonesPerTerritory": int((_world_ctrls["zones_spin"] as SpinBox).value),
+		"isEnabled": (_world_ctrls["enabled_cb"] as CheckBox).button_pressed,
+		"territories": territories_arr,
+		"zoneSuffixes": suffixes_arr,
+	}
+
+
+# ── Layout Helpers ────────────────────────────────────────────
+
+static func _make_row_margin() -> MarginContainer:
+	var m := MarginContainer.new()
+	m.add_theme_constant_override("margin_left", 6)
+	m.add_theme_constant_override("margin_right", 6)
+	m.add_theme_constant_override("margin_top", 3)
+	m.add_theme_constant_override("margin_bottom", 3)
+	return m
+
+
+static func _make_small_margin() -> MarginContainer:
+	var m := MarginContainer.new()
+	m.add_theme_constant_override("margin_left", 4)
+	m.add_theme_constant_override("margin_right", 4)
+	m.add_theme_constant_override("margin_top", 2)
+	m.add_theme_constant_override("margin_bottom", 2)
+	return m
+
+
+static func _connect_change(node: Node, signal_name: String, callable: Callable) -> void:
+	node.connect(signal_name, callable)


### PR DESCRIPTION
closes #162

## 變更內容

完成所有剩餘 7 個 Section 的表格化 UI，AdminCatalog 現已全面告別純 JSON 編輯器。

### 新增 Renderer 檔案

| 檔案 | Section | 說明 |
|------|---------|------|
| `AdminCatalogDungeonsRenderer.gd` | Dungeons | 3 行區塊：基本資訊 + 11 個數值欄位 + 圖片描述 |
| `AdminCatalogAchievementsRenderer.gd` | Achievements | 成就區塊 + 獎勵子表（含 duplicateRewardType null 處理） |
| `AdminCatalogShopRenderer.gd` | Shop | 3 Tab（Categories / Groups / Bundles）；Bundle 含獎勵子表 |
| `AdminCatalogStagesRenderer.gd` | Stages | 2 Tab（StageSetting 含 ZoneType 下拉 / WorldSetting 含多層子表） |
| `AdminCatalogScooperRenderer.gd` | Scooper | 3 Tab（IdleSetting + 3 子表 / Equipment 區塊 / Abilities 表格） |
| `AdminCatalogCatsRenderer.gd` | Cats | 3 行貓咪區塊 + PassiveSkills / ActiveSkills 子表 |
| `AdminCatalogSkillsRenderer.gd` | Skills | 技能區塊 + Effects 子表（nullable 欄位處理）+ RankScaling 子表 |

### 修改檔案

- `AdminCatalogFormHelpers.gd` — 新增 9 個 Enum 選項陣列（STAT_TYPE、VALUE_MODE、TARGET_SCOPE 等）
- `AdminCatalogScene.gd` — `_create_renderer()` 補齊全部 12 個 section case

## 測試重點

- 各 Section 資料載入後欄位正確顯示
- 儲存後 `get_data()` 回傳符合後端 DTO 格式（camelCase、enum 字串）
- Nullable 欄位（rewardReferenceId、duplicateRewardType、statType、durationSeconds、maxStack）在「無效值」時正確輸出 null
- 未覆蓋 Section 仍 fallback 至 JSON TextEdit（本 PR 已全數覆蓋，此路徑保留備用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)