### PR TITLE
fix:修正 Chrome Web 音效解鎖與技能氣泡跟隨

### DIFF
--- a/scripts/cats/cat_node.gd
+++ b/scripts/cats/cat_node.gd
@@ -26,6 +26,7 @@ var _skill_bubble_panel: PanelContainer
 var _skill_bubble_label: Label
 var _skill_bubble_tail: Polygon2D
 var _skill_bubble_tween: Tween
+var _skill_bubble_float_offset_y: float = 0.0
 var _active_animation: String = ""
 var _move_tween: Tween
 var _revert_timer: SceneTreeTimer
@@ -95,6 +96,8 @@ func setup(id: int, team_name: String, name_str: String, hp: int, file_id: Strin
 func _process(_delta: float) -> void:
 	if _skill_bubble_root != null and _skill_bubble_root.visible and not SceneNavigator.get_current_overlay_scene_path().is_empty():
 		_hide_skill_bubble()
+	elif _skill_bubble_root != null and _skill_bubble_root.visible:
+		_update_skill_bubble_position()
 
 
 func reset_for_spawn() -> void:
@@ -416,7 +419,8 @@ func show_skill_bubble(skill_name: String) -> void:
 	_skill_bubble_label.position = Vector2(SKILL_BUBBLE_H_PADDING, 5.0)
 	_skill_bubble_label.size = Vector2(bubble_width - SKILL_BUBBLE_H_PADDING * 2.0, SKILL_BUBBLE_HEIGHT - 10.0)
 	_skill_bubble_tail.position = Vector2(0.0, SKILL_BUBBLE_TAIL_GAP - SKILL_BUBBLE_TAIL_HEIGHT - SKILL_BUBBLE_TAIL_VERTICAL_NUDGE_UP)
-	_skill_bubble_root.global_position = global_position + Vector2(0.0, -SKILL_BUBBLE_OFFSET_Y + SKILL_BUBBLE_VERTICAL_NUDGE_DOWN)
+	_skill_bubble_float_offset_y = 0.0
+	_update_skill_bubble_position()
 	_skill_bubble_root.scale = Vector2(0.92, 0.92)
 	_skill_bubble_root.modulate = Color(1.0, 1.0, 1.0, 0.0)
 	_skill_bubble_root.visible = true
@@ -427,7 +431,7 @@ func show_skill_bubble(skill_name: String) -> void:
 	_skill_bubble_tween.tween_property(_skill_bubble_root, "scale", Vector2.ONE, SKILL_BUBBLE_POP_TIME).set_trans(Tween.TRANS_BACK).set_ease(Tween.EASE_OUT)
 	_skill_bubble_tween.chain().tween_interval(SKILL_BUBBLE_HOLD_TIME)
 	_skill_bubble_tween.chain().tween_property(_skill_bubble_root, "modulate:a", 0.0, SKILL_BUBBLE_FADE_TIME).set_trans(Tween.TRANS_QUAD).set_ease(Tween.EASE_IN)
-	_skill_bubble_tween.parallel().tween_property(_skill_bubble_root, "global_position:y", _skill_bubble_root.global_position.y - 12.0, SKILL_BUBBLE_FADE_TIME).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN)
+	_skill_bubble_tween.parallel().tween_property(self, "_skill_bubble_float_offset_y", -12.0, SKILL_BUBBLE_FADE_TIME).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN)
 	_skill_bubble_tween.chain().tween_callback(Callable(self, "_hide_skill_bubble"))
 
 
@@ -603,7 +607,8 @@ func _hide_skill_bubble() -> void:
 	_skill_bubble_tween = null
 	if _skill_bubble_root != null and is_instance_valid(_skill_bubble_root):
 		_skill_bubble_root.visible = false
-		_skill_bubble_root.global_position = global_position + Vector2(0.0, -SKILL_BUBBLE_OFFSET_Y + SKILL_BUBBLE_VERTICAL_NUDGE_DOWN)
+		_skill_bubble_float_offset_y = 0.0
+		_update_skill_bubble_position()
 		_skill_bubble_root.scale = Vector2.ONE
 		_skill_bubble_root.modulate = Color(1.0, 1.0, 1.0, 1.0)
 
@@ -620,6 +625,15 @@ func _ensure_skill_bubble_root() -> void:
 	_skill_bubble_label = null
 	_skill_bubble_tail = null
 	_build_skill_bubble()
+
+
+func _update_skill_bubble_position() -> void:
+	if _skill_bubble_root == null or not is_instance_valid(_skill_bubble_root):
+		return
+	_skill_bubble_root.global_position = global_position + Vector2(
+		0.0,
+		-SKILL_BUBBLE_OFFSET_Y + SKILL_BUBBLE_VERTICAL_NUDGE_DOWN + _skill_bubble_float_offset_y
+	)
 
 
 func _play_loop(animation_name: String) -> void:

--- a/scripts/ui/UiAudio.gd
+++ b/scripts/ui/UiAudio.gd
@@ -16,6 +16,7 @@ func _ready() -> void:
 	_bgm_player.bus = BGM_BUS_NAME
 	_bgm_player.stream_paused = false
 	add_child(_bgm_player)
+	_install_web_audio_unlock_hooks()
 
 
 func should_play_for_button(button: BaseButton) -> bool:
@@ -31,9 +32,8 @@ func play_ui_click() -> void:
 func unlock_from_user_gesture(play_feedback: bool = false) -> void:
 	ensure_audio_buses()
 	var should_prime_silently: bool = _is_web_runtime() and not _web_audio_unlocked and not play_feedback
-	if _is_web_runtime() and not _web_audio_unlocked:
-		_resume_web_audio_contexts()
-		_web_audio_unlocked = true
+	if _is_web_runtime():
+		_web_audio_unlocked = _resume_web_audio_contexts()
 	if UI_BUTTON_CLICK_SFX == null:
 		return
 	if should_prime_silently:
@@ -57,6 +57,8 @@ func apply_settings(settings: Dictionary) -> void:
 func play_sfx(stream: AudioStream, volume_db: float = 0.0, pitch_scale: float = 1.0) -> void:
 	if stream == null:
 		return
+	if _is_web_runtime() and not _web_audio_unlocked:
+		_web_audio_unlocked = _resume_web_audio_contexts()
 	var player: AudioStreamPlayer = AudioStreamPlayer.new()
 	player.bus = SFX_BUS_NAME
 	player.stream = stream
@@ -71,6 +73,8 @@ func play_bgm(stream: AudioStream, restart: bool = false) -> void:
 	if stream == null:
 		return
 	ensure_audio_buses()
+	if _is_web_runtime() and not _web_audio_unlocked:
+		_web_audio_unlocked = _resume_web_audio_contexts()
 	if _bgm_player == null:
 		_bgm_player = AudioStreamPlayer.new()
 		_bgm_player.bus = BGM_BUS_NAME
@@ -127,27 +131,103 @@ func _is_web_runtime() -> bool:
 	return OS.has_feature("web")
 
 
-func _resume_web_audio_contexts() -> void:
+func _install_web_audio_unlock_hooks() -> void:
 	if not _is_web_runtime():
 		return
 	if not ClassDB.class_exists("JavaScriptBridge"):
 		return
 	JavaScriptBridge.eval("""
 (() => {
-	const contexts = [];
-	if (window.godotAudioContext) contexts.push(window.godotAudioContext);
-	if (window.AudioContext && window.__mpdUnlockContext == null) {
-		try {
-			window.__mpdUnlockContext = new window.AudioContext();
-		} catch (_err) {}
+	if (window.__mpdAudioUnlock && window.__mpdAudioUnlock.installed) {
+		return true;
 	}
-	if (window.__mpdUnlockContext) contexts.push(window.__mpdUnlockContext);
-	for (const context of contexts) {
-		if (context && typeof context.resume === 'function' && context.state !== 'running') {
-			try {
-				context.resume();
-			} catch (_err) {}
+	const bootstrap = window.__mpdAudioUnlock || {
+		contexts: new Set(),
+		installed: false,
+		registerContext(value) {
+			if (!value) return;
+			const hasResume = typeof value.resume === 'function';
+			const hasState = typeof value.state === 'string';
+			if (!hasResume || !hasState) return;
+			this.contexts.add(value);
+		},
+		inspectValue(value) {
+			if (!value) return;
+			this.registerContext(value);
+			if (typeof value !== 'object' && typeof value !== 'function') return;
+			try { this.registerContext(value.audioContext); } catch (_err) {}
+			try { this.registerContext(value.context); } catch (_err) {}
+			try { this.registerContext(value.ctx); } catch (_err) {}
+			try { this.registerContext(value.audio && value.audio.context); } catch (_err) {}
+		},
+		scanWindow() {
+			this.inspectValue(window.godotAudioContext);
+			for (const key of Object.getOwnPropertyNames(window)) {
+				try {
+					this.inspectValue(window[key]);
+				} catch (_err) {}
+			}
+		},
+		installConstructorHook(name) {
+			const Original = window[name];
+			if (typeof Original !== 'function' || Original.__mpdWrapped) return;
+			const bootstrapRef = this;
+			const Wrapped = class extends Original {
+				constructor(...args) {
+					super(...args);
+					bootstrapRef.registerContext(this);
+				}
+			};
+			try { Object.setPrototypeOf(Wrapped, Original); } catch (_err) {}
+			Wrapped.__mpdWrapped = true;
+			window[name] = Wrapped;
+		},
+		resumeAllContexts() {
+			this.scanWindow();
+			let unlocked = false;
+			for (const context of this.contexts) {
+				if (!context) continue;
+				if (context.state !== 'running') {
+					try {
+						context.resume();
+					} catch (_err) {}
+				}
+				if (context.state === 'running') {
+					unlocked = true;
+				}
+			}
+			return unlocked;
+		},
+		install() {
+			if (this.installed) return;
+			this.installConstructorHook('AudioContext');
+			this.installConstructorHook('webkitAudioContext');
+			const resume = () => this.resumeAllContexts();
+			['click', 'touchend', 'pointerup', 'keydown'].forEach((eventName) => {
+				document.addEventListener(eventName, resume, { capture: true, passive: true });
+			});
+			document.addEventListener('visibilitychange', () => {
+				if (document.visibilityState === 'visible') {
+					resume();
+				}
+			}, true);
+			this.installed = true;
 		}
-	}
+	};
+	window.__mpdAudioUnlock = bootstrap;
+	bootstrap.install();
+	return bootstrap.resumeAllContexts();
 })();
 """, true)
+
+
+func _resume_web_audio_contexts() -> bool:
+	if not _is_web_runtime():
+		return true
+	if not ClassDB.class_exists("JavaScriptBridge"):
+		return false
+	_install_web_audio_unlock_hooks()
+	var resume_result: Variant = JavaScriptBridge.eval("(() => window.__mpdAudioUnlock ? window.__mpdAudioUnlock.resumeAllContexts() : false)()", true)
+	if resume_result is bool:
+		return resume_result
+	return str(resume_result).to_lower() == "true"


### PR DESCRIPTION
## 變更內容
- 修正技能氣泡只在顯示瞬間定位、之後不再跟隨角色移動的問題。
- 修正 Chrome / GitHub Pages 上 Godot Web Audio 解鎖流程，改為在頁面層持續監聽使用者互動並恢復 AudioContext。
- 在 SFX/BGM 播放前補做保守解鎖重試，降低首次互動後仍無聲的機率。

## 驗證
- 目前未能在本機直接用 Godot 執行驗證，原因是此環境缺少可用的 Godot 執行檔。
- 已確認提交範圍僅包含 `scripts/cats/cat_node.gd` 與 `scripts/ui/UiAudio.gd`。

Closes #259