### PR TITLE
fix:啟用 Web 版手機虛擬鍵盤

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@
 - Scooper UI templates should live under `scenes/ui/scooper/<feature>/`; keep equipment, ability, memory, treasure, and achievement card templates grouped by feature instead of adding new Scooper templates to the `scenes/ui/` root.
 - `MailScene`, `ChatScene`, and similar home-overlay social pages that already have bootstrap + realtime cache coverage should open from `GameState` first; do not reintroduce mandatory entry-time loading fetches for data already maintained by bootstrap and websocket sync.
 - For bootstrap-backed social pages such as `MailScene` and `SocialScene`, if summary state says data should exist but the cached detail list is missing, prefer a silent self-heal fetch over restoring visible entry-time loading.
+- Web exports that include `LineEdit` / `TextEdit` input must keep `html/experimental_virtual_keyboard=true` in `export_presets.cfg` so mobile browsers can open the native iOS / Android keyboard.
 - Environment rules:
   - All files must use UTF-8 without BOM.
   - Never use UTF-16 or system default encoding.

--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -22,5 +22,5 @@ html/custom_html_shell=""
 html/head_include=""
 html/canvas_resize_policy=2
 html/focus_canvas_on_start=true
-html/experimental_virtual_keyboard=false
+html/experimental_virtual_keyboard=true
 progressive_web_app/enabled=false


### PR DESCRIPTION
## 變更摘要

- 啟用 Web export preset 的 `html/experimental_virtual_keyboard`
- 在 Client `AGENTS.md` 補上 Web 匯出含 `LineEdit` / `TextEdit` 時必須保留虛擬鍵盤設定的穩定規則

## 驗證

- `git diff --check -- AGENTS.md export_presets.cfg` 通過
- 本機環境找不到 `godot` CLI，因此未執行 Godot 匯出或專案載入檢查

## Issue

Closes #214