### PR TITLE
fix:補齊缺圖 fallback 與 release checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
 - The home flow now runs through `HomeShellScene` + `SceneNavigator`; keep `BattleScene` persistent there and open home subpages as overlays instead of replacing the battle scene with `change_scene_to_file(...)`.
 - Runtime API config is environment-specific: CI generates `config/runtime_config.json`, while local development may override with ignored `config/runtime_config.local.json`.
 - Static support / privacy / account-deletion Pages content lives under `site/`; when deploy workflows export the Web build, they must also copy `site/` into `build/web/` so GitHub Pages keeps the game build and legal pages under the same published site.
+- For catalog-driven item art, shop/backpack reward slots, and feature preview images, prefer `AssetResolver` fallback helpers over raw `load_texture(...)` so release builds degrade to placeholders instead of blank UI when art is missing.
 - Persistent local runtime data such as login session and player save files must use `user://`, not `res://`.
 - Treat auth/session `roleType`, `role`, and `permissions` as explicit API string contract values. Do not infer frontend authority from numeric enum ordering.
 - Preserve original file encoding when editing client files with Chinese text. Treat repo GDScript/docs as `UTF-8`, and avoid shell rewrite flows that can re-encode text into mojibake such as `é...`, `?��`, or corrupted `%` lines.

--- a/docs/gdd/22_missing_art_asset_manifest.md
+++ b/docs/gdd/22_missing_art_asset_manifest.md
@@ -17,6 +17,7 @@
 - 多數功能頁仍為純色背景，缺 UI 背景圖。
 - API / DB 已經定義 `image_path` 的 catalog 圖資，目前前端多數尚未補圖或尚未實際套用。
 - Mail / Chat / Shop / Scooper / Arena Reward / Dungeon Overview 等流程仍偏文字化，缺少對應 icon 或卡面圖。
+- 前端 runtime 已補上 catalog 圖示、商店/背包圖示、功能頁預覽圖、背景圖的 fallback；缺圖時不再直接留白，但正式美術補齊需求仍然存在。
 
 ## 盤點依據
 
@@ -863,5 +864,4 @@
   - 檔名
   - 中文 prompt
   - 對應前端使用場景
-
 

--- a/docs/release/release_checklist.md
+++ b/docs/release/release_checklist.md
@@ -1,0 +1,82 @@
+# 喵喵衝撞派對 Release Checklist
+
+Last updated: 2026-04-23
+
+## P0 必做
+
+### 1. 發版技術
+
+- [x] 遊戲名稱已對齊：`喵喵衝撞派對` / `Meow Party Dash!`
+- [x] 已補 runtime config helper 與 release feature flag 流程
+- [x] 已補 `feature_flags.oauth_enabled`，demo 版可完整隱藏 OAuth 入口
+- [x] 已建立本地 demo 設定檔，方便 local 開發直接關閉 OAuth
+- [x] 已產出 demo 版 App icon 素材
+- [x] 已補 `environment` runtime config 流程，`Sandbox / Production` 不再誤判成 `Local`
+- [ ] 補 Android export preset、package name、version code、keystore
+- [ ] 補 iOS export preset、bundle id、signing、provisioning
+- [ ] 補正式 mobile API base URL 與 production / sandbox config
+- [ ] 補自動化 build / release 流程
+
+### 2. 付費與商店政策
+
+- [x] 已決定 demo 版先跳過正式金流
+- [x] Client 已補 `feature_flags.paid_shop_enabled`
+- [x] Demo / Local config 已預設 `paid_shop_enabled = false`
+- [x] Demo 版已隱藏付費商店入口與 `TrapPoints` 付款 bundle
+- [x] Backend 已補 `Shop:PaidShopEnabled`
+- [x] API 已在 paid shop 關閉時拒絕 `trap-points/purchase`
+- [x] API overview 已隱藏 trap-points 付費 bundle
+- [ ] 正式接 `Google Play Billing`
+- [ ] 正式接 `Apple In-App Purchase`
+- [ ] 補 receipt / purchase token 驗證、補單、重複發貨防護
+- [ ] 補 merchant / payments profile / sandbox 測試設定
+
+### 3. 帳號、登入與法規
+
+- [x] Demo 版已隱藏 OAuth 入口，先不依賴 iOS / Apple 開發者帳號
+- [x] 設定中心已補 `支援 / 隱私政策 / 刪除帳號` 入口
+- [x] Runtime config 已支援 `support_email`、`support_url`、`privacy_policy_url`、`account_deletion_url`
+- [x] App 內已可發起刪帳流程
+- [x] Backend 已補 `DELETE /api/profile/me` soft delete
+- [x] Backend 已補 active-user session guard，已刪除帳號不再沿用舊 session
+- [x] 已準備 GitHub Pages 版 `support / privacy / account-deletion` 靜態頁
+- [ ] 補正式 support email
+- [ ] 補 Apple production OAuth 設定
+- [ ] iOS OAuth 改成 deep link / universal link / custom URL scheme 回跳流程
+
+### 4. 內容完成度
+
+- [x] `Local / DEV` 保留未完成內容；`Sandbox / Production` 會隱藏 reviewer 不該看到的入口
+- [x] Reviewer 容易碰到的未完成活動入口已先隱藏
+- [x] 已補 runtime fallback，缺圖時不再直接留白：
+  - catalog icon
+  - 商店 / 背包 / 郵件 / 競技場獎勵 icon
+  - 常駐活動 / 地城 / Scooper preview 圖
+  - 功能頁背景圖
+- [ ] 正式素材仍需持續補齊，fallback 只能保底不能取代正式美術
+
+### 5. 商店素材與提審資料
+
+- [ ] 準備 Google Play / App Store 截圖、宣傳圖、商店 icon 主視覺
+- [ ] 補商店短描述 / 完整描述 / 關鍵賣點
+- [ ] 填 Google Play `Data safety`
+- [ ] 填 Apple `App Privacy`
+- [ ] 準備 reviewer / test account 與操作說明
+- [ ] 準備年齡分級與商店 metadata
+
+### 6. 提審前驗收
+
+- [ ] Android 真機 smoke test
+- [ ] iPhone / iPad 真機 smoke test
+- [ ] 驗證登入、刪帳、背景切換、斷線重連、首次載入、低網速流程
+- [ ] 跑 Google Play closed test
+- [ ] 確認 target API、iOS SDK、Xcode / export toolchain 符合上架要求
+
+## 可繼續由工程處理
+
+- [ ] 補更多 repo 內 release 文件與提審文件
+- [ ] 產商店文案草稿：短描述、完整描述、更新說明、審核備註
+- [ ] 產 `Data safety` / `App Privacy` 初稿
+- [ ] 補 Android demo export 骨架與版本號規則
+- [ ] 補更多缺圖 fallback 與 placeholder 清理
+- [ ] 整理 closed test / TestFlight 驗收清單

--- a/scripts/MailScene.gd
+++ b/scripts/MailScene.gd
@@ -594,9 +594,7 @@ func _build_attachment_slot(attachment_variant: Variant) -> Control:
 	var name_label: Label = slot.get_node("ItemNameLabel") as Label
 	var qty_label: Label = slot.get_node("CountLabel") as Label
 	var quantity: int = int(attachment.get("quantity", 0))
-	var texture: Texture2D = AssetResolver.load_texture(
-		AssetResolver.resolve_catalog_path(str(attachment.get("imagePath", "")))
-	)
+	var texture: Texture2D = AssetResolver.resolve_catalog_texture(str(attachment.get("imagePath", "")))
 	var display_name: String = str(attachment.get("displayName", attachment.get("rewardType", "")))
 
 	if texture != null:

--- a/scripts/activity/PermanentActivityContent.gd
+++ b/scripts/activity/PermanentActivityContent.gd
@@ -121,10 +121,10 @@ func _make_entry_card(entry_data: Dictionary) -> Control:
 	action_button.text = str(entry_data.get("button_text", UiText.ACTIVITY_DEFAULT_BUTTON))
 	UiPalette.apply_button_kind(action_button, "primary")
 
-	var art_path: String = str(entry_data.get("art_path", ""))
-	preview_image.texture = AssetResolver.load_texture(art_path)
-
 	var entry_key: String = str(entry_data.get("key", ""))
+	var art_path: String = str(entry_data.get("art_path", ""))
+	preview_image.texture = AssetResolver.resolve_preview_texture(art_path, entry_key)
+
 	action_button.pressed.connect(_emit_entry_pressed.bind(entry_key))
 	_entry_buttons[entry_key] = action_button
 

--- a/scripts/arenaScene/ArenaScene.gd
+++ b/scripts/arenaScene/ArenaScene.gd
@@ -869,9 +869,7 @@ func _apply_reward_slot(slot: Control, reward_entry: Dictionary) -> void:
 	var name_label: Label = slot.get_node("ItemNameLabel") as Label
 	var qty_label: Label = slot.get_node("CountLabel") as Label
 
-	var texture: Texture2D = AssetResolver.load_texture(
-		AssetResolver.resolve_catalog_path(str(reward_entry.get("path", "")))
-	)
+	var texture: Texture2D = AssetResolver.resolve_catalog_texture(str(reward_entry.get("path", "")))
 	if texture != null:
 		icon.texture = texture
 		icon.visible = true

--- a/scripts/arenaScene/arena_scene_helpers.gd
+++ b/scripts/arenaScene/arena_scene_helpers.gd
@@ -128,9 +128,9 @@ static func resolve_rank_texture(image_path: Variant, rank_key: Variant) -> Text
 		return badge_texture
 
 	var normalized_rank_key: String = str(rank_key if rank_key != null else "").strip_edges().to_lower()
-	if normalized_rank_key == "":
-		return null
-	return AssetResolver.load_texture("res://assets/sprites/ui/arena_ranks/%s.png" % normalized_rank_key)
+	if normalized_rank_key != "":
+		return AssetResolver.resolve_texture_or_placeholder("res://assets/sprites/ui/arena_ranks/%s.png" % normalized_rank_key)
+	return AssetResolver.resolve_placeholder_icon()
 
 
 static func resolve_cat_icon_by_catalog_id(cat_catalog_id: int) -> Texture2D:

--- a/scripts/backpack/backpack_scene.gd
+++ b/scripts/backpack/backpack_scene.gd
@@ -146,9 +146,7 @@ func _make_item_card(item: Dictionary) -> Control:
 	var overlay_mask: TextureRect = slot.get_node("OverlayMask") as TextureRect
 	var name_label: Label = slot.get_node("ItemNameLabel") as Label
 	var qty_label: Label = slot.get_node("CountLabel") as Label
-	var texture: Texture2D = AssetResolver.load_texture(
-		AssetResolver.resolve_catalog_path(str(item.get("path", "")))
-	)
+	var texture: Texture2D = AssetResolver.resolve_catalog_texture(str(item.get("path", "")))
 
 	name_label.text = str(item.get("name", ""))
 	name_label.tooltip_text = name_label.text

--- a/scripts/dungeon/DungeonSceneUI.gd
+++ b/scripts/dungeon/DungeonSceneUI.gd
@@ -370,7 +370,7 @@ static func _bind_reward_slot(slot: Control, reward_items: Array[Dictionary], in
 	var reward_item: Dictionary = reward_items[index]
 	var reward_key: String = str(reward_item.get("key", ""))
 	var amount: int = int(reward_item.get("amount", 0))
-	var texture: Texture2D = AssetResolver.load_texture(AssetResolver.resolve_catalog_path(_get_reward_catalog_path(reward_key)))
+	var texture: Texture2D = AssetResolver.resolve_catalog_texture(_get_reward_catalog_path(reward_key))
 
 	frame.visible = true
 	icon.visible = texture != null
@@ -465,13 +465,13 @@ static func _resolve_dungeon_preview_texture(dungeon: Dictionary) -> Texture2D:
 
 	var dungeon_key: String = str(dungeon.get("key", "")).to_lower()
 	if DEFAULT_DUNGEON_ICON_BY_KEY.has(dungeon_key):
-		return AssetResolver.load_texture(str(DEFAULT_DUNGEON_ICON_BY_KEY[dungeon_key]))
+		return AssetResolver.resolve_preview_texture(str(DEFAULT_DUNGEON_ICON_BY_KEY[dungeon_key]), "dungeon")
 
 	for key: String in DEFAULT_DUNGEON_ICON_BY_KEY.keys():
 		if image_path.to_lower().contains(key):
-			return AssetResolver.load_texture(str(DEFAULT_DUNGEON_ICON_BY_KEY[key]))
+			return AssetResolver.resolve_preview_texture(str(DEFAULT_DUNGEON_ICON_BY_KEY[key]), "dungeon")
 
-	return null
+	return AssetResolver.resolve_background_texture("dungeon")
 
 
 static func _build_shell_summary_left(scene, dungeon_key: String) -> String:

--- a/scripts/scooper/scooper_tab_achievement.gd
+++ b/scripts/scooper/scooper_tab_achievement.gd
@@ -446,9 +446,7 @@ func _parse_reward_display(value: Variant) -> Dictionary:
 
 
 func _resolve_reward_texture(icon_path: String) -> Texture2D:
-	if icon_path == "":
-		return null
-	return AssetResolver.load_texture(AssetResolver.resolve_catalog_path(icon_path))
+	return AssetResolver.resolve_catalog_texture(icon_path)
 
 
 func _format_achievement_text(value: Variant) -> String:

--- a/scripts/scooper/scooper_tab_memory.gd
+++ b/scripts/scooper/scooper_tab_memory.gd
@@ -93,7 +93,7 @@ func _make_memory_card(scene: Control, item: Dictionary) -> Control:
 	preview_bg.color = accent
 
 	var photo_path: String = AssetResolver.resolve_catalog_path(item.get("imagePath", ""))
-	var texture: Texture2D = AssetResolver.load_texture(photo_path)
+	var texture: Texture2D = AssetResolver.resolve_preview_texture(photo_path, "scooper")
 	preview_image.texture = texture
 	preview_image.visible = texture != null
 

--- a/scripts/scooper/scooper_tab_treasure.gd
+++ b/scripts/scooper/scooper_tab_treasure.gd
@@ -79,7 +79,7 @@ func _make_treasure_card(scene: Control, item: Dictionary) -> Control:
 	var qty: Label = panel.get_node("Margin/ContentCanvas/QuantityLabel") as Label
 	var desc: Label = panel.get_node("Margin/ContentCanvas/DescriptionLabel") as Label
 	var bonus: Label = panel.get_node("Margin/ContentCanvas/BonusLabel") as Label
-	var treasure_texture: Texture2D = AssetResolver.load_texture(AssetResolver.resolve_catalog_path(item.get("imagePath", "")))
+	var treasure_texture: Texture2D = AssetResolver.resolve_catalog_texture(item.get("imagePath", ""))
 	icon_rect.texture = treasure_texture
 	icon_rect.visible = treasure_texture != null
 	title_lbl.text = str(item.get("displayName", ""))

--- a/scripts/shop/ShopScene.gd
+++ b/scripts/shop/ShopScene.gd
@@ -362,7 +362,7 @@ func _build_shop_slot_cell(image_path: String, display_name: String, quantity: i
 	var overlay_mask: TextureRect = slot.get_node("OverlayMask") as TextureRect
 	var name_label: Label = slot.get_node("ItemNameLabel") as Label
 	var qty_label: Label = slot.get_node("CountLabel") as Label
-	var texture: Texture2D = AssetResolver.load_texture(image_path)
+	var texture: Texture2D = AssetResolver.resolve_texture_or_placeholder(image_path)
 
 	if texture != null:
 		icon.texture = texture
@@ -693,7 +693,7 @@ func _set_bundle_action_button_content(button: Button, label_text: String, icon_
 	center.add_child(row)
 
 	if icon_path != "":
-		var icon_texture: Texture2D = AssetResolver.load_texture(icon_path)
+		var icon_texture: Texture2D = AssetResolver.resolve_texture_or_placeholder(icon_path)
 		if icon_texture != null:
 			var icon: TextureRect = TextureRect.new()
 			icon.custom_minimum_size = SHOP_BUTTON_ICON_SIZE

--- a/scripts/ui/asset_resolver.gd
+++ b/scripts/ui/asset_resolver.gd
@@ -6,6 +6,9 @@ const BACKGROUND_SHADER := preload("res://scripts/ui/background_desaturate_shade
 const DEFAULT_PROFILE_AVATAR_ID := "black_cat"
 const CAT_CARD_FRAME := UI_ROOT + "cards/cat_card_frame_homey_v1.png"
 const CAT_CARD_EMPTY_SILHOUETTE := UI_ROOT + "cards/cat_card_empty_silhouette_v1.png"
+const DEFAULT_ICON_PLACEHOLDER_PATH := CAT_CARD_EMPTY_SILHOUETTE
+const DEFAULT_BACKGROUND_SLOT := "activity"
+const DEFAULT_GACHA_FRAME_KEY := "common"
 const CAT_CARD_SQUARE_FRAMES := {
 	"common": UI_ROOT + "cards/square/cat_card_square_common.png",
 	"uncommon": UI_ROOT + "cards/square/cat_card_square_common.png",
@@ -253,7 +256,7 @@ const SHOP_BUNDLES := {
 static func make_fullscreen_background(slot: String) -> TextureRect:
 	var background := TextureRect.new()
 	background.set_anchors_preset(Control.PRESET_FULL_RECT)
-	background.texture = load_texture(BACKGROUNDS.get(slot, ""))
+	background.texture = resolve_background_texture(slot)
 	background.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 	background.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
 	background.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_COVERED
@@ -276,6 +279,36 @@ static func load_texture(path: String) -> Texture2D:
 		return null
 	var texture := load(path)
 	return texture as Texture2D
+
+
+static func resolve_background_texture(slot: String) -> Texture2D:
+	var resolved_slot: String = slot.strip_edges().to_lower()
+	var texture: Texture2D = load_texture(str(BACKGROUNDS.get(resolved_slot, "")))
+	if texture != null:
+		return texture
+	return load_texture(str(BACKGROUNDS.get(DEFAULT_BACKGROUND_SLOT, "")))
+
+
+static func resolve_placeholder_icon() -> Texture2D:
+	return load_texture(DEFAULT_ICON_PLACEHOLDER_PATH)
+
+
+static func resolve_texture_or_placeholder(path: String) -> Texture2D:
+	var texture: Texture2D = load_texture(path)
+	if texture != null:
+		return texture
+	return resolve_placeholder_icon()
+
+
+static func resolve_catalog_texture(raw_path: Variant) -> Texture2D:
+	return resolve_texture_or_placeholder(resolve_catalog_path(raw_path))
+
+
+static func resolve_preview_texture(path: String, fallback_slot: String = DEFAULT_BACKGROUND_SLOT) -> Texture2D:
+	var texture: Texture2D = load_texture(path)
+	if texture != null:
+		return texture
+	return resolve_background_texture(fallback_slot)
 
 
 static func resolve_catalog_path(raw_path: Variant) -> String:
@@ -317,7 +350,7 @@ static func resolve_catalog_path(raw_path: Variant) -> String:
 
 
 static func resolve_cat_icon(cat_id: String) -> Texture2D:
-	return load_texture(CAT_ICONS.get(cat_id, ""))
+	return resolve_texture_or_placeholder(str(CAT_ICONS.get(cat_id, "")))
 
 
 static func get_profile_avatar_ids() -> Array[String]:
@@ -407,19 +440,23 @@ static func resolve_gacha_frame(result: Dictionary) -> Texture2D:
 	var rarity_key := str(result.get("rarityKey", "")).to_lower()
 	if rarity_key == "":
 		rarity_key = str(result.get("rarityType", "")).to_lower()
-	return load_texture(GACHA_FRAMES.get(rarity_key, ""))
+	var frame_path: String = str(GACHA_FRAMES.get(rarity_key, GACHA_FRAMES.get(DEFAULT_GACHA_FRAME_KEY, "")))
+	var frame_texture: Texture2D = load_texture(frame_path)
+	if frame_texture != null:
+		return frame_texture
+	return load_texture(str(GACHA_FRAMES.get(DEFAULT_GACHA_FRAME_KEY, "")))
 
 
 static func resolve_equipment_icon(item: Dictionary) -> Texture2D:
-	return load_texture(SCOOPER_EQUIPMENT.get(int(item.get("equipmentId", 0)), ""))
+	return resolve_texture_or_placeholder(str(SCOOPER_EQUIPMENT.get(int(item.get("equipmentId", 0)), "")))
 
 
 static func resolve_ability_icon(item: Dictionary) -> Texture2D:
-	return load_texture(SCOOPER_ABILITIES.get(int(item.get("abilityId", 0)), ""))
+	return resolve_texture_or_placeholder(str(SCOOPER_ABILITIES.get(int(item.get("abilityId", 0)), "")))
 
 
 static func resolve_bundle_art(bundle: Dictionary) -> Texture2D:
-	return load_texture(SHOP_BUNDLES.get(int(bundle.get("bundleId", 0)), ""))
+	return resolve_texture_or_placeholder(str(SHOP_BUNDLES.get(int(bundle.get("bundleId", 0)), "")))
 
 
 static func resolve_cat_card_frame() -> Texture2D:

--- a/scripts/ui/overlay_scene_chrome.gd
+++ b/scripts/ui/overlay_scene_chrome.gd
@@ -225,7 +225,7 @@ static func make_card_panel(accent: Color = CARD_BORDER, fill: Color = CARD_FILL
 static func _apply_shell_background(background: TextureRect, slot: String) -> void:
 	if background == null:
 		return
-	background.texture = AssetResolver.load_texture(str(AssetResolver.BACKGROUNDS.get(slot, "")))
+	background.texture = AssetResolver.resolve_background_texture(slot)
 	background.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 	background.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
 	background.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_COVERED


### PR DESCRIPTION
## 關聯 Issue

- Closes #208

## 這次修改

- 在 `AssetResolver` 補上共用 fallback helper，讓缺圖時回退到 placeholder 或預設背景
- 修正商店、背包、郵件、競技場、地城、常駐活動、Scooper 等入口的缺圖處理
- 讓 overlay / 功能頁背景在缺圖時不再直接留白
- 同步更新缺漏美術文件與 repo 內 release checklist
- 在 `AGENTS.md` 記錄缺圖一律優先走共用 fallback helper 的穩定規則

## 驗證

- `git diff --check`
- 檢查 fallback 依賴素材存在
- 掃描目前腳本對 fallback helper 的引用點
- 本機沒有 `Godot` 指令，因此未跑 headless 載入測試

## 備註

- 根目錄 `release_checklist.md` 已同步更新在本機工作區，但不在 repo 內；這次 PR 帶的是 repo 內的 `docs/release/release_checklist.md`
