### PR TITLE
fix:補上 Web API Base URL query override

### DIFF
--- a/scripts/gamestate/RuntimeConfig.gd
+++ b/scripts/gamestate/RuntimeConfig.gd
@@ -22,6 +22,10 @@ static func get_config() -> Dictionary:
 
 
 static func get_api_base_url(default_api_base_url: String) -> String:
+	var web_override := _get_web_api_base_url_override()
+	if web_override != "":
+		return web_override
+
 	var config: Dictionary = get_config()
 	if config.has("api_base_url"):
 		return str(config.get("api_base_url", default_api_base_url)).rstrip("/")
@@ -29,6 +33,22 @@ static func get_api_base_url(default_api_base_url: String) -> String:
 	var environment_config: Dictionary = _get_active_environment_config(config)
 	var api_base_url: Variant = environment_config.get("api_base_url", default_api_base_url)
 	return str(api_base_url).rstrip("/")
+
+
+static func _get_web_api_base_url_override() -> String:
+	if not OS.has_feature("web"):
+		return ""
+
+	if not ClassDB.class_exists("JavaScriptBridge"):
+		return ""
+
+	var raw_query_url := JavaScriptBridge.eval("(() => { const params = new URLSearchParams(window.location.search); const queryValue = params.get('api_base_url') || params.get('apiBaseUrl') || ''; if (queryValue) { window.sessionStorage.setItem('mpd_api_base_url', queryValue); return queryValue; } return window.sessionStorage.getItem('mpd_api_base_url') || ''; })()", true)
+
+	var query_url: String = str(raw_query_url).strip_edges()
+	if query_url == "null" or query_url == "":
+		return ""
+
+	return query_url.rstrip("/")
 
 
 static func get_environment_name() -> String:


### PR DESCRIPTION
## 變更
- `RuntimeConfig.get_api_base_url()` 新增 web query/localStorage fallback，避免 `runtime_config` 固定 ngrok 值時卡死。
- 當網址有帶 `api_base_url` 或 `apiBaseUrl` 時，會覆蓋預設值並更新 sessionStorage。

## 備註
- 這是針對 ngrok 開發階段 host 變動頻率高的熱修方案，避免每次都要改 CI variable 再打包。