### PR TITLE
fix:補齊 release 環境未完成內容隱藏與提審檢查表

### DIFF
--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -36,6 +36,7 @@ jobs:
           mkdir -p config
           cat > config/runtime_config.json <<EOF
           {
+            "environment": "DEV",
             "api_base_url": "$FINAL_API_BASE_URL",
             "support_email": "",
             "support_url": "$SITE_BASE_URL/support/",

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -36,6 +36,7 @@ jobs:
           mkdir -p config
           cat > config/runtime_config.json <<EOF
           {
+            "environment": "Production",
             "api_base_url": "$FINAL_API_BASE_URL",
             "support_email": "",
             "support_url": "$SITE_BASE_URL/support/",

--- a/.github/workflows/deploy-sandbox.yml
+++ b/.github/workflows/deploy-sandbox.yml
@@ -36,6 +36,7 @@ jobs:
           mkdir -p config
           cat > config/runtime_config.json <<EOF
           {
+            "environment": "Sandbox",
             "api_base_url": "$FINAL_API_BASE_URL",
             "support_email": "",
             "support_url": "$SITE_BASE_URL/support/",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 - Prefer adding small, explicit UI state transitions instead of rewriting whole scene flows when only one stage changes.
 - The home flow now runs through `HomeShellScene` + `SceneNavigator`; keep `BattleScene` persistent there and open home subpages as overlays instead of replacing the battle scene with `change_scene_to_file(...)`.
 - Runtime API config is environment-specific: CI generates `config/runtime_config.json`, while local development may override with ignored `config/runtime_config.local.json`.
+- Deploy-generated `config/runtime_config.json` must include an explicit `environment` value. Runtime gating for unfinished content is allowed only in `Local` / `DEV`; `Sandbox` and `Production` builds must not silently fall back to `Local`.
 - Static support / privacy / account-deletion Pages content lives under `site/`; when deploy workflows export the Web build, they must also copy `site/` into `build/web/` so GitHub Pages keeps the game build and legal pages under the same published site.
 - Persistent local runtime data such as login session and player save files must use `user://`, not `res://`.
 - Treat auth/session `roleType`, `role`, and `permissions` as explicit API string contract values. Do not infer frontend authority from numeric enum ordering.

--- a/config/runtime_config.local.example.json
+++ b/config/runtime_config.local.example.json
@@ -1,4 +1,5 @@
 {
+  "environment": "Local",
   "api_base_url": "http://localhost:5000/api",
   "support_email": "",
   "support_url": "https://chiangdean.github.io/MeowPartyDashClient/support/",

--- a/docs/gdd/18_frontend_architecture.md
+++ b/docs/gdd/18_frontend_architecture.md
@@ -331,6 +331,10 @@ Key files:
   - `support_url`
   - `privacy_policy_url`
   - `account_deletion_url`
+- environment behavior:
+  - `RuntimeConfig` normalizes `Local` / `DEV` / `Sandbox` / `Production`
+  - unfinished placeholder content is visible only in `Local` / `DEV`
+  - CI-generated `config/runtime_config.json` must include `environment`, otherwise release builds would fall back to `Local`
 
 ### 6.2 Persistent `user://` Storage
 

--- a/docs/release/release_checklist.md
+++ b/docs/release/release_checklist.md
@@ -1,0 +1,92 @@
+# MeowPartyDash Release Checklist
+
+更新日期：2026-04-23
+
+目前策略：先準備 `demo 版` 上架，不接正式金流；等 Google / Apple 開發者帳號申請完成後，再補 `Google Play Billing` / `Apple In-App Purchase`。
+
+## P0 必做
+
+### 1. 發版技術
+- [x] 遊戲名稱統一為 `喵喵衝撞派對` / `Meow Party Dash!`
+- [x] 補上 runtime config helper，支援 release feature flags
+- [x] `feature_flags.oauth_enabled` 可在 demo 版關閉 OAuth 入口
+- [x] 本地 demo 設定檔 `runtime_config.local.json` 已關閉 OAuth
+- [x] 已產出 demo 用 App icon 素材（1024 / 512 / 256 / 192 / 180 / 152）
+- [ ] 補齊 Android export preset、package name、version code、keystore
+- [ ] 補齊 iOS export preset、bundle id、signing、provisioning
+- [ ] 補齊正式 mobile API base URL 與 production / sandbox config
+- [ ] 補齊自動化 build / release 流程
+
+### 2. 付費與商店政策
+- [x] 先採用 `跳過正式金流` 的 demo 策略
+- [x] client 已支援 `feature_flags.paid_shop_enabled`
+- [x] demo / local config 已預設 `paid_shop_enabled = false`
+- [x] demo 版會隱藏付費商店入口
+  - 隱藏 `衝撞幣商店` tab
+  - 隱藏 `點數禮包` tab
+  - 隱藏所有以 `TrapPoints` 作為付款幣別的 bundle
+- [x] backend 已支援 `Shop:PaidShopEnabled`
+- [x] API 預設 `Shop:PaidShopEnabled = false`
+- [x] backend 會拒絕 `POST /api/shop/trap-points/purchase`
+- [x] backend 會拒絕所有以 `TrapPoints` 作為付款幣別的 bundle 購買
+- [x] backend shop overview 會隱藏以 `TrapPoints` 作為付款幣別的 bundle
+- [ ] 正式接入 `Google Play Billing`
+- [ ] 正式接入 `Apple In-App Purchase`
+- [ ] 補 receipt / purchase token 驗證、補單、重複發貨防護、訂單紀錄
+- [ ] 建立商店商品、merchant / payments profile、sandbox / test 帳號
+
+### 3. 帳號、登入與法規
+- [x] demo 版先隱藏 OAuth 入口，避免 iOS / Apple OAuth 未就緒阻塞上架 demo
+- [x] `ConfigScene` 已補支援與法規卡片骨架
+- [x] runtime config 已支援 `support_email` / `support_url` / `privacy_policy_url` / `account_deletion_url`
+- [x] app 內已補刪除帳號入口
+- [x] backend 已補 `DELETE /api/profile/me` soft delete
+- [x] backend 已補 active-user middleware，刪帳後舊 session 會被擋下
+- [x] 已補隱私政策 URL
+- [x] 已補帳號刪除流程（app 內入口 + web 入口 + 後端處理）
+- [x] 已補官方網站 / 支援頁 URL（GitHub Pages）
+- [ ] 補正式 support email
+- [ ] Apple production OAuth 參數補齊
+- [ ] iOS OAuth UX 改為 deep link / universal link / custom URL scheme
+
+### 4. 內容完成度
+- [x] `Local / DEV` 保留未完成內容入口，`Sandbox / Production` 自動隱藏
+- [x] 已清掉 reviewer 會直接碰到的 placeholder / 半成品入口（目前先隱藏 `活動 > 限時活動`）
+- [ ] 補齊必要素材與 fallback，避免缺圖或空資料
+
+### 5. 商店素材與提審資料
+- [ ] 準備 Play / App Store 截圖、宣傳圖、短描述、完整描述
+- [ ] 填寫 Google Play `Data safety`
+- [ ] 填寫 Apple `App Privacy`
+- [ ] 準備年齡分級資料
+- [ ] 準備 reviewer / test account 與審核說明
+
+### 6. 提審前驗收
+- [ ] Android 真機 smoke test
+- [ ] iPhone / iPad 真機 smoke test
+- [ ] 驗證安裝、登入、主流程、斷線重連、背景切回、更新覆蓋安裝
+- [ ] Google Play 新帳號若需要，先跑 closed test
+- [ ] 確認 target API、iOS SDK、Xcode 版本符合當前要求
+
+## 這次已完成的實作
+- `MeowPartyDashClient/scripts/gamestate/RuntimeConfig.gd`
+  - 新增 `paid_shop_enabled` feature flag
+- `MeowPartyDashClient/scripts/ActivityScene.gd`
+  - `Local / DEV` 保留 `限時活動` 入口，`Sandbox / Production` 自動隱藏
+- `MeowPartyDashClient/.github/workflows/deploy-*.yml`
+  - deploy 生成的 `runtime_config.json` 現在會寫入明確 `environment`
+- `MeowPartyDashClient/scripts/shop/ShopScene.gd`
+  - demo 版隱藏付費商店入口與 trap-point bundle
+- `MeowPartyDashClient/config/runtime_config*.json`
+  - demo / local config 預設關閉 paid shop
+- `MeowPartyDashAPI/MeowPartyDashAPI.Infrastructure/Shop/ShopOptions.cs`
+  - 新增 `Shop:PaidShopEnabled`
+- `MeowPartyDashAPI/MeowPartyDashAPI.Application/Services/Shop/ShopService.cs`
+  - paid shop 關閉時拒絕暫時金流與 trap-point bundle
+- `MeowPartyDashAPI/appsettings*.json`
+  - 預設關閉 paid shop
+
+## 目前最務實的下一步
+1. 先完成 Android demo 匯出與 closed test。
+2. 同步補齊隱私政策、帳號刪除頁、support 聯絡方式。
+3. 開發者帳號核准後，再接正式 Billing / IAP。

--- a/scripts/ActivityScene.gd
+++ b/scripts/ActivityScene.gd
@@ -12,30 +12,37 @@ var _content_scroll: ScrollContainer
 var _scroll_box: VBoxContainer
 var _permanent_content: Control
 var _limited_content: Control
+var _show_unfinished_content: bool = true
 
 
 func _ready() -> void:
+	_show_unfinished_content = RuntimeConfig.should_show_unfinished_content()
+	if not _show_unfinished_content and _active_tab == "limited":
+		_active_tab = "permanent"
 	_build_ui()
 	GameState.red_dot_state_changed.connect(_refresh_red_dots)
 
 
 func _build_ui() -> void:
+	var dock_items: Array[Dictionary] = [
+		{
+			"key": "permanent",
+			"label": UiText.ACTIVITY_TAB_PERMANENT,
+			"shell_description": UiText.ACTIVITY_PAGE_DESC,
+			"shell_summary_right": Callable(self, "_build_tab_summary_right").bind("permanent"),
+		},
+	]
+	if _show_unfinished_content:
+		dock_items.append({
+			"key": "limited",
+			"label": UiText.ACTIVITY_TAB_LIMITED,
+			"shell_description": UiText.ACTIVITY_LIMITED_EMPTY_BODY,
+			"shell_summary_right": Callable(self, "_build_tab_summary_right").bind("limited"),
+		})
+
 	var chrome: Dictionary = OverlaySceneChrome.build(self, "activity", Callable(self, "_on_back_pressed"), {
 		"show_dock": true,
-		"dock_items": [
-			{
-				"key": "permanent",
-				"label": UiText.ACTIVITY_TAB_PERMANENT,
-				"shell_description": UiText.ACTIVITY_PAGE_DESC,
-				"shell_summary_right": Callable(self, "_build_tab_summary_right").bind("permanent"),
-			},
-			{
-				"key": "limited",
-				"label": UiText.ACTIVITY_TAB_LIMITED,
-				"shell_description": UiText.ACTIVITY_LIMITED_EMPTY_BODY,
-				"shell_summary_right": Callable(self, "_build_tab_summary_right").bind("limited"),
-			},
-		],
+		"dock_items": dock_items,
 		"active_key": _active_tab,
 		"button_pressed": Callable(self, "_switch_tab"),
 		"button_height": 52.0,
@@ -61,6 +68,8 @@ func _build_ui() -> void:
 
 
 func _switch_tab(tab_key: String) -> void:
+	if tab_key == "limited" and not _show_unfinished_content:
+		return
 	if _active_tab == tab_key:
 		return
 	_active_tab = tab_key

--- a/scripts/gamestate/RuntimeConfig.gd
+++ b/scripts/gamestate/RuntimeConfig.gd
@@ -29,6 +29,20 @@ static func get_api_base_url(default_api_base_url: String) -> String:
 	return str(api_base_url).rstrip("/")
 
 
+static func get_environment_name() -> String:
+	var config: Dictionary = get_config()
+	return _resolve_environment_name(config)
+
+
+static func is_local_or_dev_environment() -> bool:
+	var environment_name: String = get_environment_name()
+	return environment_name == "Local" or environment_name == "DEV"
+
+
+static func should_show_unfinished_content() -> bool:
+	return is_local_or_dev_environment()
+
+
 static func is_oauth_enabled() -> bool:
 	return _get_feature_flag(FEATURE_FLAG_OAUTH_ENABLED, true)
 
@@ -82,12 +96,16 @@ static func _get_config_string(key_name: String, default_value: String = "") -> 
 
 
 static func _get_active_environment_config(config: Dictionary) -> Dictionary:
-	var configured_environment: Variant = config.get("environment", DEFAULT_ENVIRONMENT)
-	var environment_name: String = _normalize_environment_name(str(configured_environment))
+	var environment_name: String = _resolve_environment_name(config)
 	var environments_variant: Variant = config.get("environments", {})
 	var environments: Dictionary = environments_variant if environments_variant is Dictionary else {}
 	var environment_variant: Variant = environments.get(environment_name, {})
 	return environment_variant if environment_variant is Dictionary else {}
+
+
+static func _resolve_environment_name(config: Dictionary) -> String:
+	var configured_environment: Variant = config.get("environment", DEFAULT_ENVIRONMENT)
+	return _normalize_environment_name(str(configured_environment))
 
 
 static func _read_feature_flag(config: Dictionary, flag_name: String) -> Variant:


### PR DESCRIPTION
Closes #204

## 變更內容
- `RuntimeConfig` 補上明確環境判斷與未完成內容 gating helper
- `ActivityScene` 改為只有 `Local / DEV` 顯示 `限時活動` tab，`Sandbox / Production` 自動隱藏
- deploy workflow 生成的 `runtime_config.json` 會寫入明確 `environment`
- `runtime_config.local.example.json` 補上 `environment: Local`
- `docs/release/release_checklist.md` 納入 repo，保留目前可執行的上架前檢查表
- 同步更新 `docs/gdd/18_frontend_architecture.md` 與 `AGENTS.md`

## 驗證
- `git diff --check`
- `ConvertFrom-Json` 驗證 runtime config example JSON
- 靜態檢查 `ActivityScene.gd` / `RuntimeConfig.gd` 的環境 gating 流程

## 這次刻意不包含
- `MeowPartyDashAPI`，因為目前沒有新變更
- 根目錄的 `release_checklist.md`，改為納入 repo 內版 `docs/release/release_checklist.md`
- 實際 Godot 執行驗證，因為本機沒有可用的 `godot` 指令

## 風險 / 待補
- 第 4 段的素材與 fallback 尚未補完
- 目前先隱藏 `活動 > 限時活動`，其他未完成內容仍需要逐項盤點