### PR TITLE
fix:修正 AudioContext 建構子呼叫方式

### DIFF
--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -19,7 +19,7 @@ vram_texture_compression/for_desktop=true
 vram_texture_compression/for_mobile=false
 html/export_icon=true
 html/custom_html_shell=""
-html/head_include="<script>!function(){var o=window.AudioContext||window.webkitAudioContext;if(!o)return;var s=new Set,r=function(){s.forEach(function(c){try{if(c.state!=='running')c.resume()}catch(e){}})};['click','touchend','pointerup','keydown'].forEach(function(e){document.addEventListener(e,r,{capture:true,passive:true})});function W(){o.apply(this,arguments);s.add(this)}W.prototype=o.prototype;Object.setPrototypeOf(W,o);window.AudioContext=W;if(window.webkitAudioContext)window.webkitAudioContext=W}();</script>"
+html/head_include="<script>!function(){var o=window.AudioContext||window.webkitAudioContext;if(!o)return;var s=new Set,r=function(){s.forEach(function(c){try{if(c.state!=='running')c.resume()}catch(e){}})};['click','touchend','pointerup','keydown'].forEach(function(e){document.addEventListener(e,r,{capture:true,passive:true})});class W extends o{constructor(){super();s.add(this)}}Object.setPrototypeOf(W,o);window.AudioContext=W;if(window.webkitAudioContext)window.webkitAudioContext=W}();</script>"
 html/canvas_resize_policy=2
 html/focus_canvas_on_start=true
 html/experimental_virtual_keyboard=true


### PR DESCRIPTION
## 變更內容

修正 xport_presets.cfg 中 Web 匯出 head_include 腳本的 AudioContext 包裝方式。

### 問題

原先使用 unction W(){ o.apply(this, arguments); ... } 包裝 AudioContext，但 AudioContext 是 DOM 建構子，不能以一般函式方式呼叫，導致：

> Failed to construct 'AudioContext': Please use the 'new' operator, this DOM object constructor cannot be called as a function.

### 修正

改用 class W extends o { constructor(){ super(); ... } } 方式，透過 super() 正確以 
ew 呼叫原始建構子。

Closes #264