### PR TITLE
feat:每日任務事件改為前端本地累積批次送出

### DIFF
--- a/scripts/ApiClient.gd
+++ b/scripts/ApiClient.gd
@@ -20,6 +20,10 @@ var _spinner_time := 0.0
 var _loading_text_phase := 0
 var _loading_text_elapsed := 0.0
 
+## Accumulated daily-task event counts keyed by event_key.
+## Flushed in batch when the player opens the daily-tasks dialog.
+var _pending_daily_task_events: Dictionary = {}
+
 
 func _ready() -> void:
 	for i in range(POOL_SIZE):
@@ -181,7 +185,40 @@ func claim_daily_task(task_key: String, callback: Callable) -> void:
 
 
 func record_daily_task_event(event_key: String, callback: Callable = Callable()) -> void:
-	_api_post_tracked("daily-tasks/events", {"eventKey": event_key, "count": 1}, callback, false)
+	var key := event_key.strip_edges()
+	if key.is_empty():
+		return
+	_pending_daily_task_events[key] = int(_pending_daily_task_events.get(key, 0)) + 1
+	GameState.set_daily_task_events_pending(true)
+
+
+func has_pending_daily_task_events() -> bool:
+	return not _pending_daily_task_events.is_empty()
+
+
+func flush_daily_task_events(callback: Callable) -> void:
+	if _pending_daily_task_events.is_empty():
+		callback.call(false, {}, {})
+		return
+	var events_to_flush: Dictionary = _pending_daily_task_events.duplicate()
+	_pending_daily_task_events.clear()
+	GameState.set_daily_task_events_pending(false)
+	_flush_daily_task_events_sequential(events_to_flush.keys(), events_to_flush, 0, callback)
+
+
+func _flush_daily_task_events_sequential(keys: Array, counts: Dictionary, index: int, final_callback: Callable) -> void:
+	if index >= keys.size():
+		if _can_invoke_callable(final_callback):
+			final_callback.call(true, {}, {})
+		return
+	var event_key: String = keys[index]
+	var count: int = int(counts[event_key])
+	_api_post_tracked("daily-tasks/events", {"eventKey": event_key, "count": count},
+		Callable(self, "_on_flush_daily_task_event_done").bind(keys, counts, index, final_callback), false)
+
+
+func _on_flush_daily_task_event_done(ok: bool, data: Variant, err: Dictionary, keys: Array, counts: Dictionary, index: int, final_callback: Callable) -> void:
+	_flush_daily_task_events_sequential(keys, counts, index + 1, final_callback)
 
 
 func get_profile_me(callback: Callable) -> void:

--- a/scripts/battle/battle_scene.gd
+++ b/scripts/battle/battle_scene.gd
@@ -1857,6 +1857,7 @@ func _refresh_home_red_dots() -> void:
 	RedDotService.refresh_dot(_home_more_buttons.get("mail") as Control, RedDotService.has_mail_red_dot())
 	RedDotService.refresh_dot(_home_more_buttons.get("friend") as Control, RedDotService.has_friend_red_dot())
 	RedDotService.refresh_dot(_home_more_buttons.get("party") as Control, RedDotService.has_party_red_dot())
+	RedDotService.refresh_dot(_home_more_buttons.get("daily_tasks") as Control, RedDotService.has_daily_task_red_dot())
 	_refresh_mail_badge()
 
 
@@ -3166,6 +3167,13 @@ func _on_nav_announcements() -> void:
 
 func _on_nav_daily_tasks() -> void:
 	_close_home_more_menu()
+	if ApiClient.has_pending_daily_task_events():
+		ApiClient.flush_daily_task_events(Callable(self, "_on_daily_task_events_flushed"))
+		return
+	ApiClient.get_daily_tasks(Callable(self, "_on_daily_tasks_loaded"))
+
+
+func _on_daily_task_events_flushed(_ok: bool, _data: Variant, _err: Dictionary) -> void:
 	ApiClient.get_daily_tasks(Callable(self, "_on_daily_tasks_loaded"))
 
 

--- a/scripts/gamestate/GameState.gd
+++ b/scripts/gamestate/GameState.gd
@@ -115,6 +115,7 @@ func clear_persisted_player_state() -> void:
 	party_red_dot_summary = {}
 	_pending_combat_power_change = {}
 	_suppress_combat_power_notifications = true
+	daily_task_events_pending = false
 	clear_chat_state()
 	set_party_cheer_coupon_count(0)
 	_emit_red_dot_state_changed()
@@ -150,6 +151,13 @@ func clear_party_red_dot_summary() -> void:
 	if party_red_dot_summary.is_empty():
 		return
 	party_red_dot_summary = {}
+	_emit_red_dot_state_changed()
+
+
+func set_daily_task_events_pending(value: bool) -> void:
+	if daily_task_events_pending == value:
+		return
+	daily_task_events_pending = value
 	_emit_red_dot_state_changed()
 
 
@@ -705,6 +713,7 @@ var party_cheer_status_data: Dictionary = {}
 var party_applications_data: Array = []
 var party_my_applications_data: Array = []
 var party_red_dot_summary: Dictionary = {}
+var daily_task_events_pending: bool = false
 var combat_trial_battle_payload: Dictionary = {}
 
 

--- a/scripts/ui/red_dot_service.gd
+++ b/scripts/ui/red_dot_service.gd
@@ -251,8 +251,15 @@ static func has_enhance_red_dot() -> bool:
 	return false
 
 
+static func has_daily_task_red_dot() -> bool:
+	var game_state: Node = _get_game_state()
+	if game_state == null:
+		return false
+	return bool(game_state.daily_task_events_pending)
+
+
 static func has_more_menu_red_dot() -> bool:
-	return has_mail_red_dot() or has_friend_red_dot() or has_party_red_dot()
+	return has_mail_red_dot() or has_friend_red_dot() or has_party_red_dot() or has_daily_task_red_dot()
 
 
 static func has_party_chat_red_dot() -> bool:


### PR DESCRIPTION
## 變更說明
將每日任務事件從「每次操作成功立即發 API」改為「前端本地累積 + 開啟面板時批次送出」，大幅減少 `POST /api/daily-tasks/events` 請求次數。

## 改動重點
- **ApiClient.gd**: `record_daily_task_event()` 改為寫入 `_pending_daily_task_events` Dictionary；新增 `flush_daily_task_events()` 批次送出
- **GameState.gd**: 新增 `daily_task_events_pending` 旗標，變更時觸發 `red_dot_state_changed`signal
- **red_dot_service.gd**: 新增 `has_daily_task_red_dot()`，納入 `has_more_menu_red_dot()`  
- **battle_scene.gd**: 每日任務按鈕加紅點；開啟面板先 flush 再載入 overview

Closes #266