### PR TITLE
feat:關卡對手成長系統（分段 HP/ATK 倍率計算邏輯）

### DIFF
--- a/scripts/battle/battle_scene.gd
+++ b/scripts/battle/battle_scene.gd
@@ -2773,14 +2773,15 @@ func _start_battle_internal() -> void:
 		else:
 			push_error("BattleScene: failed to load player cat " + cat_id)
 
-	var diff_mult: float = GameState.get_difficulty_multiplier()
+	var hp_mult: float = GameState.get_difficulty_hp_multiplier()
+	var atk_mult: float = GameState.get_difficulty_atk_multiplier()
 	for cat_id: String in GameState.get_enemy_ids():
 		var path := cat_id + ".json"
 		var data := CatData.from_json_file(path)
 		if data:
-			data.max_hp  = roundi(data.max_hp  * diff_mult)
-			data.atk     = roundi(data.atk     * diff_mult)
-			data.weight  = roundi(data.weight  * diff_mult)
+			data.max_hp  = roundi(data.max_hp  * hp_mult)
+			data.atk     = roundi(data.atk     * atk_mult)
+			data.weight  = roundi(data.weight  * hp_mult)
 			enemy_cats.append(data)
 		else:
 			push_error("BattleScene: failed to load enemy cat " + cat_id)

--- a/scripts/gamestate/GameState.gd
+++ b/scripts/gamestate/GameState.gd
@@ -2032,7 +2032,13 @@ func get_level_display() -> String:
 	return BossStage.get_level_display(current_global_stage, boss_config)
 
 func get_difficulty_multiplier() -> float:
-	return BossStage.get_difficulty_multiplier(current_global_stage, boss_config)
+	return BossStage.get_difficulty_hp_multiplier(current_global_stage, boss_config)
+
+func get_difficulty_hp_multiplier() -> float:
+	return BossStage.get_difficulty_hp_multiplier(current_global_stage, boss_config)
+
+func get_difficulty_atk_multiplier() -> float:
+	return BossStage.get_difficulty_atk_multiplier(current_global_stage, boss_config)
 
 func get_enemy_ids() -> Array:
 	return BossStage.get_enemy_ids(current_global_stage, boss_config, stage_opponent_config)

--- a/scripts/gamestate/GameStateBossStage.gd
+++ b/scripts/gamestate/GameStateBossStage.gd
@@ -104,16 +104,70 @@ static func _get_zone_suffix(z: int, boss_cfg: Dictionary) -> String:
 
 # ── Difficulty calculation ───────────────────────────────
 
-## Return the enemy stat multiplier for the current stage
-## Regular encounters: +0.3% compound growth per stage (Stage track)
-## Boss battles: +2% compound growth per Boss (Boss track)
-static func get_difficulty_multiplier(current_stage: int, boss_cfg: Dictionary) -> float:
-	var stage_growth: float = float(boss_cfg.get("stage_growth", 1.003))
-	var boss_growth: float  = float(boss_cfg.get("boss_growth", 1.02))
+## Return the enemy stat multiplier for the current stage.
+## Return the enemy HP stat multiplier for the current stage.
+static func get_difficulty_hp_multiplier(current_stage: int, boss_cfg: Dictionary) -> float:
 	if is_current_boss(current_stage, boss_cfg):
-		return pow(boss_growth, get_boss_stage_number(current_stage, boss_cfg))
+		return _calc_boss_multiplier(get_boss_stage_number(current_stage, boss_cfg), boss_cfg, "hp_rate")
 	else:
+		return _calc_encounter_multiplier(current_stage, boss_cfg, "hp_rate")
+
+
+## Return the enemy ATK stat multiplier for the current stage.
+static func get_difficulty_atk_multiplier(current_stage: int, boss_cfg: Dictionary) -> float:
+	if is_current_boss(current_stage, boss_cfg):
+		return _calc_boss_multiplier(get_boss_stage_number(current_stage, boss_cfg), boss_cfg, "atk_rate")
+	else:
+		return _calc_encounter_multiplier(current_stage, boss_cfg, "atk_rate")
+
+
+## Legacy single-multiplier accessor — returns hp multiplier for backward compatibility.
+static func get_difficulty_multiplier(current_stage: int, boss_cfg: Dictionary) -> float:
+	return get_difficulty_hp_multiplier(current_stage, boss_cfg)
+
+
+## Calculate the encounter difficulty multiplier using segmented rates.
+## stat_key: "hp_rate" or "atk_rate"; falls back to "rate" then to default.
+## Falls back to pow(stage_growth, stage-1) when growth_segments is missing.
+static func _calc_encounter_multiplier(current_stage: int, boss_cfg: Dictionary, stat_key: String = "hp_rate") -> float:
+	var segments: Array = boss_cfg.get("growth_segments", [])
+	if segments.is_empty():
+		var stage_growth: float = float(boss_cfg.get("stage_growth", 1.001))
 		return pow(stage_growth, current_stage - 1)
+	var mult: float = 1.0
+	var prev_stage: int = 1
+	for seg: Dictionary in segments:
+		var until: int = int(seg.get("until_stage", 999999))
+		var rate: float = float(seg.get(stat_key, seg.get("rate", 1.001)))
+		var apply_to: int = mini(current_stage, until + 1)
+		var stages_in_seg: int = maxi(0, apply_to - prev_stage)
+		mult *= pow(rate, stages_in_seg)
+		prev_stage = until + 1
+		if current_stage <= until:
+			break
+	return mult
+
+
+## Calculate the boss difficulty multiplier using segmented rates.
+## stat_key: "hp_rate" or "atk_rate"; falls back to "rate" then to default.
+## Falls back to pow(boss_growth, boss_number) when boss_growth_segments is missing.
+static func _calc_boss_multiplier(boss_number: int, boss_cfg: Dictionary, stat_key: String = "hp_rate") -> float:
+	var segments: Array = boss_cfg.get("boss_growth_segments", [])
+	if segments.is_empty():
+		var boss_growth: float = float(boss_cfg.get("boss_growth", 1.02))
+		return pow(boss_growth, boss_number)
+	var mult: float = 1.0
+	var prev_boss: int = 0
+	for seg: Dictionary in segments:
+		var until: int = int(seg.get("until_boss", 999999))
+		var rate: float = float(seg.get(stat_key, seg.get("rate", 1.02)))
+		var apply_to: int = mini(boss_number, until + 1)
+		var bosses_in_seg: int = maxi(0, apply_to - prev_boss)
+		mult *= pow(rate, bosses_in_seg)
+		prev_boss = until + 1
+		if boss_number <= until:
+			break
+	return mult
 
 
 # ── Enemy generation ───────────────────────────────


### PR DESCRIPTION
## 功能說明

實作客戶端關卡對手成長邏輯，支援遭遇戰與 Boss 戰分段成長，HP 與 ATK 倍率各自獨立計算。

## 變更清單

### GameStateBossStage.gd
- 新增 get_difficulty_hp_multiplier() / get_difficulty_atk_multiplier() 靜態方法
- _calc_encounter_multiplier() 讀取 growth_segments（3 段）
- _calc_boss_multiplier() 讀取 oss_growth_segments（4 段）
- 舊方法保留 legacy fallback

### GameState.gd
- 新增 HP / ATK 倍率 wrapper 方法

### battle_scene.gd
- max_hp、weight 套用 HP 倍率
- tk 套用 ATK 倍率（獨立成長）

## 關聯 Issue

Closes #292