### PR TITLE
feat:新增關卡對手系統客戶端 Bootstrap 整合與本地查詢邏輯

### DIFF
--- a/scripts/data/cats/cat_data.gd
+++ b/scripts/data/cats/cat_data.gd
@@ -24,7 +24,9 @@ static func from_json_file(path: String) -> CatData:
 	var cat_id := path.get_file().get_basename()
 	var raw := GameState.get_cat_catalog_item(cat_id)
 	if raw.is_empty():
-		push_error("CatData: missing cached cat catalog for " + cat_id)
+		raw = GameState.get_enemy_catalog_item(cat_id)
+	if raw.is_empty():
+		push_error("CatData: missing catalog entry for " + cat_id)
 		return null
 	return _from_catalog(raw)
 

--- a/scripts/gamestate/GameState.gd
+++ b/scripts/gamestate/GameState.gd
@@ -406,6 +406,10 @@ func apply_player_bootstrap(data: Dictionary) -> void:
 	combat_power_weights = combat_power_weight_cat if combat_power_weight_cat is Array else combat_power_weights
 	CacheIO.save_catalog("combat_power_weights", combat_power_weights)
 
+	var opp_cfg: Variant = data.get("stageOpponentConfig", {})
+	stage_opponent_config = opp_cfg if opp_cfg is Dictionary else {}
+	CacheIO.save_config("stage_opponent_config", stage_opponent_config)
+
 	# ── Parse and cache live scooper data ──
 	var s_profile: Variant = data.get("scooperProfile", {})
 	if s_profile is Dictionary and not (s_profile as Dictionary).is_empty():
@@ -662,6 +666,7 @@ var cat_catalog: Array = []
 var active_skill_catalog: Array = []
 var passive_skill_catalog: Array = []
 var combat_power_weights: Array = []
+var stage_opponent_config: Dictionary = {}
 var gacha_config: Dictionary = {}
 var _cat_file_map: Dictionary = {}
 
@@ -706,6 +711,7 @@ func _ready() -> void:
 	active_skill_catalog = CacheIO.load_catalog("active_skill_catalog")
 	passive_skill_catalog = CacheIO.load_catalog("passive_skill_catalog")
 	combat_power_weights = CacheIO.load_catalog("combat_power_weights")
+	stage_opponent_config = CacheIO.load_config_dict("stage_opponent_config")
 	dungeon_config = CacheIO.load_config_dict("dungeon_static")
 	boss_config = CacheIO.load_config_dict("boss_static")
 	arena_config = CacheIO.load_config_dict("arena_static")
@@ -1989,7 +1995,23 @@ func get_difficulty_multiplier() -> float:
 	return BossStage.get_difficulty_multiplier(current_global_stage, boss_config)
 
 func get_enemy_ids() -> Array:
-	return BossStage.get_enemy_ids(current_global_stage, boss_config)
+	return BossStage.get_enemy_ids(current_global_stage, boss_config, stage_opponent_config)
+
+
+func get_enemy_catalog_item(enemy_key: String) -> Dictionary:
+	for item: Variant in stage_opponent_config.get("enemies", []):
+		if item is Dictionary and str(item.get("enemyKey", "")) == enemy_key:
+			return {
+				"id": enemy_key,
+				"display_name": str(item.get("displayName", enemy_key)),
+				"cat_type": "enemy",
+				"base_hp": int(item.get("baseHp", 100)),
+				"base_atk": int(item.get("baseAtk", 10)),
+				"base_def": int(item.get("baseDef", 0)),
+				"base_speed": float(item.get("baseSpd", 100.0)),
+				"weight": 100.0,
+			}
+	return {}
 
 
 # ── Stage progress logic ──────────────────────────────────

--- a/scripts/gamestate/GameStateBossStage.gd
+++ b/scripts/gamestate/GameStateBossStage.gd
@@ -118,16 +118,123 @@ static func get_difficulty_multiplier(current_stage: int, boss_cfg: Dictionary) 
 
 # ── Enemy generation ───────────────────────────────
 
-static func get_enemy_ids(current_stage: int, boss_cfg: Dictionary) -> Array:
+## Returns enemy_key strings for the current stage using 3-layer priority.
+## Falls back to ["test_enemy"] when opponent_cfg is empty (pre-bootstrap).
+static func get_enemy_ids(current_stage: int, boss_cfg: Dictionary, opponent_cfg: Dictionary = {}) -> Array:
+	if opponent_cfg.is_empty():
+		return _placeholder_ids(current_stage, boss_cfg)
+	if is_current_boss(current_stage, boss_cfg):
+		return [_resolve_boss_key(current_stage, boss_cfg, opponent_cfg)]
+	else:
+		return _resolve_encounter_keys(current_stage, boss_cfg, opponent_cfg)
+
+
+# ── Private helpers (opponent config query) ────────────────────
+
+static func _resolve_encounter_keys(current_stage: int, boss_cfg: Dictionary, opponent_cfg: Dictionary) -> Array:
+	var enc_idx: int = -(get_encounter_index(current_stage, boss_cfg))  # DB uses -1..-4
+	var territory: int = get_territory_number(current_stage, boss_cfg)
+
+	# 1. Level override
+	for lo: Variant in opponent_cfg.get("levelOverrides", []):
+		if lo is Dictionary and int(lo.get("globalStage", 0)) == current_stage:
+			var cfg_id: int = int(lo.get("encounterConfigId", 0))
+			if cfg_id > 0:
+				return _keys_from_encounter_id(cfg_id, opponent_cfg)
+
+	# 2. Territory encounter override
+	for teo: Variant in opponent_cfg.get("territoryEncounterOverrides", []):
+		if teo is Dictionary and int(teo.get("territoryOrder", 0)) == territory \
+				and int(teo.get("encounterIndex", 0)) == enc_idx:
+			var cfg_id: int = int(teo.get("enemyConfigId", 0))
+			if cfg_id > 0:
+				return _keys_from_encounter_id(cfg_id, opponent_cfg)
+
+	# 3. Global default
+	for ec: Variant in opponent_cfg.get("encounterConfigs", []):
+		if ec is Dictionary and bool(ec.get("isGlobalDefault", false)) \
+				and int(ec.get("encounterIndex", 0)) == enc_idx:
+			return _keys_from_members(ec.get("members", []), opponent_cfg)
+
+	return ["test_enemy"]
+
+
+static func _resolve_boss_key(current_stage: int, boss_cfg: Dictionary, opponent_cfg: Dictionary) -> String:
+	var territory: int = get_territory_number(current_stage, boss_cfg)
+	var boss_pos: int  = get_zone_boss_stage(current_stage, boss_cfg)  # 1-10
+
+	# 1. Level override
+	for lo: Variant in opponent_cfg.get("levelOverrides", []):
+		if lo is Dictionary and int(lo.get("globalStage", 0)) == current_stage:
+			var enemy_id: int = int(lo.get("enemyId", 0))
+			if enemy_id > 0:
+				return _key_from_enemy_id(enemy_id, opponent_cfg)
+
+	# 2. Territory Boss override
+	for tbo: Variant in opponent_cfg.get("territoryBossOverrides", []):
+		if tbo is Dictionary and int(tbo.get("territoryOrder", 0)) == territory \
+				and int(tbo.get("bossPosition", 0)) == boss_pos:
+			return _key_from_enemy_id(int(tbo.get("enemyId", 0)), opponent_cfg)
+
+	# 3. Territory template → global default template
+	var template_id: int = 0
+	for tbt: Variant in opponent_cfg.get("territoryBossTemplates", []):
+		if tbt is Dictionary and int(tbt.get("territoryOrder", 0)) == territory:
+			template_id = int(tbt.get("bossTemplateId", 0))
+			break
+	if template_id == 0:
+		for bt: Variant in opponent_cfg.get("bossTemplates", []):
+			if bt is Dictionary and bool(bt.get("isGlobalDefault", false)):
+				template_id = int(bt.get("id", 0))
+				break
+
+	for bt: Variant in opponent_cfg.get("bossTemplates", []):
+		if bt is Dictionary and int(bt.get("id", 0)) == template_id:
+			for m: Variant in bt.get("members", []):
+				if m is Dictionary and int(m.get("bossPosition", 0)) == boss_pos:
+					return _key_from_enemy_id(int(m.get("enemyId", 0)), opponent_cfg)
+
+	return "test_enemy"
+
+
+static func _keys_from_encounter_id(config_id: int, opponent_cfg: Dictionary) -> Array:
+	for ec: Variant in opponent_cfg.get("encounterConfigs", []):
+		if ec is Dictionary and int(ec.get("id", 0)) == config_id:
+			return _keys_from_members(ec.get("members", []), opponent_cfg)
+	return ["test_enemy"]
+
+
+static func _keys_from_members(members: Variant, opponent_cfg: Dictionary) -> Array:
+	if not (members is Array):
+		return ["test_enemy"]
+	var sorted: Array = (members as Array).duplicate()
+	sorted.sort_custom(func(a: Variant, b: Variant) -> bool:
+		return int((a as Dictionary).get("slotNo", 0)) < int((b as Dictionary).get("slotNo", 0)))
+	var keys: Array = []
+	for m: Variant in sorted:
+		if m is Dictionary:
+			var k: String = _key_from_enemy_id(int(m.get("enemyId", 0)), opponent_cfg)
+			if not k.is_empty():
+				keys.append(k)
+	return keys if not keys.is_empty() else ["test_enemy"]
+
+
+static func _key_from_enemy_id(enemy_id: int, opponent_cfg: Dictionary) -> String:
+	for e: Variant in opponent_cfg.get("enemies", []):
+		if e is Dictionary and int(e.get("id", 0)) == enemy_id:
+			return str(e.get("enemyKey", ""))
+	return "test_enemy"
+
+
+static func _placeholder_ids(current_stage: int, boss_cfg: Dictionary) -> Array:
 	var boss_stage := get_boss_stage_number(current_stage, boss_cfg)
 	var count: int
 	if is_current_boss(current_stage, boss_cfg):
 		count = mini(1 + boss_stage, 5)
 	else:
 		count = mini(1 + floori(float(boss_stage - 1) / 3.0), 5)
-	count = maxi(count, 1)
 	var ids: Array = []
-	for i in range(count):
+	for i: int in range(maxi(count, 1)):
 		ids.append("test_enemy")
 	return ids
 


### PR DESCRIPTION
## 摘要

實作 GDD 第 16 章客戶端部分，新增 Bootstrap 資料解析、本地快取、三層優先級查詢，以及 battle_scene 自動使用 DB 敵人資料。

- `GameState.stage_opponent_config`：Bootstrap 解析 + 本地快取 + `_ready()` 載入
- `GameStateBossStage.get_enemy_ids()`：三層優先級查詢（encounter / boss 各自的 level → territory → global）
- `GameState.get_enemy_catalog_item(key)`：DB 敵人資料正規化為 cat catalog 格式
- `CatData.from_json_file`：fallback 至 enemy catalog，battle_scene 零改動即可使用 DB 敵人

## 測試計畫

- [x] Bootstrap 未載入時 fallback `test_enemy`（向下相容）
- [x] 查詢函式為純 Dictionary lookup，無網路呼叫
- [ ] 實際播放確認敵人 key 符合 DB seed（需有 bootstrap 回應）

關聯 Issue: #240
對應後端：MeowPartyDashAPI#129