### PR TITLE
fix:修正 BOSS 失敗後需手動再挑戰

### DIFF
--- a/scripts/gamestate/GameState.gd
+++ b/scripts/gamestate/GameState.gd
@@ -1601,6 +1601,11 @@ func get_enemy_ids() -> Array:
 
 ## 勝利後推進到下一關
 func advance_after_win() -> void:
+	if BossStage.should_hold_after_last_encounter_win(current_global_stage, boss_available, boss_config):
+		player_data.current_stage = current_global_stage
+		player_data.save()
+		return
+
 	boss_available = false
 	current_global_stage += 1
 	player_data.current_stage = current_global_stage
@@ -1610,15 +1615,17 @@ func advance_after_win() -> void:
 ## Boss 失敗後退回該 Boss 關的最後遭遇戰，顯示「挑戰 Boss」按鈕
 func on_boss_fail() -> void:
 	var bs: int = get_boss_stage_number()
-	var enc := int(boss_config.get("encounters_per_boss_stage", 4))
-	current_global_stage = (bs - 1) * (enc + 1) + enc
+	current_global_stage = BossStage.get_last_encounter_stage_for_boss_stage(bs, boss_config)
 	boss_available = true
+	player_data.current_stage = current_global_stage
+	player_data.save()
 
 ## 玩家手動挑戰 Boss（從最後遭遇戰跳到 Boss）
 func challenge_boss() -> void:
 	var bs: int = get_boss_stage_number()
-	var enc := int(boss_config.get("encounters_per_boss_stage", 4))
-	current_global_stage = bs * (enc + 1)
+	current_global_stage = BossStage.get_boss_global_stage_for_boss_stage(bs, boss_config)
+	player_data.current_stage = current_global_stage
+	player_data.save()
 
 
 # ── 技能延遲 ──────────────────────────────────

--- a/scripts/gamestate/GameStateBossStage.gd
+++ b/scripts/gamestate/GameStateBossStage.gd
@@ -24,6 +24,31 @@ static func is_current_boss(current_stage: int, boss_cfg: Dictionary) -> bool:
 	return get_encounter_index(current_stage, boss_cfg) == enc + 1
 
 
+## 指定 Boss 關對應的最後普通遭遇戰全局關卡
+static func get_last_encounter_stage_for_boss_stage(boss_stage: int, boss_cfg: Dictionary) -> int:
+	var enc: int = _enc(boss_cfg)
+	var normalized_boss_stage: int = maxi(boss_stage, 1)
+	return normalized_boss_stage * (enc + 1) - 1
+
+
+## 指定 Boss 關對應的 Boss 全局關卡
+static func get_boss_global_stage_for_boss_stage(boss_stage: int, boss_cfg: Dictionary) -> int:
+	var enc: int = _enc(boss_cfg)
+	var normalized_boss_stage: int = maxi(boss_stage, 1)
+	return normalized_boss_stage * (enc + 1)
+
+
+## Boss 已解鎖時，最後遭遇戰勝利後停留原關卡，等待玩家手動挑戰 Boss。
+static func should_hold_after_last_encounter_win(current_stage: int, boss_available: bool, boss_cfg: Dictionary) -> bool:
+	if not boss_available:
+		return false
+	if is_current_boss(current_stage, boss_cfg):
+		return false
+
+	var enc: int = _enc(boss_cfg)
+	return get_encounter_index(current_stage, boss_cfg) == enc
+
+
 ## Boss 關在當前區域內的序號（1~boss_stages_per_zone）
 static func get_zone_boss_stage(current_stage: int, boss_cfg: Dictionary) -> int:
 	var bsz := _bsz(boss_cfg)

--- a/tests/unit/stage/test_game_state_boss_stage.gd
+++ b/tests/unit/stage/test_game_state_boss_stage.gd
@@ -69,6 +69,33 @@ func test_is_boss_false_on_stage_after_boss() -> void:
 	assert_false(GameStateBossStage.is_current_boss(6, _cfg))
 
 
+# ── boss challenge hold / jump helpers ────────────────────────────
+
+func test_last_encounter_stage_for_boss_stage_1_is_stage_4() -> void:
+	assert_eq(GameStateBossStage.get_last_encounter_stage_for_boss_stage(1, _cfg), 4)
+
+func test_boss_global_stage_for_boss_stage_1_is_stage_5() -> void:
+	assert_eq(GameStateBossStage.get_boss_global_stage_for_boss_stage(1, _cfg), 5)
+
+func test_boss_available_last_encounter_win_holds_stage() -> void:
+	assert_true(GameStateBossStage.should_hold_after_last_encounter_win(4, true, _cfg))
+
+func test_boss_unavailable_last_encounter_win_can_advance() -> void:
+	assert_false(GameStateBossStage.should_hold_after_last_encounter_win(4, false, _cfg))
+
+func test_boss_available_non_last_encounter_win_can_advance() -> void:
+	assert_false(GameStateBossStage.should_hold_after_last_encounter_win(3, true, _cfg))
+
+func test_boss_available_boss_stage_win_can_advance() -> void:
+	assert_false(GameStateBossStage.should_hold_after_last_encounter_win(5, true, _cfg))
+
+func test_custom_encounter_count_hold_and_jump_helpers() -> void:
+	var cfg: Dictionary = BossCfgBuilder.standard().with_encounters(2).build()
+	assert_eq(GameStateBossStage.get_last_encounter_stage_for_boss_stage(2, cfg), 5)
+	assert_eq(GameStateBossStage.get_boss_global_stage_for_boss_stage(2, cfg), 6)
+	assert_true(GameStateBossStage.should_hold_after_last_encounter_win(5, true, cfg))
+
+
 # ── get_difficulty_multiplier ─────────────────────────────────────
 
 func test_difficulty_stage_1_is_1() -> void:


### PR DESCRIPTION
Closes #222

## 變更摘要

- 調整推關勝利邏輯：當 BOSS 已解鎖且目前停在最後普通遭遇戰時，勝利後維持原關卡，不再自動進入 BOSS。
- 將最後遭遇戰與 BOSS 關卡全局編號計算集中到 `GameStateBossStage`。
- 補上 stage unit test，覆蓋 BOSS 可挑戰狀態下的停留規則與手動跳轉 helper。

## 驗證

- `git diff --check` 通過。
- Godot `--check-only --script res://scripts/gamestate/GameStateBossStage.gd` 可執行，但目前環境仍回報既有字型/theme 匯入問題：`Cannot open file 'res://.godot/imported/NotoSansTC-Regular.ttf-...fontdata'`、`Error loading custom project theme 'res://resources/default_theme.tres'`。