### PR TITLE
feat:鏟屎官回憶分頁加入已開放/未開放篩選標籤

### DIFF
--- a/scripts/scooper/ScooperScene.gd
+++ b/scripts/scooper/ScooperScene.gd
@@ -28,6 +28,7 @@ var _equipment_cooldown_equipment_id: int = 0
 var _equipment_cooldown_action: String = ""
 var _equipment_cooldown_nodes: Array[Dictionary] = []
 var _equipment_filter: String = "available"
+var _memory_filter: String = "available"
 var _ability_list: VBoxContainer
 var _equip_list: VBoxContainer
 var _memory_summary_label: Label

--- a/scripts/scooper/scooper_tab_memory.gd
+++ b/scripts/scooper/scooper_tab_memory.gd
@@ -1,6 +1,8 @@
 extends RefCounted
 
 const CARD_TEMPLATE: PackedScene = preload("res://scenes/ui/scooper/memory/ScooperMemoryCardTemplate.tscn")
+const FILTER_AVAILABLE: String = "available"
+const FILTER_LOCKED: String = "locked"
 
 
 func build(scene: Control) -> void:
@@ -23,6 +25,8 @@ func build(scene: Control) -> void:
 		summary_row.add_child(scene._memory_summary_label)
 
 		scene._tab_content.add_child(scene._make_separator())
+
+	_add_memory_filter_row(scene)
 
 	var scroll: ScrollContainer = ScrollContainer.new()
 	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
@@ -60,12 +64,84 @@ func _refresh_memory_tab(scene: Control) -> void:
 		scene._memory_list.add_child(empty_lbl)
 		return
 
-	var first_item: bool = true
+	var current_filter: String = _get_current_filter(scene)
+	var player_level: int = scene.GameState.player_data.scooper_level
+	var filtered: Array = []
 	for item: Dictionary in items:
+		var unlock_level: int = int(item.get("unlockLevel", 1))
+		var unlocked: bool = bool(item.get("isUnlocked", false))
+		var is_available: bool = unlocked or player_level >= unlock_level
+		if current_filter == FILTER_AVAILABLE and is_available:
+			filtered.append(item)
+		elif current_filter == FILTER_LOCKED and not is_available:
+			filtered.append(item)
+
+	if current_filter == FILTER_AVAILABLE:
+		filtered.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
+			var a_unlocked: bool = bool(a.get("isUnlocked", false))
+			var b_unlocked: bool = bool(b.get("isUnlocked", false))
+			if a_unlocked != b_unlocked:
+				return not a_unlocked
+			return int(a.get("unlockLevel", 1)) < int(b.get("unlockLevel", 1))
+		)
+	else:
+		filtered.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
+			return int(a.get("unlockLevel", 1)) < int(b.get("unlockLevel", 1))
+		)
+
+	if filtered.is_empty():
+		var filter_empty_lbl: Label = Label.new()
+		filter_empty_lbl.text = UiText.SCOOPER_MEMORY_EMPTY
+		filter_empty_lbl.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY)
+		filter_empty_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+		scene._memory_list.add_child(filter_empty_lbl)
+		return
+
+	var first_item: bool = true
+	for item: Dictionary in filtered:
 		if not first_item:
 			scene._memory_list.add_child(scene._make_separator())
 		scene._memory_list.add_child(_make_memory_card(scene, item))
 		first_item = false
+
+
+func _add_memory_filter_row(scene: Control) -> void:
+	var row: HBoxContainer = HBoxContainer.new()
+	row.add_theme_constant_override("separation", 8)
+	row.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scene._tab_content.add_child(row)
+
+	var group: ButtonGroup = ButtonGroup.new()
+	var options: Array[Dictionary] = [
+		{"key": FILTER_AVAILABLE, "text": UiText.SCOOPER_MEMORY_SECTION_UNLOCKED},
+		{"key": FILTER_LOCKED, "text": UiText.SCOOPER_MEMORY_SECTION_LOCKED},
+	]
+	for option: Dictionary in options:
+		var button: Button = Button.new()
+		button.text = str(option.get("text", ""))
+		button.toggle_mode = true
+		button.button_group = group
+		button.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		button.custom_minimum_size = Vector2(0.0, 36.0)
+		button.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_TINY)
+		UiPalette.apply_button_kind(button, "confirm" if str(option.get("key", "")) == _get_current_filter(scene) else "neutral")
+		button.button_pressed = str(option.get("key", "")) == _get_current_filter(scene)
+		button.pressed.connect(Callable(self, "_set_memory_filter").bind(scene, str(option.get("key", ""))))
+		row.add_child(button)
+
+
+func _set_memory_filter(scene: Control, filter_key: String) -> void:
+	if scene == null or not is_instance_valid(scene):
+		return
+	scene._memory_filter = filter_key
+	scene.call("_rebuild_tab_content")
+
+
+func _get_current_filter(scene: Control) -> String:
+	var current_filter: String = str(scene._memory_filter)
+	if current_filter in [FILTER_AVAILABLE, FILTER_LOCKED]:
+		return current_filter
+	return FILTER_AVAILABLE
 
 
 func _make_memory_card(scene: Control, item: Dictionary) -> Control:

--- a/scripts/ui/ui_text.gd
+++ b/scripts/ui/ui_text.gd
@@ -573,6 +573,8 @@ const SCOOPER_MEMORY_CONFIRM_FAILED_DEFAULT := "無法解鎖回憶"
 const SCOOPER_MEMORY_CONFIRM_SUCCESS := "解鎖成功"
 const SCOOPER_MEMORY_REFRESH_FAILED := "回憶資料刷新失敗"
 const SCOOPER_MEMORY_REFRESH_FAILED_DEFAULT := "無法更新回憶資料"
+const SCOOPER_MEMORY_SECTION_UNLOCKED := "已開放"
+const SCOOPER_MEMORY_SECTION_LOCKED := "未開放"
 
 # Scooper treasure labels
 const SCOOPER_TREASURE_SUMMARY_FORMAT := "寶藏種類：%d    持有總數：%d"


### PR DESCRIPTION
## 變更說明
鏟屎官回憶分頁加入「已開放」/「未開放」篩選標籤按鈕，與裝備分頁一致的操作方式。

## 變更檔案
- `scripts/scooper/ScooperScene.gd` — 新增 `_memory_filter` 狀態變數
- `scripts/scooper/scooper_tab_memory.gd` — 加入篩選按鈕列與分類篩選邏輯
- `scripts/ui/ui_text.gd` — 新增 `SCOOPER_MEMORY_SECTION_UNLOCKED`/`SCOOPER_MEMORY_SECTION_LOCKED` 常數

## 分類規則
- **已開放**：已解鎖 或 玩家等級已達解鎖門檻
  - 排序：未解鎖排前 → 按解鎖等級升冪
- **未開放**：玩家等級尚未達到解鎖門檻
  - 排序：按解鎖等級升冪

Closes #329