### PR TITLE
fix:修正誘捕點數商城分頁 category_type 過濾失效問題

### DIFF
--- a/scripts/shop/ShopScene.gd
+++ b/scripts/shop/ShopScene.gd
@@ -16,7 +16,7 @@ const CATEGORY_CONFIGS := [
 	{"key": TAB_VALUE, "label": "SHOP_SUBMENU_VALUE", "category_type": "valuepack"},
 	{"key": TAB_COLLISION_COIN, "label": "SHOP_SUBMENU_COLLISION_COIN"},
 	{"key": TAB_DIAMOND_STORE, "label": "SHOP_SUBMENU_DIAMOND_STORE"},
-	{"key": TAB_POINT, "label": "SHOP_SUBMENU_POINT", "category_type": "pointpack"},
+	{"key": TAB_POINT, "label": "SHOP_SUBMENU_POINT", "category_type": "trappointshop"},
 ]
 
 const COLLISION_COIN_ITEMS := [


### PR DESCRIPTION
## 關聯 Issue
Closes #290

## 變更摘要
ShopScene.gd CATEGORY_CONFIGS 誘捕商城 tab 的 category_type 從 "pointpack" 修正為 "trappointshop"，對應後端 API 回傳的 TrapPointShop enum 經 _to_snake_case 轉換後的字串。