### PR TITLE
fix:統一主功能背景圖

### DIFF
--- a/scripts/scooper/ScooperScene.gd
+++ b/scripts/scooper/ScooperScene.gd
@@ -81,6 +81,9 @@ func _build_ui() -> void:
 	var shell_root: Control = SHELL_SCENE.instantiate() as Control
 	add_child(shell_root)
 
+	var background: TextureRect = shell_root.get_node("Background") as TextureRect
+	var dim: ColorRect = shell_root.get_node("Dim") as ColorRect
+	var top_mask: ColorRect = shell_root.get_node("TopMask") as ColorRect
 	var content_root: Control = shell_root.get_node("ContentRoot") as Control
 	var content_frame: TextureRect = shell_root.get_node("ContentRoot/Frame") as TextureRect
 	var submenu_root: Control = shell_root.get_node("SubmenuBarRoot") as Control
@@ -90,6 +93,7 @@ func _build_ui() -> void:
 	_tab_header_desc = shell_root.get_node("ContentRoot/SubmenuDescription") as Label
 	_resource_label = shell_root.get_node("ContentRoot/SummaryLeft") as Label
 	_tab_header_summary = shell_root.get_node("ContentRoot/SummaryRight") as Label
+	OverlaySceneChrome.apply_submenu_shell_background(background, dim, top_mask, "scooper")
 	_refresh_resource_label()
 
 	tab_host.clip_contents = true

--- a/scripts/ui/asset_resolver.gd
+++ b/scripts/ui/asset_resolver.gd
@@ -23,6 +23,7 @@ const ONBOARDING_OWNER_AVATAR_PATH := UI_LOCAL_ROOT + "onboarding/onboarding_own
 const ONBOARDING_GENERIC_CAT_PATH := UI_LOCAL_ROOT + "onboarding/onboarding_generic_cat_v3.png"
 const DEFAULT_ICON_PLACEHOLDER_PATH := CAT_CARD_EMPTY_SILHOUETTE
 const DEFAULT_BACKGROUND_SLOT := "activity"
+const SHARED_OVERLAY_BACKGROUND_PATH := UI_CDN_ACTIVITY_ROOT + "activity_background_v1.png"
 const DEFAULT_GACHA_FRAME_KEY := "common"
 const CAT_CARD_SQUARE_FRAMES := {
 	"common": UI_CDN_CARDS_ROOT + "square/cat_card_square_common.png",
@@ -49,18 +50,18 @@ const CAT_TYPE_ICONS := {
 }
 
 const BACKGROUNDS := {
-	"activity": UI_CDN_ACTIVITY_ROOT + "activity_background_v1.png",
-	"arena": UI_CDN_ACTIVITY_ROOT + "arena_background_v1.png",
-	"chat": UI_CDN_ACTIVITY_ROOT + "chat_background_v1.png",
-	"combat_trial": UI_LOCAL_ROOT + "combat_trial/bath_trial_bg.svg",
-	"config": UI_CDN_ACTIVITY_ROOT + "config_background_v1.png",
-	"dungeon": UI_CDN_ACTIVITY_ROOT + "dungeon_background_v1.png",
-	"enhance": UI_CDN_ACTIVITY_ROOT + "enhance_background_v1.png",
-	"expedition": UI_CDN_ACTIVITY_ROOT + "activity_background_v1.png",
-	"gacha": UI_CDN_ACTIVITY_ROOT + "gacha_background_v1.png",
-	"mail": UI_CDN_ACTIVITY_ROOT + "mail_background_v1.png",
-	"scooper": UI_CDN_ACTIVITY_ROOT + "scooper_background_v1.png",
-	"shop": UI_CDN_ACTIVITY_ROOT + "shop_background_v1.png",
+	"activity": SHARED_OVERLAY_BACKGROUND_PATH,
+	"arena": SHARED_OVERLAY_BACKGROUND_PATH,
+	"chat": SHARED_OVERLAY_BACKGROUND_PATH,
+	"combat_trial": SHARED_OVERLAY_BACKGROUND_PATH,
+	"config": SHARED_OVERLAY_BACKGROUND_PATH,
+	"dungeon": SHARED_OVERLAY_BACKGROUND_PATH,
+	"enhance": SHARED_OVERLAY_BACKGROUND_PATH,
+	"expedition": SHARED_OVERLAY_BACKGROUND_PATH,
+	"gacha": SHARED_OVERLAY_BACKGROUND_PATH,
+	"mail": SHARED_OVERLAY_BACKGROUND_PATH,
+	"scooper": SHARED_OVERLAY_BACKGROUND_PATH,
+	"shop": SHARED_OVERLAY_BACKGROUND_PATH,
 }
 
 const CAT_ICONS := {

--- a/scripts/ui/overlay_scene_chrome.gd
+++ b/scripts/ui/overlay_scene_chrome.gd
@@ -126,9 +126,7 @@ static func _build_submenu_shell(scene: Control, background_slot: String, back_p
 	var summary_left_label: Label = shell_root.get_node("ContentRoot/SummaryLeft") as Label
 	var summary_right_label: Label = shell_root.get_node("ContentRoot/SummaryRight") as Label
 
-	_apply_shell_background(background, background_slot)
-	dim.color = Color(0.03, 0.02, 0.03, 0.56)
-	top_mask.color = Color(0.03, 0.03, 0.04, 0.62)
+	apply_submenu_shell_background(background, dim, top_mask, background_slot)
 	_apply_shell_header(title_label, desc_label, summary_left_label, summary_right_label, options)
 
 	var show_header: bool = _should_show_shell_header(options)
@@ -220,7 +218,7 @@ static func make_card_panel(accent: Color = CARD_BORDER, fill: Color = CARD_FILL
 	return panel
 
 
-static func _apply_shell_background(background: TextureRect, slot: String) -> void:
+static func apply_submenu_shell_background(background: TextureRect, dim: ColorRect, top_mask: ColorRect, slot: String) -> void:
 	if background == null:
 		return
 	AssetResolver.apply_background_texture(background, slot)
@@ -232,6 +230,10 @@ static func _apply_shell_background(background: TextureRect, slot: String) -> vo
 	material.shader = AssetResolver.BACKGROUND_SHADER
 	material.set_shader_parameter("desaturate_strength", 0.42)
 	background.material = material
+	if dim != null:
+		dim.color = Color(0.03, 0.02, 0.03, 0.56)
+	if top_mask != null:
+		top_mask.color = Color(0.03, 0.03, 0.04, 0.62)
 
 
 static func _should_show_shell_header(options: Dictionary) -> bool:


### PR DESCRIPTION
## 變更內容
- 新增 `SHARED_OVERLAY_BACKGROUND_PATH`，統一主功能 overlay 背景圖來源。
- 將各背景 slot 統一解析到 `activity_background_v1.png`。
- 將 submenu shell 背景套用方法公開給 `ScooperScene` 使用，讓鏟屎官頁面也套用同一套背景、暗化與去飽和處理。

## 驗證
- `git diff --cached --check` 通過。
- 確認共用背景圖檔存在。
- Godot MCP 啟動 `res://scenes/ScooperScene.tscn` 被既有 clean worktree import/font/parser 狀態阻塞，錯誤為 `default_theme.tres` 字型資源缺失與 `GameState.gd` 的 `PlayerData` parser error。

Closes #302