### PR TITLE
fix:修正 Production workflow environment 語法格式

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -16,7 +16,8 @@ concurrency:
 jobs:
   export-web:
     runs-on: ubuntu-latest
-    environment: Production
+    environment:
+      name: Production
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## 變更內容

將 `deploy-production.yml` 的 `environment` 從字串語法改為物件語法，消除 GitHub Actions 擴充套件的驗證警告。

Closes #268