### PR TITLE
fix:調整戰鬥動畫與開場牆體表現

### DIFF
--- a/scripts/battle/arena_battle_scene.gd
+++ b/scripts/battle/arena_battle_scene.gd
@@ -95,6 +95,7 @@ func _build_battle_area() -> void:
 
 	_enemy_team = Node2D.new()
 	_enemy_team.position = Vector2(0.0, BATTLE_Y)
+	_enemy_team.set_meta("battle_sprite_target_size", Vector2(128.0, 128.0))
 	add_child(_enemy_team)
 
 	_battle_manager = BattleManager.new()

--- a/scripts/battle/battle_manager.gd
+++ b/scripts/battle/battle_manager.gd
@@ -17,6 +17,9 @@ const CAT_DIED_SFXS := [
 const SKILL_SLOT_DISPLAY_CAP: int = 10
 const BATTLE_WALL_LEFT: float = 20.0
 const BATTLE_WALL_RIGHT: float = 700.0
+const BATTLE_WALL_START_LEFT: float = -80.0
+const BATTLE_WALL_START_RIGHT: float = 800.0
+const BATTLE_WALL_SHRINK_DURATION: float = 3.0
 const CAT_HALF_W: float = 48.0
 const PLAYER_FRONT_START_X: float = 220.0
 const ENEMY_FRONT_START_X: float = 500.0
@@ -28,6 +31,10 @@ const WALL_COUNTER_HEIGHT_MULT: float = 2.0
 const WALL_COUNTER_MIN_ARC_HEIGHT: float = 200.0
 const WALL_COUNTER_MAX_ARC_HEIGHT: float = 400.0
 const WALL_COUNTER_DURATION: float = 0.6
+const DEFAULT_SKILL_HIT_KNOCKBACK: float = 120.0
+const SKILL_ANIMATION_DURATION: float = 0.5
+const SKILL_CAST_STAND_START: float = 0.2
+const SKILL_CAST_STAND_END: float = 0.5
 
 signal battle_finished(result: String)
 var _events: Array = []
@@ -49,6 +56,7 @@ var _cat_knockback_timers: Dictionary = {}
 var _cat_accel_timers: Dictionary = {}
 var _cat_skip_recovery_accel: Dictionary = {}
 var _cat_airborne_timers: Dictionary = {}
+var _cat_skill_animation_timers: Dictionary = {}
 var _pending_recycled_cats: Dictionary = {}
 var _pending_recycle_count: int = 0
 
@@ -85,6 +93,7 @@ func setup(_events_param: Array, player_cats: Array, enemy_cats: Array,
 	_cat_accel_timers.clear()
 	_cat_skip_recovery_accel.clear()
 	_cat_airborne_timers.clear()
+	_cat_skill_animation_timers.clear()
 	_pending_recycled_cats.clear()
 	_pending_recycle_count = 0
 	_player_skill_slots.clear()
@@ -104,6 +113,7 @@ func setup(_events_param: Array, player_cats: Array, enemy_cats: Array,
 	_refresh_skill_bar_display()
 	_spawn_initial_cat_nodes()
 	_apply_all_passives()
+	_refresh_initial_skill_slot_cooldowns()
 
 
 func prime_initial_spawn_state() -> void:
@@ -178,6 +188,7 @@ func _spawn_runtime_cat(cat_id: int, team_name: String, cat_data: CatData, pos_x
 		"reflect": 0.0,
 		"buffs": [],
 	}
+	_cat_skill_animation_timers[cat_id] = 0.0
 	_update_skill_slot_spawn_state(cat_id, cat_data.max_hp, cat_data.max_hp)
 
 
@@ -259,6 +270,7 @@ func _spawn_cat_node(ev: BattleEvent) -> void:
 	_cat_speeds[ev.cat_id] = cat_data.speed
 	_cat_stagger_timers[ev.cat_id] = 0.0
 	_cat_accel_timers[ev.cat_id] = 0.0
+	_cat_skill_animation_timers[ev.cat_id] = 0.0
 	_update_skill_slot_spawn_state(ev.cat_id, ev.current_hp, ev.max_hp)
 
 
@@ -308,6 +320,7 @@ func _on_skill_activate(ev: BattleEvent) -> void:
 	var node: CatNode = _get_cat_node(ev.cat_id)
 	if node:
 		node.play_skill()
+		_cat_skill_animation_timers[ev.cat_id] = SKILL_ANIMATION_DURATION
 		node.flash_skill()
 		node.show_skill_bubble(_get_skill_display_name(ev.cat_id, ev.skill_id))
 		_play_audio_sfx(CAT_SKILL_SFX, -6.0, 1.0)
@@ -366,6 +379,8 @@ func _update_cat_movement(delta: float) -> void:
 			_cat_airborne_timers[id] = maxf(0.0, float(_cat_airborne_timers[id]) - scaled_delta)
 			if float(_cat_airborne_timers[id]) <= 0.0:
 				_cat_airborne_timers.erase(id)
+		if _cat_skill_animation_timers.has(id):
+			_cat_skill_animation_timers[id] = maxf(0.0, float(_cat_skill_animation_timers[id]) - scaled_delta)
 		if _cat_knockback_timers.has(id):
 			var previous_knockback_timer: float = float(_cat_knockback_timers[id])
 			_cat_knockback_timers[id] = maxf(0.0, previous_knockback_timer - scaled_delta)
@@ -387,10 +402,14 @@ func _update_cat_movement(delta: float) -> void:
 			)
 			_cat_accel_timers[id] = maxf(0.0, float(_cat_accel_timers[id]) - scaled_delta)
 		var dir: float = 1.0 if node.team == "player" else -1.0
+		if _is_cat_in_skill_cast_stand_window(id):
+			continue
+		var current_left_wall: float = _get_current_wall_left()
+		var current_right_wall: float = _get_current_wall_right()
 		node.position.x = clampf(
 			node.position.x + dir * speed * speed_scale * scaled_delta,
-			BATTLE_WALL_LEFT + CAT_HALF_W,
-			BATTLE_WALL_RIGHT - CAT_HALF_W
+			current_left_wall + CAT_HALF_W,
+			current_right_wall - CAT_HALF_W
 		)
 		node.play_run()
 
@@ -446,12 +465,14 @@ func _handle_runtime_collision(p_node: CatNode, e_node: CatNode) -> void:
 	var e_hit_wall: bool = false
 	var p_causes_wall_hit: bool = false
 	var e_causes_wall_hit: bool = false
-	if p_target_x - CAT_HALF_W <= BATTLE_WALL_LEFT:
-		p_target_x = BATTLE_WALL_LEFT + CAT_HALF_W
+	var current_left_wall: float = _get_current_wall_left()
+	var current_right_wall: float = _get_current_wall_right()
+	if p_target_x - CAT_HALF_W <= current_left_wall:
+		p_target_x = current_left_wall + CAT_HALF_W
 		p_hit_wall = true
 		e_causes_wall_hit = not e_staggered
-	if e_target_x + CAT_HALF_W >= BATTLE_WALL_RIGHT:
-		e_target_x = BATTLE_WALL_RIGHT - CAT_HALF_W
+	if e_target_x + CAT_HALF_W >= current_right_wall:
+		e_target_x = current_right_wall - CAT_HALF_W
 		e_hit_wall = true
 		p_causes_wall_hit = not p_staggered
 
@@ -538,11 +559,21 @@ func _is_cat_airborne(cat_id: int) -> bool:
 	return float(_cat_airborne_timers.get(cat_id, 0.0)) > 0.0
 
 
+func _is_cat_in_skill_cast_stand_window(cat_id: int) -> bool:
+	var remaining: float = float(_cat_skill_animation_timers.get(cat_id, 0.0))
+	if remaining <= 0.0:
+		return false
+	var elapsed: float = SKILL_ANIMATION_DURATION - remaining
+	return elapsed >= SKILL_CAST_STAND_START and elapsed < SKILL_CAST_STAND_END
+
+
 func _get_wall_counter_target_x(node: CatNode, target_knockback: float) -> float:
 	var retreat_distance: float = maxf(WALL_COUNTER_MIN_RETREAT_X, target_knockback * WALL_COUNTER_DISTANCE_MULT)
+	var current_left_wall: float = _get_current_wall_left()
+	var current_right_wall: float = _get_current_wall_right()
 	if node.team == "player":
-		return maxf(BATTLE_WALL_LEFT + CAT_HALF_W, node.position.x - retreat_distance)
-	return minf(BATTLE_WALL_RIGHT - CAT_HALF_W, node.position.x + retreat_distance)
+		return maxf(current_left_wall + CAT_HALF_W, node.position.x - retreat_distance)
+	return minf(current_right_wall - CAT_HALF_W, node.position.x + retreat_distance)
 
 
 func _get_wall_counter_arc_height(target_knockback: float) -> float:
@@ -706,6 +737,7 @@ func _execute_runtime_skill(caster_id: int, skill_d: Dictionary) -> void:
 	if caster_data == null:
 		return
 	caster_node.play_skill()
+	_cat_skill_animation_timers[caster_id] = SKILL_ANIMATION_DURATION
 	caster_node.flash_skill()
 	caster_node.show_skill_bubble(str(skill_d.get("display_name", "")))
 	_play_audio_sfx(CAT_SKILL_SFX, -6.0, 1.0)
@@ -727,8 +759,8 @@ func _execute_runtime_skill(caster_id: int, skill_d: Dictionary) -> void:
 					if _is_runtime_dead(target_id):
 						_check_runtime_death(target_id)
 						break
-				var extra_kb: float = float(eff.get("extra_knockback", 0.0))
-				if extra_kb > 0.0 and _cat_runtime.has(target_id):
+				var extra_kb: float = maxf(float(eff.get("extra_knockback", 0.0)), DEFAULT_SKILL_HIT_KNOCKBACK)
+				if _cat_runtime.has(target_id) and not _is_cat_airborne(target_id):
 					_apply_skill_extra_knockback(caster_id, target_id, extra_kb)
 			"buff_stat":
 				var buff_target_id: int = _resolve_runtime_buff_target_id(caster_id, str(eff.get("target", "self")))
@@ -805,12 +837,24 @@ func _apply_skill_extra_knockback(caster_id: int, target_id: int, extra_kb: floa
 	if caster_node == null or target_node == null:
 		return
 	var direction: float = 1.0 if caster_node.team == "player" else -1.0
+	var current_left_wall: float = _get_current_wall_left()
+	var current_right_wall: float = _get_current_wall_right()
 	var target_x: float = clampf(
 		target_node.position.x + extra_kb * direction,
-		BATTLE_WALL_LEFT + CAT_HALF_W,
-		BATTLE_WALL_RIGHT - CAT_HALF_W
+		current_left_wall + CAT_HALF_W,
+		current_right_wall - CAT_HALF_W
 	)
-	_apply_runtime_knockback(target_id, target_x, extra_kb * direction, target_x <= BATTLE_WALL_LEFT + CAT_HALF_W or target_x >= BATTLE_WALL_RIGHT - CAT_HALF_W)
+	_apply_runtime_knockback(target_id, target_x, extra_kb * direction, target_x <= current_left_wall + CAT_HALF_W or target_x >= current_right_wall - CAT_HALF_W)
+
+
+func _get_current_wall_left() -> float:
+	var progress: float = clampf(_sim_time / BATTLE_WALL_SHRINK_DURATION, 0.0, 1.0)
+	return lerpf(BATTLE_WALL_START_LEFT, BATTLE_WALL_LEFT, progress)
+
+
+func _get_current_wall_right() -> float:
+	var progress: float = clampf(_sim_time / BATTLE_WALL_SHRINK_DURATION, 0.0, 1.0)
+	return lerpf(BATTLE_WALL_START_RIGHT, BATTLE_WALL_RIGHT, progress)
 
 
 func _resolve_runtime_target_id(caster_id: int, target: String) -> int:
@@ -963,6 +1007,7 @@ func _remove_cat_runtime_state(cat_id: int) -> void:
 	_cat_accel_timers.erase(cat_id)
 	_cat_skip_recovery_accel.erase(cat_id)
 	_cat_airborne_timers.erase(cat_id)
+	_cat_skill_animation_timers.erase(cat_id)
 
 
 func _play_collision_sfx(event_time: float) -> void:
@@ -1027,7 +1072,7 @@ func _build_skill_slot_entries(cats: Array) -> Array:
 			skill_id = str(cat.active_skills_data[0].get("id", ""))
 			max_cd = float(cat.active_skills_data[0].get("cooldown", 5.0))
 			var initial_delay: float = float(cat.active_skills_data[0].get("initial_delay", 0))
-			remaining_cd = initial_delay
+			remaining_cd = _calc_initial_skill_cooldown(max_cd, initial_delay)
 			skill_name = str(cat.active_skills_data[0].get("display_name", ""))
 		entries.append({
 			"max_cd": max_cd,
@@ -1041,6 +1086,28 @@ func _build_skill_slot_entries(cats: Array) -> Array:
 			"skill_name": skill_name,
 		})
 	return entries
+
+
+func _refresh_initial_skill_slot_cooldowns() -> void:
+	for id_variant: Variant in _cat_runtime.keys():
+		var cat_id: int = int(id_variant)
+		var runtime: Dictionary = _cat_runtime.get(cat_id, {})
+		var cat_data: CatData = runtime.get("data", null) as CatData
+		if cat_data == null or cat_data.active_skills_data.is_empty():
+			continue
+		var slot: Dictionary = _get_skill_slot_entry(cat_id)
+		if slot.is_empty():
+			continue
+		var skill_d: Dictionary = cat_data.active_skills_data[0]
+		var cdr_mult: float = 1.0 - float(runtime.get("cooldown_reduction", 0.0))
+		var effective_cooldown: float = float(skill_d.get("cooldown", 5.0)) * cdr_mult
+		var initial_delay: float = float(skill_d.get("initial_delay", 0.0))
+		slot["max_cd"] = effective_cooldown
+		slot["remaining_cd"] = _calc_initial_skill_cooldown(effective_cooldown, initial_delay)
+
+
+func _calc_initial_skill_cooldown(cooldown: float, initial_delay: float) -> float:
+	return maxf(0.0, cooldown * 0.3 + initial_delay)
 
 
 func _update_skill_bar(delta: float) -> void:
@@ -1078,7 +1145,12 @@ func _refresh_skill_bar_display() -> void:
 
 func _get_display_skill_slots() -> Array:
 	if _skill_bar_filter == "all":
-		return _player_skill_slots + _enemy_skill_slots
+		var display_slots: Array = []
+		for i in range(SKILL_SLOT_DISPLAY_CAP / 2):
+			display_slots.append(_player_skill_slots[i] if i < _player_skill_slots.size() else null)
+		for i in range(SKILL_SLOT_DISPLAY_CAP / 2):
+			display_slots.append(_enemy_skill_slots[i] if i < _enemy_skill_slots.size() else null)
+		return display_slots	
 	return []
 
 

--- a/scripts/battle/battle_scene.gd
+++ b/scripts/battle/battle_scene.gd
@@ -2355,6 +2355,18 @@ func _refresh_overlay_fx_state() -> void:
 			for child: Node in _damage_fx_layer.get_children():
 				child.queue_free()
 		_damage_fx_layer.visible = not overlay_open
+	if overlay_open:
+		_hide_team_skill_bubbles()
+
+
+func _hide_team_skill_bubbles() -> void:
+	for team_node: Node2D in [_player_team, _enemy_team]:
+		if team_node == null:
+			continue
+		for child: Node in team_node.get_children():
+			var cat_node: CatNode = child as CatNode
+			if cat_node != null:
+				cat_node.hide_skill_bubble()
 
 
 func _clear_battle_transient_fx() -> void:

--- a/scripts/battle/battle_simulator.gd
+++ b/scripts/battle/battle_simulator.gd
@@ -329,8 +329,8 @@ func _init_skill_cooldowns(sc: SimCat) -> void:
 	for skill_d: Dictionary in sc.data.active_skills_data:
 		var base_cd: float = float(skill_d.get("cooldown", 5.0))
 		var eff_cd: float = base_cd * cdr_mult
-		var delay: float = float(skill_d.get("initial_delay", 0)) * cdr_mult
-		sc.skill_cooldowns.append(delay)
+		var delay: float = float(skill_d.get("initial_delay", 0.0))
+		sc.skill_cooldowns.append(maxf(0.0, eff_cd * 0.3 + delay))
 		sc.skill_max_cds.append(eff_cd)
 
 
@@ -599,8 +599,8 @@ func _execute_skill(caster: SimCat, skill_d: Dictionary, t: float, events: Array
 						_check_death(target, t, events)
 						break
 				# Extra knockback
-				var extra_kb: float = eff.get("extra_knockback", 0.0)
-				if extra_kb > 0.0 and target.is_alive:
+				var extra_kb: float = maxf(float(eff.get("extra_knockback", 0.0)), 120.0)
+				if target.is_alive:
 					if caster.team == "player":
 						target.pos_x += extra_kb
 						if target.pos_x + CAT_HALF_W >= WALL_RIGHT:

--- a/scripts/cats/cat_node.gd
+++ b/scripts/cats/cat_node.gd
@@ -37,9 +37,8 @@ const BODY_W := 56.0
 const BODY_H := 72.0
 const HP_BAR_W := 64.0
 const HP_BAR_H := 8.0
-const SPRITE_TARGET_W := 128.0
-const SPRITE_TARGET_H := 128.0
-const SPRITE_TARGET_SIZE := Vector2(SPRITE_TARGET_W, SPRITE_TARGET_H)
+const PLAYER_SPRITE_TARGET_SIZE := Vector2(128.0, 128.0)
+const ENEMY_SPRITE_TARGET_SIZE := Vector2(160.0, 160.0)
 const SPRITE_VERTICAL_OFFSET_Y := 10.0
 const SHADOW_RADIUS_X := 28.0
 const SHADOW_RADIUS_Y := 9.0
@@ -59,6 +58,7 @@ const DAMAGE_POP_LABEL_W := 40.0
 const DAMAGE_POP_LABEL_H := 42.0
 const DAMAGE_DIGIT_DELAY := 0.05
 const SKILL_BUBBLE_OFFSET_Y := 162.0
+const SKILL_BUBBLE_VERTICAL_NUDGE_DOWN := 5.0
 const SKILL_BUBBLE_MIN_WIDTH := 92.0
 const SKILL_BUBBLE_MAX_WIDTH := 220.0
 const SKILL_BUBBLE_HEIGHT := 42.0
@@ -66,6 +66,7 @@ const SKILL_BUBBLE_H_PADDING := 18.0
 const SKILL_BUBBLE_TAIL_WIDTH := 18.0
 const SKILL_BUBBLE_TAIL_HEIGHT := 12.0
 const SKILL_BUBBLE_TAIL_GAP := 23.0
+const SKILL_BUBBLE_TAIL_VERTICAL_NUDGE_UP := 10.0
 const SKILL_BUBBLE_POP_TIME := 0.12
 const SKILL_BUBBLE_HOLD_TIME := 2.0
 const SKILL_BUBBLE_FADE_TIME := 0.22
@@ -89,6 +90,11 @@ func setup(id: int, team_name: String, name_str: String, hp: int, file_id: Strin
 	_damage_rng.randomize()
 	_build_visuals()
 	reset_for_spawn()
+
+
+func _process(_delta: float) -> void:
+	if _skill_bubble_root != null and _skill_bubble_root.visible and not SceneNavigator.get_current_overlay_scene_path().is_empty():
+		_hide_skill_bubble()
 
 
 func reset_for_spawn() -> void:
@@ -283,10 +289,20 @@ func _build_animated_body() -> void:
 func _calculate_uniform_sprite_scale(visible_size: Vector2) -> float:
 	var safe_width: float = maxf(1.0, visible_size.x)
 	var safe_height: float = maxf(1.0, visible_size.y)
+	var target_size: Vector2 = _get_sprite_target_size()
 	return minf(
-		SPRITE_TARGET_SIZE.x / safe_width,
-		SPRITE_TARGET_SIZE.y / safe_height
+		target_size.x / safe_width,
+		target_size.y / safe_height
 	)
+
+
+func _get_sprite_target_size() -> Vector2:
+	var parent_node: Node = get_parent()
+	if parent_node != null and parent_node.has_meta("battle_sprite_target_size"):
+		var override_size: Variant = parent_node.get_meta("battle_sprite_target_size")
+		if override_size is Vector2:
+			return override_size as Vector2
+	return PLAYER_SPRITE_TARGET_SIZE if team == "player" else ENEMY_SPRITE_TARGET_SIZE
 
 
 func _get_texture_visible_rect(texture: Texture2D) -> Rect2:
@@ -375,10 +391,23 @@ func show_damage_number(damage: int) -> void:
 func show_skill_bubble(skill_name: String) -> void:
 	if skill_name.strip_edges().is_empty():
 		return
+	if not SceneNavigator.get_current_overlay_scene_path().is_empty():
+		return
+	_ensure_skill_bubble_root()
 	if _skill_bubble_root == null or _skill_bubble_panel == null or _skill_bubble_label == null or _skill_bubble_tail == null:
 		return
 	if _skill_bubble_tween != null and _skill_bubble_tween.is_valid():
 		_skill_bubble_tween.kill()
+	var bubble_host: Node = self
+	var battle_scene: Node = get_tree().get_first_node_in_group("battle_scene")
+	if battle_scene != null and battle_scene.has_method("get_damage_fx_host"):
+		bubble_host = battle_scene.call("get_damage_fx_host")
+	elif battle_scene != null:
+		bubble_host = battle_scene
+	if _skill_bubble_root.get_parent() != bubble_host:
+		if _skill_bubble_root.get_parent() != null:
+			_skill_bubble_root.get_parent().remove_child(_skill_bubble_root)
+		bubble_host.add_child(_skill_bubble_root)
 	_skill_bubble_label.text = skill_name
 	var content_size: Vector2 = _skill_bubble_label.get_combined_minimum_size()
 	var bubble_width: float = clampf(content_size.x + SKILL_BUBBLE_H_PADDING * 2.0, SKILL_BUBBLE_MIN_WIDTH, SKILL_BUBBLE_MAX_WIDTH)
@@ -386,8 +415,8 @@ func show_skill_bubble(skill_name: String) -> void:
 	_skill_bubble_panel.position = Vector2(-bubble_width * 0.5, -SKILL_BUBBLE_HEIGHT)
 	_skill_bubble_label.position = Vector2(SKILL_BUBBLE_H_PADDING, 5.0)
 	_skill_bubble_label.size = Vector2(bubble_width - SKILL_BUBBLE_H_PADDING * 2.0, SKILL_BUBBLE_HEIGHT - 10.0)
-	_skill_bubble_tail.position = Vector2(0.0, SKILL_BUBBLE_TAIL_GAP - SKILL_BUBBLE_TAIL_HEIGHT)
-	_skill_bubble_root.position = Vector2(0.0, -SKILL_BUBBLE_OFFSET_Y)
+	_skill_bubble_tail.position = Vector2(0.0, SKILL_BUBBLE_TAIL_GAP - SKILL_BUBBLE_TAIL_HEIGHT - SKILL_BUBBLE_TAIL_VERTICAL_NUDGE_UP)
+	_skill_bubble_root.global_position = global_position + Vector2(0.0, -SKILL_BUBBLE_OFFSET_Y + SKILL_BUBBLE_VERTICAL_NUDGE_DOWN)
 	_skill_bubble_root.scale = Vector2(0.92, 0.92)
 	_skill_bubble_root.modulate = Color(1.0, 1.0, 1.0, 0.0)
 	_skill_bubble_root.visible = true
@@ -398,7 +427,7 @@ func show_skill_bubble(skill_name: String) -> void:
 	_skill_bubble_tween.tween_property(_skill_bubble_root, "scale", Vector2.ONE, SKILL_BUBBLE_POP_TIME).set_trans(Tween.TRANS_BACK).set_ease(Tween.EASE_OUT)
 	_skill_bubble_tween.chain().tween_interval(SKILL_BUBBLE_HOLD_TIME)
 	_skill_bubble_tween.chain().tween_property(_skill_bubble_root, "modulate:a", 0.0, SKILL_BUBBLE_FADE_TIME).set_trans(Tween.TRANS_QUAD).set_ease(Tween.EASE_IN)
-	_skill_bubble_tween.parallel().tween_property(_skill_bubble_root, "position:y", -SKILL_BUBBLE_OFFSET_Y - 12.0, SKILL_BUBBLE_FADE_TIME).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN)
+	_skill_bubble_tween.parallel().tween_property(_skill_bubble_root, "global_position:y", _skill_bubble_root.global_position.y - 12.0, SKILL_BUBBLE_FADE_TIME).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN)
 	_skill_bubble_tween.chain().tween_callback(Callable(self, "_hide_skill_bubble"))
 
 
@@ -439,7 +468,7 @@ func play_stagger() -> void:
 
 
 func play_skill() -> void:
-	_play_temporary("skill", 0.35)
+	_play_temporary("skill", 0.5)
 
 
 func play_wall_counter(target_x: float, arc_height: float, duration: float) -> void:
@@ -518,11 +547,12 @@ func flash_skill() -> void:
 
 
 func _build_skill_bubble() -> void:
+	if _skill_bubble_root != null and is_instance_valid(_skill_bubble_root):
+		return
 	_skill_bubble_root = Node2D.new()
 	_skill_bubble_root.visible = false
 	_skill_bubble_root.z_as_relative = false
-	_skill_bubble_root.z_index = 2
-	add_child(_skill_bubble_root)
+	_skill_bubble_root.z_index = 1
 
 	_skill_bubble_panel = PanelContainer.new()
 	var bubble_style: StyleBoxFlat = StyleBoxFlat.new()
@@ -571,15 +601,31 @@ func _hide_skill_bubble() -> void:
 	if _skill_bubble_tween != null and _skill_bubble_tween.is_valid():
 		_skill_bubble_tween.kill()
 	_skill_bubble_tween = null
-	if _skill_bubble_root != null:
+	if _skill_bubble_root != null and is_instance_valid(_skill_bubble_root):
 		_skill_bubble_root.visible = false
-		_skill_bubble_root.position = Vector2(0.0, -SKILL_BUBBLE_OFFSET_Y)
+		_skill_bubble_root.global_position = global_position + Vector2(0.0, -SKILL_BUBBLE_OFFSET_Y + SKILL_BUBBLE_VERTICAL_NUDGE_DOWN)
 		_skill_bubble_root.scale = Vector2.ONE
 		_skill_bubble_root.modulate = Color(1.0, 1.0, 1.0, 1.0)
 
 
+func hide_skill_bubble() -> void:
+	_hide_skill_bubble()
+
+
+func _ensure_skill_bubble_root() -> void:
+	if _skill_bubble_root != null and is_instance_valid(_skill_bubble_root):
+		return
+	_skill_bubble_root = null
+	_skill_bubble_panel = null
+	_skill_bubble_label = null
+	_skill_bubble_tail = null
+	_build_skill_bubble()
+
+
 func _play_loop(animation_name: String) -> void:
 	if not _has_animation(animation_name):
+		return
+	if animation_name == "run" and _revert_timer != null:
 		return
 	_cancel_revert()
 	if _active_animation == animation_name:
@@ -741,7 +787,6 @@ func _play_hit_feedback() -> void:
 		body_target = _body_rect
 	if body_target != null:
 		var body_base_position: Vector2 = body_target.position
-		var body_base_scale: Vector2 = body_target.scale
 		var body_tween: Tween = create_tween()
 		body_tween.set_parallel(true)
 		body_tween.tween_property(
@@ -752,18 +797,11 @@ func _play_hit_feedback() -> void:
 		).set_trans(Tween.TRANS_QUAD).set_ease(Tween.EASE_OUT)
 		body_tween.tween_property(
 			body_target,
-			"scale",
-			Vector2(body_base_scale.x * 1.08, body_base_scale.y * 0.93),
-			0.06
-		).set_trans(Tween.TRANS_BACK).set_ease(Tween.EASE_OUT)
-		body_tween.tween_property(
-			body_target,
 			"modulate",
 			Color(1.25, 1.25, 1.25, 1.0),
 			0.04
 		).set_trans(Tween.TRANS_LINEAR).set_ease(Tween.EASE_OUT)
 		body_tween.chain().tween_property(body_target, "position", body_base_position, 0.12).set_trans(Tween.TRANS_BOUNCE).set_ease(Tween.EASE_OUT)
-		body_tween.parallel().tween_property(body_target, "scale", body_base_scale, 0.14).set_trans(Tween.TRANS_BOUNCE).set_ease(Tween.EASE_OUT)
 		body_tween.parallel().tween_property(body_target, "modulate", Color(1.0, 1.0, 1.0, 1.0), 0.10).set_trans(Tween.TRANS_QUAD).set_ease(Tween.EASE_OUT)
 
 	if _hp_bar_fill != null:

--- a/scripts/ui/asset_resolver.gd
+++ b/scripts/ui/asset_resolver.gd
@@ -520,7 +520,7 @@ static func apply_catalog_texture(texture_rect: TextureRect, raw_path: Variant) 
 static func apply_cat_icon_texture(texture_rect: TextureRect, cat_id: String) -> void:
 	if texture_rect == null:
 		return
-	var resolved_path: String = str(CAT_ICONS.get(cat_id, ""))
+	var resolved_path: String = _resolve_cat_icon_path(cat_id)
 	var fallback_texture: Texture2D = resolve_cat_icon(cat_id)
 	_apply_remote_texture(texture_rect, resolved_path, fallback_texture)
 
@@ -619,7 +619,7 @@ static func resolve_catalog_path(raw_path: Variant) -> String:
 
 
 static func resolve_cat_icon(cat_id: String) -> Texture2D:
-	return resolve_texture_or_placeholder(str(CAT_ICONS.get(cat_id, "")))
+	return resolve_texture_or_placeholder(_resolve_cat_icon_path(cat_id))
 
 
 static func get_profile_avatar_ids() -> Array[String]:
@@ -649,6 +649,11 @@ static func resolve_cat_showcase_art(cat_id: String) -> Texture2D:
 		var texture: Texture2D = load_texture(candidate_path)
 		if texture != null:
 			return texture
+	for suffix: String in ["ref_right_v1", "ref_three_quarter_v1", "ref_front_v1", "icon_v1"]:
+		var resolved_path: String = _resolve_character_ref_path(cat_id, suffix)
+		var resolved_texture: Texture2D = load_texture(resolved_path)
+		if resolved_texture != null:
+			return resolved_texture
 	return resolve_cat_icon(cat_id)
 
 
@@ -673,18 +678,11 @@ static func resolve_cat_battle_static_art(cat_id: String) -> Texture2D:
 		var texture: Texture2D = load_texture(candidate_path)
 		if texture != null:
 			return texture
-	if CAT_BATTLE_ENCOUNTER_CHARACTER_IDS.has(cat_id):
-		for suffix: String in ["ref_right_v1", "ref_three_quarter_v1", "ref_front_v1", "icon_v1"]:
-			var encounter_path: String = ENCOUNTER_CHARACTER_REF_ROOT + cat_id + "/" + cat_id + "_" + suffix + ".png"
-			var encounter_texture: Texture2D = load_texture(encounter_path)
-			if encounter_texture != null:
-				return encounter_texture
-	if CAT_BATTLE_BOSS_CHARACTER_IDS.has(cat_id):
-		for suffix: String in ["ref_right_v1", "ref_three_quarter_v1", "ref_front_v1", "icon_v1"]:
-			var boss_path: String = BOSS_CHARACTER_REF_ROOT + cat_id + "/" + cat_id + "_" + suffix + ".png"
-			var boss_texture: Texture2D = load_texture(boss_path)
-			if boss_texture != null:
-				return boss_texture
+	for suffix: String in ["ref_right_v1", "ref_three_quarter_v1", "ref_front_v1", "icon_v1"]:
+		var resolved_path: String = _resolve_character_ref_path(cat_id, suffix)
+		var resolved_texture: Texture2D = load_texture(resolved_path)
+		if resolved_texture != null:
+			return resolved_texture
 	return resolve_cat_showcase_art(cat_id)
 
 
@@ -776,6 +774,33 @@ static func get_cat_battle_animation_names() -> Array[String]:
 	for animation_name: String in CAT_BATTLE_ANIMATION_NAMES:
 		animation_names.append(animation_name)
 	return animation_names
+
+
+static func _resolve_cat_icon_path(cat_id: String) -> String:
+	var mapped_path: String = str(CAT_ICONS.get(cat_id, ""))
+	if mapped_path != "" and ResourceLoader.exists(mapped_path):
+		return mapped_path
+	return _resolve_character_ref_path(cat_id, "icon_v1")
+
+
+static func _resolve_character_ref_path(cat_id: String, suffix: String) -> String:
+	if cat_id.strip_edges().is_empty():
+		return ""
+	for root: String in _get_character_ref_roots(cat_id):
+		var candidate_path: String = "%s%s/%s_%s.png" % [root, cat_id, cat_id, suffix]
+		if ResourceLoader.exists(candidate_path):
+			return candidate_path
+	return ""
+
+
+static func _get_character_ref_roots(cat_id: String) -> Array[String]:
+	var roots: Array[String] = []
+	if CAT_BATTLE_ENCOUNTER_CHARACTER_IDS.has(cat_id):
+		roots.append(ENCOUNTER_CHARACTER_REF_ROOT)
+	if CAT_BATTLE_BOSS_CHARACTER_IDS.has(cat_id):
+		roots.append(BOSS_CHARACTER_REF_ROOT)
+	roots.append(UI_CDN_CHARACTER_REF_ROOT)
+	return roots
 
 
 static func resolve_gacha_frame(result: Dictionary) -> Texture2D:


### PR DESCRIPTION
## 變更內容
- 補齊戰鬥角色 / encounter / boss icon 解析與 fallback，修正 Warning 條與技能欄顯示
- 固定首頁衝撞欄位為上排我方、下排敵方，空位保留不補位
- 調整技能氣泡位置與隱藏機制，並改成比照傷害數字掛到戰鬥特效層
- 調整技能動畫時間與站樁節奏，讓施放中段停步後恢復位移
- 技能命中時預設擊退敵方，且空中目標不重複吃額外擊退
- 取消受擊時的非等比壓扁回饋
- 調整戰鬥圖縮放規則：我方 128x128、一般敵方 160x160、競技場敵方 128x128，皆維持等比
- 開場牆體改為前 3 秒由外往內縮，避免五隻隊伍出生時被牆擠壓

## 測試
- 未執行 Godot 實機驗證（本次以靜態修改與 diff 檢查為主）

Closes #253
