### PR TITLE
fix:修正 GitHub Pages 首次互動音訊解鎖

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - Preserve the established visual identity of `StartScene` unless the user explicitly asks to change it.
 - When updating `StartScene`, treat the legacy title block, loading block, tap-to-start placement, and loading timing as separate behaviors; do not change them unless requested.
 - Keep Godot client changes in GDScript and follow existing scene/script patterns already used in this project.
+- When the task involves launching the Godot project, running it, capturing runtime debug output, or performing scene/node operations through the editor/runtime, prefer the configured `godot` MCP server before relying on static inspection alone.
 - Before making Client frontend architecture, UI flow, scene flow, or shared-state changes, first read `docs/gdd/18_frontend_architecture.md`.
 - Prefer adding small, explicit UI state transitions instead of rewriting whole scene flows when only one stage changes.
 - The home flow now runs through `HomeShellScene` + `SceneNavigator`; keep `BattleScene` persistent there and open home subpages as overlays instead of replacing the battle scene with `change_scene_to_file(...)`.

--- a/scripts/StartScene.gd
+++ b/scripts/StartScene.gd
@@ -1556,10 +1556,12 @@ func _input(event: InputEvent) -> void:
 	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
 		if _is_event_on_logout_button(event.position):
 			return
+		UiAudio.unlock_from_user_gesture(false)
 		_start_game()
 	elif event is InputEventScreenTouch and event.pressed:
 		if _is_event_on_logout_button(event.position):
 			return
+		UiAudio.unlock_from_user_gesture(false)
 		_start_game()
 
 

--- a/scripts/ui/UiAudio.gd
+++ b/scripts/ui/UiAudio.gd
@@ -7,6 +7,7 @@ const SFX_BUS_NAME := "SFX"
 
 var _bgm_player: AudioStreamPlayer
 var _current_bgm_path: String = ""
+var _web_audio_unlocked: bool = false
 
 
 func _ready() -> void:
@@ -24,9 +25,21 @@ func should_play_for_button(button: BaseButton) -> bool:
 
 
 func play_ui_click() -> void:
+	unlock_from_user_gesture(true)
+
+
+func unlock_from_user_gesture(play_feedback: bool = false) -> void:
+	ensure_audio_buses()
+	var should_prime_silently: bool = _is_web_runtime() and not _web_audio_unlocked and not play_feedback
+	if _is_web_runtime() and not _web_audio_unlocked:
+		_resume_web_audio_contexts()
+		_web_audio_unlocked = true
 	if UI_BUTTON_CLICK_SFX == null:
 		return
-	play_sfx(UI_BUTTON_CLICK_SFX, 0.0, 1.0)
+	if should_prime_silently:
+		play_sfx(UI_BUTTON_CLICK_SFX, -80.0, 1.0)
+	elif play_feedback:
+		play_sfx(UI_BUTTON_CLICK_SFX, 0.0, 1.0)
 
 
 func ensure_audio_buses() -> void:
@@ -108,3 +121,33 @@ func _linear_to_db(value: float) -> float:
 	if value <= 0.0001:
 		return -80.0
 	return linear_to_db(value)
+
+
+func _is_web_runtime() -> bool:
+	return OS.has_feature("web")
+
+
+func _resume_web_audio_contexts() -> void:
+	if not _is_web_runtime():
+		return
+	if not ClassDB.class_exists("JavaScriptBridge"):
+		return
+	JavaScriptBridge.eval("""
+(() => {
+	const contexts = [];
+	if (window.godotAudioContext) contexts.push(window.godotAudioContext);
+	if (window.AudioContext && window.__mpdUnlockContext == null) {
+		try {
+			window.__mpdUnlockContext = new window.AudioContext();
+		} catch (_err) {}
+	}
+	if (window.__mpdUnlockContext) contexts.push(window.__mpdUnlockContext);
+	for (const context of contexts) {
+		if (context && typeof context.resume === 'function' && context.state !== 'running') {
+			try {
+				context.resume();
+			} catch (_err) {}
+		}
+	}
+})();
+""", true)


### PR DESCRIPTION
## 摘要
- 在 UiAudio 集中加入 Web 首次互動音訊解鎖流程
- 讓既有 UI 點擊音效在首次互動時自動完成解鎖
- 在 StartScene 的 tap-to-start 先做靜音 prime，避免第一下不是一般按鈕時仍無聲
- 補充 AGENTS.md 的 Godot MCP 使用規則

## 驗證
- 未執行 Godot runtime 驗證；本機環境找不到 godot 指令

## 範圍說明
- 僅納入 AGENTS.md、scripts/StartScene.gd、scripts/ui/UiAudio.gd
- 本機其餘對話框 / 事件系統草稿檔未納入本次提交

Closes #ISSUE_NUMBER_PLACEHOLDER