### PR TITLE
fix:Demo 版隱藏付費商店入口

### DIFF
--- a/config/runtime_config.demo.example.json
+++ b/config/runtime_config.demo.example.json
@@ -1,7 +1,8 @@
 {
   "environment": "Production",
   "feature_flags": {
-    "oauth_enabled": false
+    "oauth_enabled": false,
+    "paid_shop_enabled": false
   },
   "environments": {
     "Production": {

--- a/config/runtime_config.example.json
+++ b/config/runtime_config.example.json
@@ -1,7 +1,8 @@
 {
   "environment": "Local",
   "feature_flags": {
-    "oauth_enabled": true
+    "oauth_enabled": true,
+    "paid_shop_enabled": true
   },
   "environments": {
     "Local": {

--- a/config/runtime_config.local.example.json
+++ b/config/runtime_config.local.example.json
@@ -1,6 +1,7 @@
 {
   "api_base_url": "http://localhost:5000/api",
   "feature_flags": {
-    "oauth_enabled": true
+    "oauth_enabled": true,
+    "paid_shop_enabled": true
   }
 }

--- a/docs/gdd/18_frontend_architecture.md
+++ b/docs/gdd/18_frontend_architecture.md
@@ -1,6 +1,6 @@
 # 18. Frontend Architecture
 
-> Last updated: 2026-04-19
+> Last updated: 2026-04-23
 > Audience: AI agents and engineers modifying `MeowPartyDashClient`
 
 This document describes the current frontend architecture of `MeowPartyDashClient` so an agent can quickly find the correct edit location, understand data flow, and avoid reintroducing the old `ConfigScene = team config` assumption.
@@ -323,6 +323,9 @@ Key files:
 - runtime reads:
   - `res://config/runtime_config.json`
   - `res://config/runtime_config.local.json`
+- current release flags:
+  - `feature_flags.oauth_enabled`
+  - `feature_flags.paid_shop_enabled`
 
 ### 6.2 Persistent `user://` Storage
 

--- a/scripts/gamestate/RuntimeConfig.gd
+++ b/scripts/gamestate/RuntimeConfig.gd
@@ -4,6 +4,8 @@ extends RefCounted
 const CONFIG_PATH := "res://config/runtime_config.json"
 const LOCAL_CONFIG_PATH := "res://config/runtime_config.local.json"
 const DEFAULT_ENVIRONMENT := "Local"
+const FEATURE_FLAG_OAUTH_ENABLED := "oauth_enabled"
+const FEATURE_FLAG_PAID_SHOP_ENABLED := "paid_shop_enabled"
 
 
 static func get_config() -> Dictionary:
@@ -24,17 +26,25 @@ static func get_api_base_url(default_api_base_url: String) -> String:
 
 
 static func is_oauth_enabled() -> bool:
+	return _get_feature_flag(FEATURE_FLAG_OAUTH_ENABLED, true)
+
+
+static func is_paid_shop_enabled() -> bool:
+	return _get_feature_flag(FEATURE_FLAG_PAID_SHOP_ENABLED, true)
+
+
+static func _get_feature_flag(flag_name: String, default_value: bool) -> bool:
 	var config: Dictionary = get_config()
-	var top_level_value: Variant = _read_oauth_flag(config)
+	var top_level_value: Variant = _read_feature_flag(config, flag_name)
 	if top_level_value != null:
 		return bool(top_level_value)
 
 	var environment_config: Dictionary = _get_active_environment_config(config)
-	var environment_value: Variant = _read_oauth_flag(environment_config)
+	var environment_value: Variant = _read_feature_flag(environment_config, flag_name)
 	if environment_value != null:
 		return bool(environment_value)
 
-	return true
+	return default_value
 
 
 static func _get_active_environment_config(config: Dictionary) -> Dictionary:
@@ -46,14 +56,14 @@ static func _get_active_environment_config(config: Dictionary) -> Dictionary:
 	return environment_variant if environment_variant is Dictionary else {}
 
 
-static func _read_oauth_flag(config: Dictionary) -> Variant:
-	if config.has("oauth_enabled"):
-		return config.get("oauth_enabled")
+static func _read_feature_flag(config: Dictionary, flag_name: String) -> Variant:
+	if config.has(flag_name):
+		return config.get(flag_name)
 
 	var feature_flags_variant: Variant = config.get("feature_flags", {})
 	var feature_flags: Dictionary = feature_flags_variant if feature_flags_variant is Dictionary else {}
-	if feature_flags.has("oauth_enabled"):
-		return feature_flags.get("oauth_enabled")
+	if feature_flags.has(flag_name):
+		return feature_flags.get(flag_name)
 
 	return null
 

--- a/scripts/shop/ShopScene.gd
+++ b/scripts/shop/ShopScene.gd
@@ -1,5 +1,6 @@
 extends Control
 
+const RuntimeConfig = preload("res://scripts/gamestate/RuntimeConfig.gd")
 const OverlaySceneChrome = preload("res://scripts/ui/overlay_scene_chrome.gd")
 const UiPalette = preload("res://scripts/ui/ui_palette.gd")
 const SceneMenuTheme = preload("res://scripts/ui/scene_menu_theme.gd")
@@ -15,6 +16,7 @@ const TAB_DAILY := "daily_bundle"
 const TAB_COLLISION_COIN := "collision_coin"
 const TAB_DIAMOND_STORE := "diamond_store"
 const TAB_POINT := "point_bundle"
+const TRAP_POINTS_CURRENCY_ID := 3
 const COLLISION_COIN_ICON_PATH := "res://assets/sprites/ui/rewards/collision_coin.png"
 const ARENA_TICKET_ICON_PATH := "res://assets/sprites/ui/rewards/arena_ticket.png"
 
@@ -66,11 +68,14 @@ var _content_host: Control
 var _diamond_store_quantities: Dictionary = {}
 var _diamond_store_keypad_close: Callable = Callable()
 var _pending_bundle_purchase: Dictionary = {}
+var _paid_shop_enabled: bool = true
 
 @onready var _api_client = get_node("/root/ApiClient")
 
 
 func _ready() -> void:
+	_paid_shop_enabled = RuntimeConfig.is_paid_shop_enabled()
+	_normalize_active_tab()
 	_build_ui()
 	GameState.red_dot_state_changed.connect(_refresh_red_dots)
 	_refresh_content()
@@ -78,7 +83,7 @@ func _ready() -> void:
 
 func _build_ui() -> void:
 	var dock_items: Array = []
-	for item: Dictionary in CATEGORY_CONFIGS:
+	for item: Dictionary in _get_visible_category_configs():
 		var tab_key: String = str(item.get("key", ""))
 		var tab_meta: Dictionary = _get_tab_meta(tab_key)
 		dock_items.append({
@@ -127,6 +132,8 @@ func refresh_from_bootstrap(show_error_dialog: bool = true) -> void:
 
 
 func _switch_tab(tab_key: String) -> void:
+	if not _is_tab_visible(tab_key):
+		return
 	if _active_tab == tab_key:
 		return
 	_active_tab = tab_key
@@ -139,6 +146,7 @@ func _switch_secondary_item(item_key: String) -> void:
 
 
 func _refresh_content() -> void:
+	_normalize_active_tab()
 	_rebuild_content()
 	SceneSubmenuBar.refresh(_tab_buttons, _active_tab, {
 		"active_color": SceneMenuTheme.ACTIVE_COLOR,
@@ -177,6 +185,8 @@ func _rebuild_content() -> void:
 
 
 func _build_secondary_items(tab_key: String) -> Array:
+	if not _is_tab_visible(tab_key):
+		return []
 	match tab_key:
 		TAB_COLLISION_COIN:
 			return COLLISION_COIN_ITEMS
@@ -987,9 +997,11 @@ func _on_bundle_purchase_completed(success: bool, data: Variant, error: Dictiona
 
 
 func _should_redirect_to_collision_coin_store(error: Dictionary) -> bool:
+	if not _paid_shop_enabled:
+		return false
 	if str(error.get("code", "")) != "SHOP.NOT_ENOUGH_PAYMENT_CURRENCY":
 		return false
-	return int(_pending_bundle_purchase.get("priceCurrencyId", 0)) == 3
+	return int(_pending_bundle_purchase.get("priceCurrencyId", 0)) == TRAP_POINTS_CURRENCY_ID
 
 
 func _get_bundles_for_tab(tab_key: String) -> Array:
@@ -999,7 +1011,7 @@ func _get_bundles_for_tab(tab_key: String) -> Array:
 		if not (bundle_variant is Dictionary):
 			continue
 		var bundle: Dictionary = bundle_variant
-		if str(bundle.get("categoryType", "")).to_lower() == category_type:
+		if str(bundle.get("categoryType", "")).to_lower() == category_type and _is_bundle_visible(bundle):
 			result.append(bundle)
 	result.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
 		var a_sold_out: bool = bool(a.get("isSoldOut", false))
@@ -1022,6 +1034,8 @@ func _get_bundle_groups_for_tab(tab_key: String) -> Array:
 		var group: Dictionary = group_variant
 		if str(group.get("categoryType", "")).to_lower() != category_type:
 			continue
+		if not _has_visible_bundle_for_group(tab_key, str(group.get("groupId", ""))):
+			continue
 		result.append(group)
 	result.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
 		return int(a.get("sortOrder", 0)) < int(b.get("sortOrder", 0))
@@ -1039,8 +1053,11 @@ func _get_bundles_for_group(tab_key: String, group_id: String) -> Array:
 
 func _get_bundle_by_id(bundle_id: String) -> Dictionary:
 	for bundle_variant: Variant in GameState.shop_data.get("bundles", []):
-		if bundle_variant is Dictionary and str(bundle_variant.get("bundleId", "")) == bundle_id:
-			return bundle_variant
+		if not (bundle_variant is Dictionary):
+			continue
+		var bundle: Dictionary = bundle_variant
+		if str(bundle.get("bundleId", "")) == bundle_id and _is_bundle_visible(bundle):
+			return bundle
 	return {}
 
 
@@ -1169,6 +1186,48 @@ func _get_collision_coin_item(item_key: String) -> Dictionary:
 	return COLLISION_COIN_ITEMS[0]
 
 
+func _get_visible_category_configs() -> Array:
+	var result: Array = []
+	for config: Dictionary in CATEGORY_CONFIGS:
+		var tab_key: String = str(config.get("key", ""))
+		if _is_tab_visible(tab_key):
+			result.append(config)
+	return result
+
+
+func _normalize_active_tab() -> void:
+	if _is_tab_visible(_active_tab):
+		return
+	var visible_tabs: Array = _get_visible_category_configs()
+	if visible_tabs.is_empty():
+		_active_tab = TAB_VALUE
+		return
+	var first_visible_variant: Variant = visible_tabs[0]
+	var first_visible: Dictionary = first_visible_variant if first_visible_variant is Dictionary else {}
+	_active_tab = str(first_visible.get("key", TAB_VALUE))
+
+
+func _is_tab_visible(tab_key: String) -> bool:
+	if _paid_shop_enabled:
+		return true
+	return tab_key != TAB_COLLISION_COIN and tab_key != TAB_POINT
+
+
+func _is_bundle_visible(bundle: Dictionary) -> bool:
+	if _paid_shop_enabled:
+		return true
+	var price_currency_type: String = str(bundle.get("priceCurrencyType", "")).to_lower()
+	var price_currency_id: int = int(bundle.get("priceCurrencyId", 0))
+	return price_currency_type != "trappoints" and price_currency_id != TRAP_POINTS_CURRENCY_ID
+
+
+func _has_visible_bundle_for_group(tab_key: String, group_id: String) -> bool:
+	for bundle_variant: Variant in _get_bundles_for_tab(tab_key):
+		if bundle_variant is Dictionary and str(bundle_variant.get("groupId", "")) == group_id:
+			return true
+	return false
+
+
 func _get_category_type(tab_key: String) -> String:
 	for config: Dictionary in CATEGORY_CONFIGS:
 		if str(config.get("key", "")) == tab_key:
@@ -1213,6 +1272,11 @@ func _get_tab_meta(tab_key: String) -> Dictionary:
 
 
 func _get_shell_summary_left() -> String:
+	if not _paid_shop_enabled:
+		return UiText.SHOP_RESOURCE_FORMAT % [
+			GameState.player_data.diamonds,
+			GameState.player_data.trap_cages,
+		]
 	return UiText.SHOP_RESOURCE_WITH_COLLISION_COIN_FORMAT % [
 		GameState.player_data.diamonds,
 		GameState.player_data.trap_points,


### PR DESCRIPTION
## 變更摘要

- 在 `RuntimeConfig` 新增 `paid_shop_enabled` feature flag
- 當 demo 版關閉 paid shop 時，隱藏衝撞幣商店與點數禮包 tab
- 過濾所有以 `TrapPoints` 作為付款幣別的 bundle
- 缺少付款幣別時，不再導回衝撞幣商店
- 同步更新 runtime config 範例檔與前端架構文件

## 測試與確認

- 已確認本次 client staged scope 只包含 demo 付費商店關閉所需檔案
- 已確認 `runtime_config.example.json` / `runtime_config.demo.example.json` 已加入 `paid_shop_enabled`
- 目前環境未安裝 `godot`，因此尚未執行 headless 專案載入驗證

## 關聯 Issue

Closes #200