### PR TITLE
fix:支援平板安全區與裝飾背景

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,4 +28,5 @@
   - Do not use `Out-File`.
   - Always use `Set-Content -Encoding utf8` when writing files from PowerShell.
   - Ensure UTF-8 encoding is set before writing files from shell scripts.
+- Tablet and wide-screen layout must keep the playable UI inside the centered `720 x 1280` safe frame; use extra side space only for decorative background, not required buttons or gameplay controls.
 - When new stable project-specific constraints are discovered during work, record them here so future changes stay consistent.

--- a/docs/gdd/18_frontend_architecture.md
+++ b/docs/gdd/18_frontend_architecture.md
@@ -15,8 +15,11 @@ This document describes the current frontend architecture of `MeowPartyDashClien
 - Main entry scene: `res://scenes/StartScene.tscn`
 - Home shell scene: `res://scenes/HomeShellScene.tscn`
 - Runtime viewport baseline: `720 x 1280`
+- Tablet and wide-screen policy: keep the playable UI inside the centered `720 x 1280` safe frame, scale it evenly through project stretch settings, and use the extra side space only for decorative background.
 
 Important rule: many UI surfaces are built directly in GDScript at runtime. A `.tscn` file is often only a root node plus a script attachment.
+
+Important tablet rule: do not widen core buttons, battle coordinates, or overlay interaction areas just because the device is wider. Use `scripts/ui/adaptive_viewport.gd` to center fixed-coordinate `Node2D` scenes and CanvasLayer UI inside the `720 x 1280` safe frame. Decorative side space may extend or tint background art, but it must not contain required gameplay actions.
 
 ---
 

--- a/project.godot
+++ b/project.godot
@@ -32,6 +32,7 @@ ToastManager="*res://scripts/ui/ToastManager.gd"
 window/size/viewport_width=720
 window/size/viewport_height=1280
 window/stretch/mode="canvas_items"
+window/stretch/aspect="expand"
 
 [dotnet]
 

--- a/scripts/StartScene.gd
+++ b/scripts/StartScene.gd
@@ -1,6 +1,7 @@
 extends Control
 
 const HERO_IMAGE := preload("res://assets/sprites/ui/start_scene_homey_v1.png")
+const AdaptiveViewportScript = preload("res://scripts/ui/adaptive_viewport.gd")
 const RuntimeConfigScript = preload("res://scripts/gamestate/RuntimeConfig.gd")
 const TITLE_TEXT := UiText.START_TITLE
 const SUBTITLE_TEXT := UiText.START_SUBTITLE
@@ -120,6 +121,8 @@ func _ready() -> void:
 	_api_base_url = _resolve_api_base_url()
 	_device_id = _load_or_create_device_id()
 	_build_ui()
+	_sync_adaptive_layout()
+	get_viewport().size_changed.connect(_sync_adaptive_layout)
 	_attach_http_request()
 	_play_idle_animation()
 	_apply_mode()
@@ -414,11 +417,11 @@ func _build_tap_hint() -> Label:
 func _build_logout_button() -> Button:
 	var button := Button.new()
 	button.text = UiText.START_LOGOUT_BUTTON
-	button.anchor_left = 1.0
+	button.anchor_left = 0.0
 	button.anchor_top = 0.0
-	button.anchor_right = 1.0
+	button.anchor_right = 0.0
 	button.anchor_bottom = 0.0
-	button.position = Vector2(-156, 28)
+	button.position = Vector2(720.0 - 156.0, 28.0)
 	button.custom_minimum_size = Vector2(128, 52)
 	button.visible = false
 	button.mouse_filter = Control.MOUSE_FILTER_STOP
@@ -432,6 +435,11 @@ func _build_logout_button() -> Button:
 	button.add_theme_stylebox_override("pressed", _make_button_stylebox(Color("a6473e"), 8))
 	button.pressed.connect(_on_logout_pressed)
 	return button
+
+
+func _sync_adaptive_layout() -> void:
+	if _logout_button != null:
+		_logout_button.position = AdaptiveViewportScript.get_content_origin(self) + Vector2(720.0 - 156.0, 28.0)
 
 
 func _build_paw_row() -> HBoxContainer:

--- a/scripts/battle/arena_battle_scene.gd
+++ b/scripts/battle/arena_battle_scene.gd
@@ -2,6 +2,7 @@ class_name ArenaBattleScene
 extends Node2D
 
 const BATTLE_BG_TEXTURE := preload("res://assets/sprites/ui/battle_background_homey_v1.png")
+const AdaptiveViewportScript = preload("res://scripts/ui/adaptive_viewport.gd")
 const RESULT_VICTORY_TEXTURE := preload("res://assets/sprites/ui/results/victory_overlay_v1.png")
 const RESULT_DEFEAT_TEXTURE := preload("res://assets/sprites/ui/results/defeat_overlay_v1.png")
 
@@ -34,9 +35,14 @@ var _skill_bar: Control
 
 var _opponent: Dictionary = {}
 var _settling := false
+var _tablet_decor_canvas: CanvasLayer
+var _tablet_decor: TextureRect
 
 
 func _ready() -> void:
+	_build_tablet_decor()
+	_sync_adaptive_layout()
+	get_viewport().size_changed.connect(_sync_adaptive_layout)
 	_opponent = GameState.arena_opponent
 	_build_scene()
 	_start_battle()
@@ -97,6 +103,7 @@ func _build_battle_area() -> void:
 
 func _build_ui() -> void:
 	_ui_layer = CanvasLayer.new()
+	AdaptiveViewportScript.apply_canvas_layer_origin(_ui_layer, self)
 	add_child(_ui_layer)
 
 	_speed_1x = _make_button("1x", Vector2(20.0, 20.0), Vector2(70.0, 44.0))
@@ -529,3 +536,24 @@ func _show_result_overlay(is_win: bool) -> Control:
 
 func _on_retreat_pressed() -> void:
 	SceneNavigator.open_overlay_scene("res://scenes/ArenaScene.tscn")
+
+
+func _build_tablet_decor() -> void:
+	_tablet_decor_canvas = CanvasLayer.new()
+	_tablet_decor_canvas.layer = -100
+	add_child(_tablet_decor_canvas)
+
+	_tablet_decor = TextureRect.new()
+	_tablet_decor.name = "TabletDecorBackground"
+	_tablet_decor.texture = BATTLE_BG_TEXTURE
+	_tablet_decor.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_tablet_decor.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+	_tablet_decor.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_COVERED
+	_tablet_decor.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_tablet_decor_canvas.add_child(_tablet_decor)
+
+
+func _sync_adaptive_layout() -> void:
+	AdaptiveViewportScript.apply_centered_node2d(self)
+	AdaptiveViewportScript.apply_full_viewport(_tablet_decor, self)
+	AdaptiveViewportScript.apply_canvas_layer_origin(_ui_layer, self)

--- a/scripts/battle/battle_scene.gd
+++ b/scripts/battle/battle_scene.gd
@@ -4,6 +4,7 @@ extends Node2D
 ## Main home scene: battle view plus bottom navigation.
 
 const BATTLE_BG_TEXTURE := preload("res://assets/sprites/ui/battle_background_homey_v1.png")
+const AdaptiveViewportScript = preload("res://scripts/ui/adaptive_viewport.gd")
 const OverlaySceneChromeRef = preload("res://scripts/ui/overlay_scene_chrome.gd")
 const HOME_TOP_HUD_SCENE := preload("res://scenes/ui/home/HomeTopHudEditor.tscn")
 const HOME_BOTTOM_HUD_SCENE := preload("res://scenes/ui/home/HomeBottomHudEditor.tscn")
@@ -265,6 +266,7 @@ var _free_speed_boost_used: bool = false
 var _boss_warning_flash_tween: Tween
 var _boss_warning_pulse_tween: Tween
 var _current_enemy_cats: Array = []
+var _adaptive_content_origin: Vector2 = Vector2.ZERO
 
 
 func _ready() -> void:
@@ -290,6 +292,18 @@ func _ready() -> void:
 		reward_demo_timer.autostart = true
 		reward_demo_timer.timeout.connect(_play_reward_float_demo_tick)
 		add_child(reward_demo_timer)
+
+
+func set_adaptive_content_origin(origin: Vector2) -> void:
+	_adaptive_content_origin = origin
+	_apply_adaptive_content_origin()
+
+
+func _apply_adaptive_content_origin() -> void:
+	if _nav_canvas != null:
+		_nav_canvas.offset = _adaptive_content_origin
+	if _reward_fx_canvas != null:
+		_reward_fx_canvas.offset = _adaptive_content_origin
 
 
 func _process(_delta: float) -> void:
@@ -877,6 +891,7 @@ func _build_ui() -> void:
 
 	_nav_canvas = CanvasLayer.new()
 	_nav_canvas.layer = 20
+	_nav_canvas.offset = _adaptive_content_origin
 	add_child(_nav_canvas)
 
 	_home_more_buttons_layer = Control.new()
@@ -965,6 +980,7 @@ func _build_ui() -> void:
 
 	_reward_fx_canvas = CanvasLayer.new()
 	_reward_fx_canvas.layer = 101
+	_reward_fx_canvas.offset = _adaptive_content_origin
 	add_child(_reward_fx_canvas)
 
 	_reward_fx_layer = Control.new()

--- a/scripts/battle/dungeon_battle_scene.gd
+++ b/scripts/battle/dungeon_battle_scene.gd
@@ -2,6 +2,7 @@ class_name DungeonBattleScene
 extends Node2D
 
 const BATTLE_BG_TEXTURE := preload("res://assets/sprites/ui/battle_background_homey_v1.png")
+const AdaptiveViewportScript = preload("res://scripts/ui/adaptive_viewport.gd")
 const RESULT_VICTORY_TEXTURE := preload("res://assets/sprites/ui/results/victory_overlay_v1.png")
 const RESULT_DEFEAT_TEXTURE := preload("res://assets/sprites/ui/results/defeat_overlay_v1.png")
 
@@ -39,11 +40,16 @@ var _dungeon_key: String = ""
 var _dungeon_level: int = 1
 var _dungeon_cfg: Dictionary = {}
 var _result_submit_inflight := false
+var _tablet_decor_canvas: CanvasLayer
+var _tablet_decor: TextureRect
 
 @onready var ApiClient = get_node("/root/ApiClient")
 
 
 func _ready() -> void:
+	_build_tablet_decor()
+	_sync_adaptive_layout()
+	get_viewport().size_changed.connect(_sync_adaptive_layout)
 	_dungeon_id = GameState.dungeon_battle_id
 	_dungeon_key = GameState.dungeon_battle_key
 	_dungeon_level = GameState.dungeon_battle_level
@@ -113,6 +119,7 @@ func _build_battle_area() -> void:
 
 func _build_ui() -> void:
 	_ui_layer = CanvasLayer.new()
+	AdaptiveViewportScript.apply_canvas_layer_origin(_ui_layer, self)
 	add_child(_ui_layer)
 
 	_speed_1x = _make_button("1x", Vector2(20.0, 20.0), Vector2(70.0, 44.0))
@@ -434,12 +441,12 @@ func _on_complete_challenge(success: bool, data: Variant, error: Dictionary) -> 
 		_show_reward_popup(_dungeon_level, rewards if rewards is Dictionary else {})
 		return
 
-	var message := str(error.get("message", UiText.DUNGEON_CHALLENGE_SETTLE_FAILED_BODY))
-		DialogManager.show_info(
-			UiText.DUNGEON_CHALLENGE_SETTLE_FAILED_TITLE,
-			message,
-			Callable(self, "_return_to_dungeon_scene")
-		)
+	var message: String = str(error.get("message", UiText.DUNGEON_CHALLENGE_SETTLE_FAILED_BODY))
+	DialogManager.show_info(
+		UiText.DUNGEON_CHALLENGE_SETTLE_FAILED_TITLE,
+		message,
+		Callable(self, "_return_to_dungeon_scene")
+	)
 
 
 func _show_reward_popup(level: int, rewards: Dictionary) -> void:
@@ -486,3 +493,24 @@ func _show_result_overlay(is_win: bool) -> void:
 
 func _on_retreat_pressed() -> void:
 	SceneNavigator.open_overlay_scene("res://scenes/DungeonScene.tscn")
+
+
+func _build_tablet_decor() -> void:
+	_tablet_decor_canvas = CanvasLayer.new()
+	_tablet_decor_canvas.layer = -100
+	add_child(_tablet_decor_canvas)
+
+	_tablet_decor = TextureRect.new()
+	_tablet_decor.name = "TabletDecorBackground"
+	_tablet_decor.texture = BATTLE_BG_TEXTURE
+	_tablet_decor.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_tablet_decor.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+	_tablet_decor.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_COVERED
+	_tablet_decor.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_tablet_decor_canvas.add_child(_tablet_decor)
+
+
+func _sync_adaptive_layout() -> void:
+	AdaptiveViewportScript.apply_centered_node2d(self)
+	AdaptiveViewportScript.apply_full_viewport(_tablet_decor, self)
+	AdaptiveViewportScript.apply_canvas_layer_origin(_ui_layer, self)

--- a/scripts/navigation/HomeShellScene.gd
+++ b/scripts/navigation/HomeShellScene.gd
@@ -1,15 +1,21 @@
 extends Control
 
 const BATTLE_SCENE := preload("res://scenes/BattleScene.tscn")
+const BATTLE_BG_TEXTURE := preload("res://assets/sprites/ui/battle_background_homey_v1.png")
+const AdaptiveViewportScript = preload("res://scripts/ui/adaptive_viewport.gd")
 const OVERLAY_BOTTOM_RESERVE := 0.0
 
 var _battle_scene: Node
+var _tablet_decor: TextureRect
+var _tablet_decor_tint: ColorRect
 var _overlay_root: Control
 
 
 func _ready() -> void:
 	set_anchors_preset(Control.PRESET_FULL_RECT)
 	_build_shell()
+	_sync_adaptive_layout()
+	get_viewport().size_changed.connect(_sync_adaptive_layout)
 	SceneNavigator.register_home_shell(self)
 
 
@@ -51,6 +57,21 @@ func clear_overlay_scene() -> void:
 
 
 func _build_shell() -> void:
+	_tablet_decor = TextureRect.new()
+	_tablet_decor.name = "TabletDecorBackground"
+	_tablet_decor.texture = BATTLE_BG_TEXTURE
+	_tablet_decor.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_tablet_decor.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+	_tablet_decor.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_COVERED
+	_tablet_decor.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	add_child(_tablet_decor)
+
+	_tablet_decor_tint = ColorRect.new()
+	_tablet_decor_tint.name = "TabletDecorTint"
+	_tablet_decor_tint.color = Color(0.20, 0.14, 0.08, 0.18)
+	_tablet_decor_tint.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	add_child(_tablet_decor_tint)
+
 	_battle_scene = BATTLE_SCENE.instantiate()
 	add_child(_battle_scene)
 
@@ -61,6 +82,18 @@ func _build_shell() -> void:
 	_overlay_root.clip_contents = true
 	_overlay_root.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	add_child(_overlay_root)
+	_sync_adaptive_layout()
+
+
+func _sync_adaptive_layout() -> void:
+	AdaptiveViewportScript.apply_full_viewport(_tablet_decor, self)
+	AdaptiveViewportScript.apply_full_viewport(_tablet_decor_tint, self)
+	if _battle_scene is Node2D:
+		var battle_node: Node2D = _battle_scene as Node2D
+		var origin: Vector2 = AdaptiveViewportScript.apply_centered_node2d(battle_node)
+		if _battle_scene.has_method("set_adaptive_content_origin"):
+			_battle_scene.call("set_adaptive_content_origin", origin)
+	AdaptiveViewportScript.apply_safe_control_frame(_overlay_root, self)
 
 
 func _attach_ui_click_sfx(root: Node) -> void:

--- a/scripts/ui/adaptive_viewport.gd
+++ b/scripts/ui/adaptive_viewport.gd
@@ -1,0 +1,53 @@
+class_name AdaptiveViewport
+extends RefCounted
+
+const BASE_SIZE: Vector2 = Vector2(720.0, 1280.0)
+
+
+static func get_visible_size(node: Node) -> Vector2:
+	var viewport: Viewport = node.get_viewport()
+	if viewport == null:
+		return BASE_SIZE
+	return viewport.get_visible_rect().size
+
+
+static func get_content_origin(node: Node) -> Vector2:
+	var viewport_size: Vector2 = get_visible_size(node)
+	return Vector2(
+		maxf((viewport_size.x - BASE_SIZE.x) * 0.5, 0.0),
+		maxf((viewport_size.y - BASE_SIZE.y) * 0.5, 0.0)
+	)
+
+
+static func apply_centered_node2d(node: Node2D) -> Vector2:
+	var origin: Vector2 = get_content_origin(node)
+	node.position = origin
+	return origin
+
+
+static func apply_canvas_layer_origin(layer: CanvasLayer, node: Node) -> void:
+	if layer == null:
+		return
+	layer.offset = get_content_origin(node)
+
+
+static func apply_safe_control_frame(control: Control, node: Node) -> void:
+	if control == null:
+		return
+	control.anchor_left = 0.0
+	control.anchor_top = 0.0
+	control.anchor_right = 0.0
+	control.anchor_bottom = 0.0
+	control.position = get_content_origin(node)
+	control.size = BASE_SIZE
+
+
+static func apply_full_viewport(control: Control, node: Node) -> void:
+	if control == null:
+		return
+	control.anchor_left = 0.0
+	control.anchor_top = 0.0
+	control.anchor_right = 0.0
+	control.anchor_bottom = 0.0
+	control.position = Vector2.ZERO
+	control.size = get_visible_size(node)


### PR DESCRIPTION
## 摘要
- 新增 `AdaptiveViewport`，統一計算 720x1280 安全區置中與 CanvasLayer 偏移。
- 將 HomeShell、主戰鬥、地城戰鬥、競技場戰鬥維持在中央安全區，平板左右空間改為裝飾背景。
- 更新 `project.godot` stretch aspect 與前端架構文件 / AGENTS 規則。

## 驗證
- `git diff --cached --check`
- 原工作區已執行 `Godot_v4.6.2-stable_mono_win64_console.exe --headless --quit-after 1` 通過。
- 乾淨 worktree 的 headless 啟動受 `.godot/imported` 字型/theme 快取缺失阻塞，錯誤包含 `Cannot open file 'res://.godot/imported/NotoSansTC-Regular.ttf-69f32930577d4873b4bf5866893fe3c6.fontdata'` 與 `Error loading custom project theme 'res://resources/default_theme.tres'`。

Closes #216