### PR TITLE
fix:補齊戰鬥缺動畫 fallback，避免缺圖時出現空動畫

### DIFF
--- a/docs/gdd/22_missing_art_asset_manifest.md
+++ b/docs/gdd/22_missing_art_asset_manifest.md
@@ -14,6 +14,7 @@
 
 - 黑貓素材已經開始補齊，故本文件不重複列黑貓。
 - 其餘 5 隻正式貓咪角色，仍缺完整角色定稿、頭像、戰鬥動畫。
+- client runtime 已補戰鬥動畫 fallback；當 `collide / knockback / stagger / skill / death_fly` 缺圖時，會先回退到現有 `run / idle` 類動畫，避免正式流程出現空動畫。
 - 多數功能頁仍為純色背景，缺 UI 背景圖。
 - API / DB 已經定義 `image_path` 的 catalog 圖資，目前前端多數尚未補圖或尚未實際套用。
 - Mail / Chat / Shop / Scooper / Arena Reward / Dungeon Overview 等流程仍偏文字化，缺少對應 icon 或卡面圖。
@@ -863,5 +864,4 @@
   - 檔名
   - 中文 prompt
   - 對應前端使用場景
-
 

--- a/scripts/ui/asset_resolver.gd
+++ b/scripts/ui/asset_resolver.gd
@@ -195,6 +195,15 @@ const CAT_BATTLE_LOOPING_ANIMATIONS := {
 	"skill": false,
 	"death_fly": false,
 }
+const CAT_BATTLE_ANIMATION_FALLBACKS := {
+	"idle": ["run"],
+	"run": ["idle"],
+	"collide": ["run", "idle"],
+	"knockback": ["stagger", "collide", "run", "idle"],
+	"stagger": ["knockback", "collide", "run", "idle"],
+	"skill": ["run", "collide", "idle"],
+	"death_fly": ["knockback", "stagger", "collide", "run", "idle"],
+}
 
 const GACHA_FRAMES := {
 	"common": UI_ROOT + "gacha/rarity_common_frame_v1.png",
@@ -365,6 +374,30 @@ static func resolve_cat_battle_idle(cat_id: String) -> Texture2D:
 
 
 static func resolve_cat_battle_animation_path(cat_id: String, animation_name: String) -> String:
+	return _resolve_cat_battle_animation_path_with_fallback(cat_id, animation_name, [])
+
+
+static func _resolve_cat_battle_animation_path_with_fallback(cat_id: String, animation_name: String, visited: Array[String]) -> String:
+	if visited.has(animation_name):
+		return ""
+
+	var direct_path: String = _resolve_cat_battle_animation_path_exact(cat_id, animation_name)
+	if direct_path != "":
+		return direct_path
+
+	var next_visited: Array[String] = visited.duplicate()
+	next_visited.append(animation_name)
+	var fallback_variant: Variant = CAT_BATTLE_ANIMATION_FALLBACKS.get(animation_name, [])
+	var fallback_names: Array = fallback_variant if fallback_variant is Array else []
+	for fallback_name_variant: Variant in fallback_names:
+		var fallback_name: String = str(fallback_name_variant)
+		var fallback_path: String = _resolve_cat_battle_animation_path_with_fallback(cat_id, fallback_name, next_visited)
+		if fallback_path != "":
+			return fallback_path
+	return ""
+
+
+static func _resolve_cat_battle_animation_path_exact(cat_id: String, animation_name: String) -> String:
 	var suffixes: Variant = CAT_BATTLE_ANIMATION_SUFFIXES.get(animation_name, [])
 	if not (suffixes is Array):
 		return ""


### PR DESCRIPTION
Closes #206

## 變更內容
- `AssetResolver.resolve_cat_battle_animation_path(...)` 改為支援 fallback chain
- 缺少 `collide / knockback / stagger / skill / death_fly` 時，會先回退到同貓咪現有的 `run / idle` 類動畫
- `docs/gdd/22_missing_art_asset_manifest.md` 補註記，說明 runtime 已有戰鬥動畫 fallback，但素材缺口仍存在

## 驗證
- `git diff --check`
- 檔案層級驗證每隻貓咪的 `idle / run / collide / knockback / stagger / skill / death_fly` 都能解析到實際存在的 sheet

## 這次刻意不包含
- 真正新增缺漏動畫素材
- 其他 icon / 背景 / catalog 圖資的 fallback
- `MeowPartyDashAPI`，因為沒有新變更

## 風險 / 待補
- fallback 只能避免空動畫，不代表動作語意完全正確
- 第 4 段的其他素材與 fallback 仍要繼續盤點