### PR TITLE
fix:修正戰鬥牆面高度與空中互撞判定

### DIFF
--- a/scripts/battle/arena_battle_scene.gd
+++ b/scripts/battle/arena_battle_scene.gd
@@ -77,14 +77,14 @@ func _build_background() -> void:
 
 	var wall_l := ColorRect.new()
 	wall_l.color = Color(0.5, 0.2, 0.7, 0.0)
-	wall_l.position = Vector2(-20.0, 200.0)
-	wall_l.size = Vector2(20.0, BATTLE_Y - 200.0)
+	wall_l.position = Vector2(-20.0, 0.0)
+	wall_l.size = Vector2(20.0, BATTLE_Y)
 	add_child(wall_l)
 
 	var wall_r := ColorRect.new()
 	wall_r.color = Color(0.5, 0.2, 0.7, 0.0)
-	wall_r.position = Vector2(SW, 200.0)
-	wall_r.size = Vector2(20.0, BATTLE_Y - 200.0)
+	wall_r.position = Vector2(SW, 0.0)
+	wall_r.size = Vector2(20.0, BATTLE_Y)
 	add_child(wall_r)
 
 

--- a/scripts/battle/battle_manager.gd
+++ b/scripts/battle/battle_manager.gd
@@ -48,6 +48,7 @@ var _cat_stagger_timers: Dictionary = {}
 var _cat_knockback_timers: Dictionary = {}
 var _cat_accel_timers: Dictionary = {}
 var _cat_skip_recovery_accel: Dictionary = {}
+var _cat_airborne_timers: Dictionary = {}
 var _pending_recycled_cats: Dictionary = {}
 var _pending_recycle_count: int = 0
 
@@ -83,6 +84,7 @@ func setup(_events_param: Array, player_cats: Array, enemy_cats: Array,
 	_cat_knockback_timers.clear()
 	_cat_accel_timers.clear()
 	_cat_skip_recovery_accel.clear()
+	_cat_airborne_timers.clear()
 	_pending_recycled_cats.clear()
 	_pending_recycle_count = 0
 	_player_skill_slots.clear()
@@ -359,6 +361,10 @@ func _update_cat_movement(delta: float) -> void:
 			if previous_stagger_timer > 0.0:
 				if float(_cat_stagger_timers[id]) <= 0.0:
 					_cat_stagger_timers.erase(id)
+		if _cat_airborne_timers.has(id):
+			_cat_airborne_timers[id] = maxf(0.0, float(_cat_airborne_timers[id]) - scaled_delta)
+			if float(_cat_airborne_timers[id]) <= 0.0:
+				_cat_airborne_timers.erase(id)
 		if _cat_knockback_timers.has(id):
 			var previous_knockback_timer: float = float(_cat_knockback_timers[id])
 			_cat_knockback_timers[id] = maxf(0.0, previous_knockback_timer - scaled_delta)
@@ -389,8 +395,8 @@ func _update_cat_movement(delta: float) -> void:
 
 
 func _check_runtime_collision() -> void:
-	var p_front: CatNode = _get_front_runtime_node("player")
-	var e_front: CatNode = _get_front_runtime_node("enemy")
+	var p_front: CatNode = _get_front_runtime_collision_node("player")
+	var e_front: CatNode = _get_front_runtime_collision_node("enemy")
 	if p_front == null or e_front == null:
 		return
 	if absf(p_front.position.x - e_front.position.x) > CAT_HALF_W * 2.0:
@@ -488,6 +494,7 @@ func _apply_runtime_wall_counter(cat_id: int, target_x: float, arc_height: float
 	_cat_knockback_timers[cat_id] = WALL_COUNTER_DURATION
 	_cat_accel_timers[cat_id] = 0.0
 	_cat_skip_recovery_accel[cat_id] = false
+	_cat_airborne_timers[cat_id] = WALL_COUNTER_DURATION
 
 
 func _get_front_runtime_node(team_name: String) -> CatNode:
@@ -506,8 +513,28 @@ func _get_front_runtime_node(team_name: String) -> CatNode:
 	return best
 
 
+func _get_front_runtime_collision_node(team_name: String) -> CatNode:
+	var best: CatNode = null
+	for id_variant: Variant in _cat_nodes.keys():
+		var cat_id: int = int(id_variant)
+		var node: CatNode = _get_cat_node(cat_id)
+		if node == null or node.team != team_name or _is_cat_airborne(cat_id):
+			continue
+		if best == null:
+			best = node
+		elif team_name == "player" and node.position.x > best.position.x:
+			best = node
+		elif team_name == "enemy" and node.position.x < best.position.x:
+			best = node
+	return best
+
+
 func _is_cat_staggered(cat_id: int) -> bool:
 	return float(_cat_stagger_timers.get(cat_id, 0.0)) > 0.0
+
+
+func _is_cat_airborne(cat_id: int) -> bool:
+	return float(_cat_airborne_timers.get(cat_id, 0.0)) > 0.0
 
 
 func _get_wall_counter_target_x(node: CatNode, target_knockback: float) -> float:
@@ -933,6 +960,7 @@ func _remove_cat_runtime_state(cat_id: int) -> void:
 	_cat_knockback_timers.erase(cat_id)
 	_cat_accel_timers.erase(cat_id)
 	_cat_skip_recovery_accel.erase(cat_id)
+	_cat_airborne_timers.erase(cat_id)
 
 
 func _play_collision_sfx(event_time: float) -> void:

--- a/scripts/battle/battle_scene.gd
+++ b/scripts/battle/battle_scene.gd
@@ -380,14 +380,14 @@ func _build_background() -> void:
 
 	var wall_l := ColorRect.new()
 	wall_l.color = Color(0.34, 0.24, 0.6, 0.0)
-	wall_l.position = Vector2(-20.0, 200.0)
-	wall_l.size = Vector2(20.0, BATTLE_Y - 200.0)
+	wall_l.position = Vector2(-20.0, 0.0)
+	wall_l.size = Vector2(20.0, BATTLE_Y)
 	add_child(wall_l)
 
 	var wall_r := ColorRect.new()
 	wall_r.color = Color(0.34, 0.24, 0.6, 0.0)
-	wall_r.position = Vector2(SW, 200.0)
-	wall_r.size = Vector2(20.0, BATTLE_Y - 200.0)
+	wall_r.position = Vector2(SW, 0.0)
+	wall_r.size = Vector2(20.0, BATTLE_Y)
 	add_child(wall_r)
 
 

--- a/scripts/battle/battle_simulator.gd
+++ b/scripts/battle/battle_simulator.gd
@@ -35,6 +35,7 @@ class SimCat:
 	var stagger_timer: float = 0.0
 	var knockback_timer: float = 0.0
 	var recovery_accel_timer: float = 0.0
+	var airborne_timer: float = 0.0
 	var facing: int          # 1 = right, -1 = left
 
 	# Skill cooldowns (indexed parallel to data.active_skills_data)
@@ -206,7 +207,7 @@ func simulate(player_cats: Array, enemy_cats: Array) -> Array:
 			events.append(BattleEvent.battle_end(sim_time, "WIN"))
 			events.sort_custom(_sort_battle_events_by_timestamp)
 			return events
-		_check_front_collision(p_front, e_front, sim_time, events)
+		_check_front_collision(_get_front_collidable(p_list), _get_front_collidable(e_list), sim_time, events)
 
 		# Skill timing + triggering
 		for sc: SimCat in p_list + e_list:
@@ -336,6 +337,8 @@ func _init_skill_cooldowns(sc: SimCat) -> void:
 # ── Movement ──────────────────────────────────────────
 
 func _move_cat(sc: SimCat, delta: float) -> void:
+	if sc.airborne_timer > 0.0:
+		sc.airborne_timer = maxf(0.0, sc.airborne_timer - delta)
 	if sc.is_staggered:
 		sc.stagger_timer = maxf(0.0, sc.stagger_timer - delta)
 		if sc.stagger_timer <= 0.0:
@@ -363,6 +366,20 @@ func _get_front(team_list: Array) -> SimCat:
 	var best: SimCat = null
 	for sc: SimCat in team_list:
 		if not sc.is_alive:
+			continue
+		if best == null:
+			best = sc
+		elif sc.team == "player" and sc.pos_x > best.pos_x:
+			best = sc
+		elif sc.team == "enemy" and sc.pos_x < best.pos_x:
+			best = sc
+	return best
+
+
+func _get_front_collidable(team_list: Array) -> SimCat:
+	var best: SimCat = null
+	for sc: SimCat in team_list:
+		if not sc.is_alive or sc.airborne_timer > 0.0:
 			continue
 		if best == null:
 			best = sc
@@ -481,6 +498,7 @@ func _handle_collision(p: SimCat, e: SimCat, t: float, events: Array) -> void:
 		p.skip_recovery_accel_after_stagger = false
 		p.stagger_timer = WALL_COUNTER_DURATION
 		p.knockback_timer = WALL_COUNTER_DURATION
+		p.airborne_timer = WALL_COUNTER_DURATION
 		events.append(BattleEvent.wall_counter(t, p.instance_id, p.pos_x, WALL_COUNTER_DURATION, p_counter_height))
 	else:
 		events.append(BattleEvent.collision(t, p.instance_id, p.pos_x, p.current_hp, -kb_p, p_hit_wall))
@@ -492,6 +510,7 @@ func _handle_collision(p: SimCat, e: SimCat, t: float, events: Array) -> void:
 		e.skip_recovery_accel_after_stagger = false
 		e.stagger_timer = WALL_COUNTER_DURATION
 		e.knockback_timer = WALL_COUNTER_DURATION
+		e.airborne_timer = WALL_COUNTER_DURATION
 		events.append(BattleEvent.wall_counter(t, e.instance_id, e.pos_x, WALL_COUNTER_DURATION, e_counter_height))
 	else:
 		events.append(BattleEvent.collision(t, e.instance_id, e.pos_x, e.current_hp, kb_e, e_hit_wall))

--- a/scripts/battle/dungeon_battle_scene.gd
+++ b/scripts/battle/dungeon_battle_scene.gd
@@ -93,14 +93,14 @@ func _build_background() -> void:
 
 	var wall_l := ColorRect.new()
 	wall_l.color = Color(0.5, 0.2, 0.7, 0.0)
-	wall_l.position = Vector2(-20.0, 200.0)
-	wall_l.size = Vector2(20.0, BATTLE_Y - 200.0)
+	wall_l.position = Vector2(-20.0, 0.0)
+	wall_l.size = Vector2(20.0, BATTLE_Y)
 	add_child(wall_l)
 
 	var wall_r := ColorRect.new()
 	wall_r.color = Color(0.5, 0.2, 0.7, 0.0)
-	wall_r.position = Vector2(SW, 200.0)
-	wall_r.size = Vector2(20.0, BATTLE_Y - 200.0)
+	wall_r.position = Vector2(SW, 0.0)
+	wall_r.size = Vector2(20.0, BATTLE_Y)
 	add_child(wall_r)
 
 


### PR DESCRIPTION
## 摘要
- 將主戰鬥、競技場、地城戰鬥場景的左右牆視覺延伸到畫面頂端，避免角色反彈時出現站上牆頂的錯覺
- 為 runtime battle manager 加入空中狀態，讓牆反彈弧線中的角色暫時不參與前排互撞判定
- 同步調整 battle simulator，讓預算事件與 runtime 表現一致

## 測試
- 未執行 Godot 實機驗證
- 已檢查 git diff，確認只包含本次戰鬥修正範圍

Closes #249