### PR TITLE
fix:清理 Godot MCP 場景檢查錯誤

### DIFF
--- a/scenes/ui/activity/dungeon/DungeonContentEditor.tscn
+++ b/scenes/ui/activity/dungeon/DungeonContentEditor.tscn
@@ -5,13 +5,13 @@
 [ext_resource type="Texture2D" uid="uid://d3t6ulbaubpos" path="res://assets/sprites/ui/common/content_m2_default_v1.png" id="3"]
 [ext_resource type="Texture2D" uid="uid://c4xrlbul504g4" path="res://assets/sprites/ui/common/button_m_default_v1.png" id="4"]
 [ext_resource type="Texture2D" uid="uid://b3j1goddylwph" path="res://assets/sprites/ui/common/function_bar_m_v1.png" id="4_vb5tr"]
-[ext_resource type="Texture2D" uid="uid://c3nd53fjl233k" path="res://assets/sprites/cdn/ui/dungeon/cat_food.png" id="5"]
+[ext_resource type="Texture2D" path="res://assets/sprites/cdn/ui/dungeon/cat_food.png" id="5"]
 [ext_resource type="Texture2D" uid="uid://dqvpwaof3j1ld" path="res://assets/sprites/ui/rewards/item_slot_frame_wood.png" id="6"]
 [ext_resource type="Texture2D" uid="uid://bgnlujru3nkkk" path="res://assets/sprites/ui/rewards/item_slot_overlay_mask.png" id="7"]
-[ext_resource type="Texture2D" uid="uid://c3js2wqott8ic" path="res://assets/sprites/cdn/ui/rewards/cat_food.png" id="8"]
-[ext_resource type="Texture2D" uid="uid://cf1k0vs51rj6g" path="res://assets/sprites/cdn/ui/rewards/special_cat_food.png" id="9"]
+[ext_resource type="Texture2D" path="res://assets/sprites/cdn/ui/rewards/cat_food.png" id="8"]
+[ext_resource type="Texture2D" path="res://assets/sprites/cdn/ui/rewards/special_cat_food.png" id="9"]
 [ext_resource type="Texture2D" uid="uid://bakdwyhnhd6rl" path="res://assets/sprites/ui/rewards/diamonds.png" id="10"]
-[ext_resource type="Texture2D" uid="uid://xhh112x8cax4" path="res://assets/sprites/cdn/ui/rewards/trap_cages.png" id="11"]
+[ext_resource type="Texture2D" path="res://assets/sprites/cdn/ui/rewards/trap_cages.png" id="11"]
 
 [node name="DungeonContentEditor" type="Control" unique_id=701516299]
 layout_mode = 3

--- a/scenes/ui/activity/dungeon/DungeonContentEditorPreview.tscn
+++ b/scenes/ui/activity/dungeon/DungeonContentEditorPreview.tscn
@@ -5,13 +5,13 @@
 [ext_resource type="Texture2D" uid="uid://d3t6ulbaubpos" path="res://assets/sprites/ui/common/content_m2_default_v1.png" id="3"]
 [ext_resource type="Texture2D" uid="uid://c4xrlbul504g4" path="res://assets/sprites/ui/common/button_m_default_v1.png" id="4"]
 [ext_resource type="Texture2D" uid="uid://b3j1goddylwph" path="res://assets/sprites/ui/common/function_bar_m_v1.png" id="4_vb5tr"]
-[ext_resource type="Texture2D" uid="uid://c3nd53fjl233k" path="res://assets/sprites/cdn/ui/dungeon/cat_food.png" id="5"]
+[ext_resource type="Texture2D" path="res://assets/sprites/cdn/ui/dungeon/cat_food.png" id="5"]
 [ext_resource type="Texture2D" uid="uid://dqvpwaof3j1ld" path="res://assets/sprites/ui/rewards/item_slot_frame_wood.png" id="6"]
 [ext_resource type="Texture2D" uid="uid://bgnlujru3nkkk" path="res://assets/sprites/ui/rewards/item_slot_overlay_mask.png" id="7"]
-[ext_resource type="Texture2D" uid="uid://c3js2wqott8ic" path="res://assets/sprites/cdn/ui/rewards/cat_food.png" id="8"]
-[ext_resource type="Texture2D" uid="uid://cf1k0vs51rj6g" path="res://assets/sprites/cdn/ui/rewards/special_cat_food.png" id="9"]
+[ext_resource type="Texture2D" path="res://assets/sprites/cdn/ui/rewards/cat_food.png" id="8"]
+[ext_resource type="Texture2D" path="res://assets/sprites/cdn/ui/rewards/special_cat_food.png" id="9"]
 [ext_resource type="Texture2D" uid="uid://bakdwyhnhd6rl" path="res://assets/sprites/ui/rewards/diamonds.png" id="10"]
-[ext_resource type="Texture2D" uid="uid://xhh112x8cax4" path="res://assets/sprites/cdn/ui/rewards/trap_cages.png" id="11"]
+[ext_resource type="Texture2D" path="res://assets/sprites/cdn/ui/rewards/trap_cages.png" id="11"]
 
 [node name="DungeonContentEditor" type="Control" unique_id=701516299]
 layout_mode = 3

--- a/scenes/ui/activity/expedition/ExpeditionZoneCardTemplate.tscn
+++ b/scenes/ui/activity/expedition/ExpeditionZoneCardTemplate.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Theme" uid="uid://b2vhdk7k3wwmo" path="res://resources/default_theme.tres" id="1"]
 [ext_resource type="Texture2D" uid="uid://ud0q1ef7irvk" path="res://assets/sprites/ui/common/content_s2_default_uncheck_v1.png" id="2"]
-[ext_resource type="Texture2D" uid="uid://b8ooeufjfoikf" path="res://assets/sprites/cdn/ui/activity/activity_background_v1.png" id="3"]
+[ext_resource type="Texture2D" path="res://assets/sprites/cdn/ui/activity/activity_background_v1.png" id="3"]
 
 [sub_resource type="StyleBoxFlat" id="1"]
 bg_color = Color(0.19, 0.17, 0.15, 0)

--- a/scenes/ui/activity/permanent/PermanentActivityCardTemplate.tscn
+++ b/scenes/ui/activity/permanent/PermanentActivityCardTemplate.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Theme" uid="uid://b2vhdk7k3wwmo" path="res://resources/default_theme.tres" id="1"]
 [ext_resource type="Texture2D" uid="uid://ud0q1ef7irvk" path="res://assets/sprites/ui/common/content_s2_default_uncheck_v1.png" id="2"]
-[ext_resource type="Texture2D" uid="uid://b8ooeufjfoikf" path="res://assets/sprites/cdn/ui/activity/activity_background_v1.png" id="3"]
+[ext_resource type="Texture2D" path="res://assets/sprites/cdn/ui/activity/activity_background_v1.png" id="3"]
 
 [sub_resource type="StyleBoxFlat" id="1"]
 bg_color = Color(0.19, 0.17, 0.15, 0)

--- a/scenes/ui/arena/rewards/ArenaRewardRowEditor.tscn
+++ b/scenes/ui/arena/rewards/ArenaRewardRowEditor.tscn
@@ -2,12 +2,12 @@
 
 [ext_resource type="Theme" uid="uid://b2vhdk7k3wwmo" path="res://resources/default_theme.tres" id="1"]
 [ext_resource type="Texture2D" uid="uid://bdvfq1i266esl" path="res://assets/sprites/ui/common/button_bar_m_default.png" id="2"]
-[ext_resource type="Texture2D" uid="uid://bkbp52enbnm0p" path="res://assets/sprites/cdn/ui/arena_ranks/master_1.png" id="3"]
+[ext_resource type="Texture2D" path="res://assets/sprites/cdn/ui/arena_ranks/master_1.png" id="3"]
 [ext_resource type="Texture2D" uid="uid://dqvpwaof3j1ld" path="res://assets/sprites/ui/rewards/item_slot_frame_wood.png" id="4"]
 [ext_resource type="Texture2D" uid="uid://bgnlujru3nkkk" path="res://assets/sprites/ui/rewards/item_slot_overlay_mask.png" id="5"]
 [ext_resource type="Texture2D" uid="uid://bakdwyhnhd6rl" path="res://assets/sprites/ui/rewards/diamonds.png" id="6"]
-[ext_resource type="Texture2D" uid="uid://xhh112x8cax4" path="res://assets/sprites/cdn/ui/rewards/trap_cages.png" id="7"]
-[ext_resource type="Texture2D" uid="uid://cf1k0vs51rj6g" path="res://assets/sprites/cdn/ui/rewards/special_cat_food.png" id="8"]
+[ext_resource type="Texture2D" path="res://assets/sprites/cdn/ui/rewards/trap_cages.png" id="7"]
+[ext_resource type="Texture2D" path="res://assets/sprites/cdn/ui/rewards/special_cat_food.png" id="8"]
 
 [sub_resource type="StyleBoxFlat" id="1"]
 bg_color = Color(0.8, 0.7, 0.43, 0.98)

--- a/scenes/ui/scooper/ScooperContentEditor.tscn
+++ b/scenes/ui/scooper/ScooperContentEditor.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Theme" uid="uid://b2vhdk7k3wwmo" path="res://resources/default_theme.tres" id="1"]
 [ext_resource type="Texture2D" uid="uid://bgfob8og7uoum" path="res://assets/sprites/ui/common/content_s_default_v1.png" id="2_w7vmv"]
 [ext_resource type="Texture2D" uid="uid://dqvpwaof3j1ld" path="res://assets/sprites/ui/rewards/item_slot_frame_wood.png" id="3_k7nah"]
-[ext_resource type="Texture2D" uid="uid://313it5185y0g" path="res://assets/sprites/cdn/ui/scooper_equipment/food_bowl.png" id="4"]
+[ext_resource type="Texture2D" path="res://assets/sprites/cdn/ui/scooper_equipment/food_bowl.png" id="4"]
 
 [sub_resource type="StyleBoxFlat" id="1"]
 bg_color = Color(0.16, 0.14, 0.12, 1)

--- a/scenes/ui/scooper/ability/ScooperAbilityCardTemplate.tscn
+++ b/scenes/ui/scooper/ability/ScooperAbilityCardTemplate.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Theme" uid="uid://b2vhdk7k3wwmo" path="res://resources/default_theme.tres" id="1"]
 [ext_resource type="Texture2D" uid="uid://cxuk30ilrjkb7" path="res://assets/sprites/ui/common/content_s_default_uncheck_v1.png" id="2"]
 [ext_resource type="Texture2D" uid="uid://dqvpwaof3j1ld" path="res://assets/sprites/ui/rewards/item_slot_frame_wood.png" id="3"]
-[ext_resource type="Texture2D" uid="uid://3ispmsnkb4cm" path="res://assets/sprites/cdn/ui/scooper_abilities/triple_speed.png" id="4"]
+[ext_resource type="Texture2D" path="res://assets/sprites/cdn/ui/scooper_abilities/triple_speed.png" id="4"]
 
 [sub_resource type="StyleBoxFlat" id="1"]
 bg_color = Color(0.19, 0.17, 0.15, 0)

--- a/scenes/ui/scooper/achievement/ScooperAchievementCardTemplate.tscn
+++ b/scenes/ui/scooper/achievement/ScooperAchievementCardTemplate.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Theme" uid="uid://b2vhdk7k3wwmo" path="res://resources/default_theme.tres" id="1"]
 [ext_resource type="Texture2D" uid="uid://df5tkswcfbvwd" path="res://assets/sprites/ui/common/content_xs_default_uncheck_v1.png" id="2_o2l61"]
 [ext_resource type="Texture2D" uid="uid://dqvpwaof3j1ld" path="res://assets/sprites/ui/rewards/item_slot_frame_wood.png" id="3_3f78s"]
-[ext_resource type="Texture2D" uid="uid://3ispmsnkb4cm" path="res://assets/sprites/cdn/ui/scooper_abilities/triple_speed.png" id="4_u3pah"]
+[ext_resource type="Texture2D" path="res://assets/sprites/cdn/ui/scooper_abilities/triple_speed.png" id="4_u3pah"]
 
 [sub_resource type="StyleBoxFlat" id="1"]
 bg_color = Color(0.19, 0.17, 0.15, 0)

--- a/scenes/ui/scooper/equipment/ScooperEquipmentCardTemplate.tscn
+++ b/scenes/ui/scooper/equipment/ScooperEquipmentCardTemplate.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Theme" uid="uid://b2vhdk7k3wwmo" path="res://resources/default_theme.tres" id="1"]
 [ext_resource type="Texture2D" uid="uid://bgfob8og7uoum" path="res://assets/sprites/ui/common/content_s_default_v1.png" id="2"]
 [ext_resource type="Texture2D" uid="uid://dqvpwaof3j1ld" path="res://assets/sprites/ui/rewards/item_slot_frame_wood.png" id="3"]
-[ext_resource type="Texture2D" uid="uid://313it5185y0g" path="res://assets/sprites/cdn/ui/scooper_equipment/food_bowl.png" id="4"]
+[ext_resource type="Texture2D" path="res://assets/sprites/cdn/ui/scooper_equipment/food_bowl.png" id="4"]
 
 [sub_resource type="StyleBoxFlat" id="1"]
 bg_color = Color(0.19, 0.35, 0.23, 1)

--- a/scenes/ui/scooper/treasure/ScooperTreasureCardTemplate.tscn
+++ b/scenes/ui/scooper/treasure/ScooperTreasureCardTemplate.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Theme" uid="uid://b2vhdk7k3wwmo" path="res://resources/default_theme.tres" id="1"]
 [ext_resource type="Texture2D" uid="uid://cxuk30ilrjkb7" path="res://assets/sprites/ui/common/content_s_default_uncheck_v1.png" id="2"]
 [ext_resource type="Texture2D" uid="uid://dqvpwaof3j1ld" path="res://assets/sprites/ui/rewards/item_slot_frame_wood.png" id="3"]
-[ext_resource type="Texture2D" uid="uid://cnggq4m2jt17d" path="res://assets/sprites/cdn/ui/treasure/moon_chime.png" id="4"]
+[ext_resource type="Texture2D" path="res://assets/sprites/cdn/ui/treasure/moon_chime.png" id="4"]
 
 [sub_resource type="StyleBoxFlat" id="1"]
 bg_color = Color(0.19, 0.17, 0.15, 0)

--- a/scripts/ApiClient.gd
+++ b/scripts/ApiClient.gd
@@ -26,6 +26,11 @@ var _pending_daily_task_events: Dictionary = {}
 
 
 func _ready() -> void:
+	if GameState.api_base_url.strip_edges().is_empty():
+		var resolved_api_base_url: String = RuntimeConfig.get_api_base_url("")
+		if not resolved_api_base_url.is_empty():
+			GameState.api_base_url = resolved_api_base_url
+
 	for i in range(POOL_SIZE):
 		var http := HTTPRequest.new()
 		http.timeout = REQUEST_TIMEOUT

--- a/scripts/dungeon/DungeonSceneUI.gd
+++ b/scripts/dungeon/DungeonSceneUI.gd
@@ -257,7 +257,6 @@ static func _ensure_card_hit_button(card: Control) -> Button:
 	var action_texture: TextureRect = card.get_node("ActionButton") as TextureRect
 	var button: Button = Button.new()
 	button.name = "HitButton"
-	button.layout_mode = 0
 	button.offset_left = action_texture.offset_left
 	button.offset_top = action_texture.offset_top
 	button.offset_right = action_texture.offset_right

--- a/scripts/enhance/EnhanceSceneUI.gd
+++ b/scripts/enhance/EnhanceSceneUI.gd
@@ -204,7 +204,7 @@ static func populate_catalog_buttons(scene) -> void:
 	if scene._selected_cat_id == "" and cat_ids.size() > 0:
 		scene._selected_cat_id = cat_ids[0]
 	if scene._selected_cat_id != "" and not cat_ids.has(scene._selected_cat_id):
-		scene._selected_cat_id = cat_ids[0]
+		scene._selected_cat_id = cat_ids[0] if cat_ids.size() > 0 else ""
 
 	if cat_ids.is_empty():
 		var empty_label := Label.new()

--- a/scripts/expedition/ExpeditionScene.gd
+++ b/scripts/expedition/ExpeditionScene.gd
@@ -23,7 +23,7 @@ func _ready() -> void:
 
 
 func _process(_delta: float) -> void:
-	var now_unix: int = Time.get_unix_time_from_system()
+	var now_unix: int = int(Time.get_unix_time_from_system())
 	var should_refresh: bool = false
 	for zone_key_variant: Variant in _countdown_labels.keys():
 		var entry_variant: Variant = _countdown_labels.get(zone_key_variant, {})
@@ -167,7 +167,7 @@ func _get_active_expedition_count() -> int:
 
 func _get_claimable_expedition_count() -> int:
 	var claimable_count: int = 0
-	var now_unix: int = Time.get_unix_time_from_system()
+	var now_unix: int = int(Time.get_unix_time_from_system())
 	for expedition_variant: Variant in GameState.expedition_data:
 		if not (expedition_variant is Dictionary):
 			continue
@@ -262,7 +262,7 @@ func _make_zone_card(zone: Dictionary) -> Control:
 		"completesAtUnixSeconds": int(expedition.get("completesAtUnixSeconds", 0)),
 	}
 
-	action_button.text = UiText.EXPEDITION_REMAINING_TIME_FORMAT % _format_remaining_time(maxi(int(expedition.get("completesAtUnixSeconds", 0)) - Time.get_unix_time_from_system(), 0))
+	action_button.text = UiText.EXPEDITION_REMAINING_TIME_FORMAT % _format_remaining_time(maxi(int(expedition.get("completesAtUnixSeconds", 0)) - int(Time.get_unix_time_from_system()), 0))
 	action_button.disabled = true
 	UiPalette.apply_button_kind(action_button, "neutral")
 	return card
@@ -612,8 +612,8 @@ func _get_cat_display_name(cat_id: String) -> String:
 
 
 func _format_remaining_time(seconds_left: int) -> String:
-	var hours: int = seconds_left / 3600
-	var minutes: int = (seconds_left % 3600) / 60
+	var hours: int = floori(float(seconds_left) / 3600.0)
+	var minutes: int = floori(float(seconds_left % 3600) / 60.0)
 	var seconds: int = seconds_left % 60
 	return UiText.EXPEDITION_TIME_FORMAT % [hours, minutes, seconds]
 

--- a/scripts/navigation/SceneNavigator.gd
+++ b/scripts/navigation/SceneNavigator.gd
@@ -40,7 +40,7 @@ func open_overlay_scene(scene_path: String) -> void:
 		_home_shell.call_deferred("show_overlay_scene", scene_path)
 		return
 	_pending_overlay_scene_path = scene_path
-	get_tree().change_scene_to_file(HOME_SHELL_SCENE_PATH)
+	call_deferred("_change_to_home_shell_for_pending_overlay")
 
 
 func toggle_overlay_scene(scene_path: String) -> void:
@@ -61,3 +61,9 @@ func return_to_battle() -> void:
 
 func get_current_overlay_scene_path() -> String:
 	return _current_overlay_scene_path
+
+
+func _change_to_home_shell_for_pending_overlay() -> void:
+	if _pending_overlay_scene_path == "":
+		return
+	get_tree().change_scene_to_file(HOME_SHELL_SCENE_PATH)


### PR DESCRIPTION
## 變更內容
- 移除多個 UI template 中已失效的資源 UID，保留實際 path 載入，避免 Godot MCP 場景檢查出現缺圖或 invalid UID 雜訊。
- 修正 EnhanceScene 圖鑑清單為空時仍取第一筆造成的 crash。
- 讓 ApiClient 在非 StartScene 入口啟動時可用 RuntimeConfig 初始化 API base URL，避免 standalone scene 檢查產生無效 URL。
- 修正 ExpeditionScene 的時間與型別轉換警告。
- 將 SceneNavigator 的 HomeShell 切換延後執行，避免 _ready 階段 parent busy 時 remove_child 失敗。

## 驗證
- Godot MCP：原工作區已跑過 StartScene、ActivityScene、DungeonScene、ArenaScene、ScooperScene、ExpeditionScene 等主要入口 smoke test。
- git diff --check 通過。
- stale UID 搜尋無殘留。

## 未納入
- 原工作區中既有的 battle script 變更、結果素材與 output 目錄未納入本 PR。
- standalone battle scene 因本機未經 bootstrap / catalog cache 缺少 milk_cat、silver_cat catalog 的資料錯誤未以假資料掩蓋。

Closes #298