### PR TITLE
feat:實作貓咪技能與衝撞戰鬥數值

### DIFF
--- a/docs/gdd/03_battle.md
+++ b/docs/gdd/03_battle.md
@@ -33,6 +33,12 @@ Cat5 Cat4 Cat3 Cat2 Cat1  →←  Cat1 Cat2 Cat3 Cat4 Cat5
 | 回彈距離 | 基礎回彈 200px，再加上雙方 Weight 差 × 20px；最小 0px、最大 500px |
 | 硬直時間 | 碰撞後 0.2 秒；撞牆額外增加 2 秒 |
 
+- 衝撞傷害使用目前 runtime 數值，不直接讀靜態基礎值：`ATK`、`ATK%`、`DEF`、`DEF%`、`ArmorPen`、`DamageReduction`、`CritRate`、`CritDamage`、`Evasion`、`Accuracy`、`MultiHitRate`、`MultiHitDamage`、`CounterDamageChance`、技能 buff / debuff、裝備、記憶、寶物都需在計算前合併。
+- DEF 減傷公式：`effectiveDef = DEF × (1 - ArmorPen)`，`defReduction = effectiveDef / (effectiveDef + 100)`，基礎傷害為 `max(1, ATK × (1 - defReduction))`。
+- 閃避判定：`Evasion - Accuracy`，最小 0%，最高 75%；成功閃避時該次攻擊傷害為 0。
+- 暴擊率最高 100%；超過 100% 的暴擊率不再提高觸發率，改為等量轉換成暴擊傷害加成。暴擊倍率為 `1.5 + CritDamage + max(0, CritRate - 1.0)`。
+- 連擊率最高 75%；連擊觸發時追加 1 次額外傷害，額外傷害倍率為 `50% + MultiHitDamage`。連擊只增加傷害，不新增碰撞擊退事件。
+- 反傷機率（`CounterDamageChance`）觸發時，該次原本承受的傷害由受擊者承受 50%，攻擊者承受 50%。技能型反擊 / 反傷則依技能 `value` 將實際承受傷害反彈給攻擊者。
 - 碰撞判定以戰鬥角色視覺寬度約 96px 為基準；兩方中心距離小於等於 96px 時視為前緣接觸。
 - 每次碰撞只檢查雙方目前最前排角色；後排角色不會穿過前排去碰撞對方第二排。
 - 正式戰鬥以畫面 runtime 位置作為碰撞來源；角色實際跑到接觸點時才計算碰撞、傷害、擊退、死亡與勝負。`BattleSimulator` 僅保留為開發快速模擬工具，不作為正式畫面戰鬥的事件來源。

--- a/docs/gdd/10_skills.md
+++ b/docs/gdd/10_skills.md
@@ -97,6 +97,8 @@
 | `revive` | 復活最近陣亡的友方，回復 `value%` HP | 血量最少/最近陣亡 | 限 SR+ |
 | `cd_reset` | `value=1`：完全重置全隊 CD；`0<value<1`：縮減 `value×100%` CD（上限 40%） | 全隊/自身 | |
 
+目前 runtime 已接上：`damage`、`heal`、`heal_over_time`、`shield`、`buff_stat`、`debuff_stat`、`damage_reduction`、`reflect`、`counter`、`next_attack_buff`、`mark`、`execute`、`invincibility`、`cd_reset`、`revive`。`damage_share` 保留為後續需要分攤傷害 UI / 記錄時再實作的技能類型。
+
 ### 被動技能效果
 
 | type | 說明 |
@@ -104,6 +106,8 @@
 | `stat_boost` | 戰鬥開始永久提升屬性（不倒數） |
 | `damage_reduction` | 永久減少自身受到的傷害 |
 | `cooldown_reduction` | 永久縮短全隊冷卻時間（上限 40%） |
+
+被動 `stat_boost` 可使用的戰鬥屬性包含 `max_hp` / `max_hp_percent`、`atk` / `atk_percent`、`defense` / `def_percent`、`speed`、`crit_rate`、`crit_damage`、`armor_pen`、`evasion`、`accuracy`、`multi_hit_rate`、`multi_hit_damage`、`counter_damage_chance`、`damage_reduction`、`cooldown_reduction`。
 
 ---
 

--- a/scripts/ApiClient.gd
+++ b/scripts/ApiClient.gd
@@ -547,6 +547,10 @@ func purchase_shop_bundle(bundle_id: int, callback: Callable, record_daily_free_
 	_api_post("shop/bundles/%d/purchase" % bundle_id, {}, request_callback)
 
 
+func upgrade_scooper_ability(ability_id: int, expected_cost: int, callback: Callable) -> void:
+	_api_post("scooper/ability/%d/upgrade" % ability_id, {"expectedCost": expected_cost}, callback)
+
+
 func purchase_trap_points(trap_point_amount: int, callback: Callable) -> void:
 	_api_post("shop/trap-points/purchase", {
 		"trapPointAmount": trap_point_amount,

--- a/scripts/battle/battle_manager.gd
+++ b/scripts/battle/battle_manager.gd
@@ -59,6 +59,7 @@ var _cat_airborne_timers: Dictionary = {}
 var _cat_skill_animation_timers: Dictionary = {}
 var _pending_recycled_cats: Dictionary = {}
 var _pending_recycle_count: int = 0
+var _defeated_runtime_records: Dictionary = {}
 
 var _player_team_node: Node2D
 var _enemy_team_node: Node2D
@@ -96,6 +97,7 @@ func setup(_events_param: Array, player_cats: Array, enemy_cats: Array,
 	_cat_skill_animation_timers.clear()
 	_pending_recycled_cats.clear()
 	_pending_recycle_count = 0
+	_defeated_runtime_records.clear()
 	_player_skill_slots.clear()
 	_enemy_skill_slots.clear()
 	_event_idx = 0
@@ -183,11 +185,22 @@ func _spawn_runtime_cat(cat_id: int, team_name: String, cat_data: CatData, pos_x
 		"defense": float(cat_data.defense),
 		"speed": float(cat_data.speed),
 		"weight": float(cat_data.weight),
-		"damage_reduction": 0.0,
-		"crit_rate": 0.0,
-		"crit_damage_bonus": 0.0,
+		"damage_reduction": clampf(float(cat_data.damage_reduction), 0.0, 0.9),
+		"crit_rate": maxf(0.0, float(cat_data.crit_rate)),
+		"crit_damage_bonus": maxf(0.0, float(cat_data.crit_damage_bonus)),
+		"armor_pen": maxf(0.0, float(cat_data.armor_pen)),
+		"evasion": maxf(0.0, float(cat_data.evasion)),
+		"accuracy": maxf(0.0, float(cat_data.accuracy)),
+		"multi_hit_rate": maxf(0.0, float(cat_data.multi_hit_rate)),
+		"multi_hit_damage": maxf(0.0, float(cat_data.multi_hit_damage)),
+		"counter_damage_chance": maxf(0.0, float(cat_data.counter_damage_chance)),
 		"reflect": 0.0,
+		"shield": 0,
+		"invincible_hits": 0,
+		"next_attack_damage_bonus": 0.0,
+		"damage_taken_bonus": 0.0,
 		"buffs": [],
+		"hot_effects": [],
 	}
 	_cat_skill_animation_timers[cat_id] = 0.0
 	_update_skill_slot_spawn_state(cat_id, cat_data.max_hp, cat_data.max_hp)
@@ -444,16 +457,16 @@ func _handle_runtime_collision(p_node: CatNode, e_node: CatNode) -> void:
 	var e_damage: int = 0
 	if not p_staggered:
 		e_damage = _calc_runtime_attack_damage(p_id, e_id, _get_runtime_atk(p_id))
-		_apply_runtime_damage(e_id, e_damage)
+		e_damage = _apply_runtime_damage(e_id, e_damage, p_id)
 	if not e_staggered:
 		p_damage = _calc_runtime_attack_damage(e_id, p_id, _get_runtime_atk(e_id))
-		_apply_runtime_damage(p_id, p_damage)
+		p_damage = _apply_runtime_damage(p_id, p_damage, e_id)
 	if e_damage > 0:
 		var reflect_to_p: int = int(float(e_damage) * _get_runtime_reflect(e_id))
-		_apply_runtime_damage(p_id, reflect_to_p)
+		_apply_runtime_damage(p_id, reflect_to_p, e_id, false)
 	if p_damage > 0:
 		var reflect_to_e: int = int(float(p_damage) * _get_runtime_reflect(p_id))
-		_apply_runtime_damage(e_id, reflect_to_e)
+		_apply_runtime_damage(e_id, reflect_to_e, p_id, false)
 
 	var p_weight: float = float(p_runtime.get("weight", 100.0))
 	var e_weight: float = float(e_runtime.get("weight", 100.0))
@@ -586,13 +599,33 @@ func _get_wall_counter_arc_height(target_knockback: float) -> float:
 	)
 
 
-func _apply_runtime_damage(cat_id: int, damage: int) -> void:
+func _apply_runtime_damage(cat_id: int, damage: int, source_id: int = -1, can_counter: bool = true) -> int:
 	if damage <= 0:
-		return
+		return 0
 	if not _cat_runtime.has(cat_id):
-		return
+		return 0
 	var runtime: Dictionary = _cat_runtime[cat_id]
-	var current_hp: int = maxi(0, int(runtime.get("current_hp", 0)) - damage)
+	if can_counter and source_id >= 0 and _cat_runtime.has(source_id):
+		var counter_chance: float = clampf(float(runtime.get("counter_damage_chance", 0.0)), 0.0, 1.0)
+		if counter_chance > 0.0 and _rng.randf() < counter_chance:
+			var counter_damage: int = int(float(damage) * 0.5)
+			damage = max(0, damage - counter_damage)
+			_apply_runtime_damage(source_id, counter_damage, cat_id, false)
+	var invincible_hits: int = int(runtime.get("invincible_hits", 0))
+	if invincible_hits > 0:
+		runtime["invincible_hits"] = invincible_hits - 1
+		_cat_runtime[cat_id] = runtime
+		return 0
+	var shield: int = int(runtime.get("shield", 0))
+	if shield > 0:
+		var absorbed: int = mini(shield, damage)
+		runtime["shield"] = shield - absorbed
+		damage -= absorbed
+	if damage <= 0:
+		_cat_runtime[cat_id] = runtime
+		return 0
+	var previous_hp: int = int(runtime.get("current_hp", 0))
+	var current_hp: int = maxi(0, previous_hp - damage)
 	runtime["current_hp"] = current_hp
 	_cat_runtime[cat_id] = runtime
 	var node: CatNode = _get_cat_node(cat_id)
@@ -600,6 +633,7 @@ func _apply_runtime_damage(cat_id: int, damage: int) -> void:
 		node.update_hp(current_hp)
 		node.show_damage_number(damage)
 	_update_skill_slot_hp(cat_id, current_hp)
+	return previous_hp - current_hp
 
 
 func _check_runtime_death(cat_id: int) -> void:
@@ -608,6 +642,10 @@ func _check_runtime_death(cat_id: int) -> void:
 	var runtime: Dictionary = _cat_runtime[cat_id]
 	if int(runtime.get("current_hp", 0)) > 0:
 		return
+	_defeated_runtime_records[cat_id] = {
+		"team": runtime.get("team", ""),
+		"data": runtime.get("data", null),
+	}
 	var node: CatNode = _get_cat_node(cat_id)
 	if node != null:
 		node.play_death()
@@ -684,25 +722,65 @@ func _apply_runtime_passive_effect(cat_id: int, effect_type: String, stat: Strin
 	var runtime: Dictionary = _cat_runtime[cat_id]
 	match effect_type:
 		"stat_boost":
-			var bonus_base: float = float(runtime.get(stat, 0.0))
-			var bonus: float = bonus_base * value if value_type == "percent" else value
-			if stat == "max_hp":
-				runtime["max_hp"] = int(runtime.get("max_hp", 0)) + int(bonus)
-				runtime["current_hp"] = int(runtime.get("current_hp", 0)) + int(bonus)
-				var node: CatNode = _get_cat_node(cat_id)
-				if node != null:
-					node.max_hp = int(runtime["max_hp"])
-					node.update_hp(int(runtime["current_hp"]))
-				_update_skill_slot_spawn_state(cat_id, int(runtime["current_hp"]), int(runtime["max_hp"]))
-			elif runtime.has(stat):
-				runtime[stat] = bonus_base + bonus
-				if stat == "speed":
-					_cat_speeds[cat_id] = float(runtime[stat])
+			_apply_runtime_stat_delta(cat_id, runtime, stat, value, value_type)
 		"damage_reduction":
 			runtime["damage_reduction"] = minf(float(runtime.get("damage_reduction", 0.0)) + value, 0.9)
 		"cooldown_reduction":
-			runtime["cooldown_reduction"] = minf(float(runtime.get("cooldown_reduction", 0.0)) + value, 0.5)
+			runtime["cooldown_reduction"] = minf(float(runtime.get("cooldown_reduction", 0.0)) + value, 0.4)
 	_cat_runtime[cat_id] = runtime
+
+
+func _apply_runtime_stat_delta(cat_id: int, runtime: Dictionary, stat: String,
+		value: float, value_type: String) -> float:
+	var amount: float = 0.0
+	match stat:
+		"max_hp", "hp":
+			amount = float(runtime.get("max_hp", 0)) * value if value_type == "percent" else value
+			runtime["max_hp"] = int(runtime.get("max_hp", 0)) + int(amount)
+			runtime["current_hp"] = int(runtime.get("current_hp", 0)) + int(amount)
+			_update_runtime_hp_display(cat_id, runtime)
+		"max_hp_percent", "hp_percent":
+			amount = float(runtime.get("max_hp", 0)) * value
+			runtime["max_hp"] = int(runtime.get("max_hp", 0)) + int(amount)
+			runtime["current_hp"] = int(runtime.get("current_hp", 0)) + int(amount)
+			_update_runtime_hp_display(cat_id, runtime)
+		"atk":
+			amount = float(runtime.get("atk", 0.0)) * value if value_type == "percent" else value
+			runtime["atk"] = float(runtime.get("atk", 0.0)) + amount
+		"atk_percent":
+			amount = float(runtime.get("atk", 0.0)) * value
+			runtime["atk"] = float(runtime.get("atk", 0.0)) + amount
+		"defense", "def":
+			amount = float(runtime.get("defense", 0.0)) * value if value_type == "percent" else value
+			runtime["defense"] = float(runtime.get("defense", 0.0)) + amount
+		"def_percent":
+			amount = float(runtime.get("defense", 0.0)) * value
+			runtime["defense"] = float(runtime.get("defense", 0.0)) + amount
+		"speed":
+			amount = float(runtime.get("speed", 0.0)) * value if value_type == "percent" else value
+			runtime["speed"] = float(runtime.get("speed", 0.0)) + amount
+			_cat_speeds[cat_id] = float(runtime["speed"])
+		"crit_rate", "armor_pen", "evasion", "accuracy", "multi_hit_rate", "multi_hit_damage", "counter_damage_chance":
+			amount = value
+			runtime[stat] = maxf(0.0, float(runtime.get(stat, 0.0)) + amount)
+		"crit_damage":
+			amount = value
+			runtime["crit_damage_bonus"] = maxf(0.0, float(runtime.get("crit_damage_bonus", 0.0)) + amount)
+		"damage_reduction":
+			amount = value
+			runtime["damage_reduction"] = clampf(float(runtime.get("damage_reduction", 0.0)) + amount, 0.0, 0.9)
+		"cooldown_reduction":
+			amount = value
+			runtime["cooldown_reduction"] = clampf(float(runtime.get("cooldown_reduction", 0.0)) + amount, 0.0, 0.4)
+	return amount
+
+
+func _update_runtime_hp_display(cat_id: int, runtime: Dictionary) -> void:
+	var node: CatNode = _get_cat_node(cat_id)
+	if node != null:
+		node.max_hp = int(runtime.get("max_hp", 0))
+		node.update_hp(int(runtime.get("current_hp", 0)))
+	_update_skill_slot_spawn_state(cat_id, int(runtime.get("current_hp", 0)), int(runtime.get("max_hp", 0)))
 
 
 func _update_runtime_skills(delta: float) -> void:
@@ -751,26 +829,55 @@ func _execute_runtime_skill(caster_id: int, skill_d: Dictionary) -> void:
 		var value: float = _get_scaled_value(skill_d, eff_idx, eff.get("value", 0.0), rank)
 		match effect_type:
 			"damage":
-				var target_id: int = _resolve_runtime_target_id(caster_id, str(eff.get("target", "enemy_front")))
-				if target_id < 0:
-					continue
+				var target_ids: Array = _resolve_runtime_target_ids(caster_id, str(eff.get("target", "enemy_front")))
 				var hits: int = int(eff.get("hits", 1))
-				for _hit_index in range(hits):
-					var damage: int = _calc_runtime_attack_damage(caster_id, target_id, _get_runtime_atk(caster_id) * value)
-					_apply_runtime_damage(target_id, damage)
-					if _is_runtime_dead(target_id):
-						_check_runtime_death(target_id)
-						break
+				for target_id_variant: Variant in target_ids:
+					var target_id: int = int(target_id_variant)
+					for _hit_index in range(hits):
+						var damage: int = _calc_runtime_attack_damage(caster_id, target_id, _get_runtime_atk(caster_id) * value)
+						_apply_runtime_damage(target_id, damage, caster_id)
+						if _is_runtime_dead(target_id):
+							_check_runtime_death(target_id)
+							break
 				var extra_kb: float = maxf(float(eff.get("extra_knockback", 0.0)), DEFAULT_SKILL_HIT_KNOCKBACK)
-				if _cat_runtime.has(target_id) and not _is_cat_airborne(target_id):
-					_apply_skill_extra_knockback(caster_id, target_id, extra_kb)
-			"buff_stat":
-				var buff_target_id: int = _resolve_runtime_buff_target_id(caster_id, str(eff.get("target", "self")))
-				if buff_target_id < 0:
-					continue
-				_apply_runtime_buff(buff_target_id, str(eff.get("stat", "")), value, str(eff.get("value_type", "percent")), float(eff.get("duration", 3.0)))
+				for target_id_variant: Variant in target_ids:
+					var target_id: int = int(target_id_variant)
+					if _cat_runtime.has(target_id) and not _is_cat_airborne(target_id):
+						_apply_skill_extra_knockback(caster_id, target_id, extra_kb)
+			"heal":
+				for target_id_variant: Variant in _resolve_runtime_target_ids(caster_id, str(eff.get("target", "ally_lowest_hp"))):
+					_apply_runtime_heal(int(target_id_variant), int(_get_runtime_atk(caster_id) * value))
+			"heal_over_time":
+				for target_id_variant: Variant in _resolve_runtime_target_ids(caster_id, str(eff.get("target", "ally_lowest_hp"))):
+					_apply_runtime_hot(int(target_id_variant), _get_runtime_atk(caster_id) * value, float(eff.get("duration", 8.0)))
+			"shield":
+				for target_id_variant: Variant in _resolve_runtime_target_ids(caster_id, str(eff.get("target", "self"))):
+					_apply_runtime_shield(int(target_id_variant), int(_get_runtime_atk(caster_id) * value))
+			"buff_stat", "debuff_stat":
+				var signed_value: float = -value if effect_type == "debuff_stat" else value
+				for buff_target_id_variant: Variant in _resolve_runtime_target_ids(caster_id, str(eff.get("target", "self"))):
+					_apply_runtime_buff(int(buff_target_id_variant), str(eff.get("stat", "")), signed_value, str(eff.get("value_type", "percent")), float(eff.get("duration", 8.0)))
+			"damage_reduction":
+				for buff_target_id_variant: Variant in _resolve_runtime_target_ids(caster_id, str(eff.get("target", "self"))):
+					_apply_runtime_buff(int(buff_target_id_variant), "damage_reduction", value, "flat", float(eff.get("duration", 8.0)))
 			"reflect":
 				_apply_runtime_reflect(caster_id, value, float(eff.get("duration", 4.0)))
+			"counter":
+				_apply_runtime_reflect(caster_id, value, float(eff.get("duration", 8.0)))
+			"next_attack_buff":
+				_apply_runtime_next_attack_buff(caster_id, value)
+			"mark":
+				for target_id_variant: Variant in _resolve_runtime_target_ids(caster_id, str(eff.get("target", "enemy_front"))):
+					_apply_runtime_buff(int(target_id_variant), "damage_taken_bonus", value, "flat", float(eff.get("duration", 8.0)))
+			"execute":
+				for target_id_variant: Variant in _resolve_runtime_target_ids(caster_id, str(eff.get("target", "enemy_lowest_hp"))):
+					_apply_runtime_execute(int(target_id_variant), value, caster_id)
+			"invincibility":
+				_apply_runtime_invincibility(caster_id, int(eff.get("max_stack", 1)))
+			"cd_reset":
+				_apply_runtime_cd_reset(caster_id, value)
+			"revive":
+				_apply_runtime_revive(caster_id, value)
 
 
 func _tick_runtime_buffs(delta: float) -> void:
@@ -784,19 +891,34 @@ func _tick_runtime_buffs(delta: float) -> void:
 			runtime["reflect_remaining"] = maxf(0.0, float(runtime["reflect_remaining"]) - scaled_delta)
 			if float(runtime["reflect_remaining"]) <= 0.0:
 				runtime["reflect"] = 0.0
+		var hot_effects: Array = runtime.get("hot_effects", [])
+		for i in range(hot_effects.size() - 1, -1, -1):
+			var hot: Dictionary = hot_effects[i]
+			var remaining: float = maxf(0.0, float(hot.get("remaining", 0.0)) - scaled_delta)
+			var tick_accum: float = float(hot.get("tick_accum", 0.0)) + scaled_delta
+			while tick_accum >= 1.0 and remaining > 0.0:
+				_apply_runtime_heal(cat_id, int(hot.get("heal_per_second", 0.0)))
+				tick_accum -= 1.0
+			if remaining <= 0.0:
+				hot_effects.remove_at(i)
+			else:
+				hot["remaining"] = remaining
+				hot["tick_accum"] = tick_accum
+				hot_effects[i] = hot
+		var latest_runtime: Dictionary = _cat_runtime.get(cat_id, runtime)
+		runtime["current_hp"] = latest_runtime.get("current_hp", runtime.get("current_hp", 0))
+		runtime["max_hp"] = latest_runtime.get("max_hp", runtime.get("max_hp", 0))
 		var buffs: Array = runtime.get("buffs", [])
 		for i in range(buffs.size() - 1, -1, -1):
 			var buff: Dictionary = buffs[i]
 			buff["remaining"] = maxf(0.0, float(buff.get("remaining", 0.0)) - scaled_delta)
 			if float(buff["remaining"]) <= 0.0:
-				var stat: String = str(buff.get("stat", ""))
-				runtime[stat] = float(runtime.get(stat, 0.0)) - float(buff.get("amount", 0.0))
-				if stat == "speed":
-					_cat_speeds[cat_id] = float(runtime.get("speed", 80.0))
+				_revert_runtime_buff_amount(cat_id, runtime, buff)
 				buffs.remove_at(i)
 			else:
 				buffs[i] = buff
 		runtime["buffs"] = buffs
+		runtime["hot_effects"] = hot_effects
 		_cat_runtime[cat_id] = runtime
 
 
@@ -811,16 +933,39 @@ func _apply_runtime_buff(cat_id: int, stat: String, value: float, value_type: St
 	if not _cat_runtime.has(cat_id):
 		return
 	var runtime: Dictionary = _cat_runtime[cat_id]
-	var base_value: float = float(runtime.get(stat, 0.0))
-	var amount: float = base_value * value if value_type == "percent" else value
-	runtime[stat] = base_value + amount
 	var buffs: Array = runtime.get("buffs", [])
+	for i in range(buffs.size() - 1, -1, -1):
+		var old_buff: Dictionary = buffs[i]
+		if str(old_buff.get("stat", "")) == stat:
+			_revert_runtime_buff_amount(cat_id, runtime, old_buff)
+			buffs.remove_at(i)
+	var amount: float = _apply_runtime_stat_delta(cat_id, runtime, stat, value, value_type)
 	buffs.append({"stat": stat, "amount": amount, "remaining": duration})
 	runtime["buffs"] = buffs
 	_cat_runtime[cat_id] = runtime
-	if stat == "speed":
-		_cat_speeds[cat_id] = float(runtime[stat])
 	_update_skill_slot_buff(cat_id, duration)
+
+
+func _revert_runtime_buff_amount(cat_id: int, runtime: Dictionary, buff: Dictionary) -> void:
+	var stat: String = str(buff.get("stat", ""))
+	var amount: float = float(buff.get("amount", 0.0))
+	match stat:
+		"max_hp", "hp", "max_hp_percent", "hp_percent":
+			runtime["max_hp"] = max(1, int(runtime.get("max_hp", 0)) - int(amount))
+			runtime["current_hp"] = mini(int(runtime.get("current_hp", 0)), int(runtime.get("max_hp", 0)))
+			_update_runtime_hp_display(cat_id, runtime)
+		"atk", "atk_percent":
+			runtime["atk"] = float(runtime.get("atk", 0.0)) - amount
+		"defense", "def", "def_percent":
+			runtime["defense"] = float(runtime.get("defense", 0.0)) - amount
+		"speed":
+			runtime["speed"] = float(runtime.get("speed", 0.0)) - amount
+			_cat_speeds[cat_id] = float(runtime.get("speed", 80.0))
+		"crit_damage":
+			runtime["crit_damage_bonus"] = maxf(0.0, float(runtime.get("crit_damage_bonus", 0.0)) - amount)
+		_:
+			if runtime.has(stat):
+				runtime[stat] = maxf(0.0, float(runtime.get(stat, 0.0)) - amount)
 
 
 func _apply_runtime_reflect(cat_id: int, value: float, duration: float) -> void:
@@ -831,6 +976,111 @@ func _apply_runtime_reflect(cat_id: int, value: float, duration: float) -> void:
 	runtime["reflect_remaining"] = duration
 	_cat_runtime[cat_id] = runtime
 	_update_skill_slot_buff(cat_id, duration)
+
+
+func _apply_runtime_heal(cat_id: int, amount: int) -> void:
+	if amount <= 0 or not _cat_runtime.has(cat_id):
+		return
+	var runtime: Dictionary = _cat_runtime[cat_id]
+	var max_hp: int = int(runtime.get("max_hp", 0))
+	var current_hp: int = mini(max_hp, int(runtime.get("current_hp", 0)) + amount)
+	runtime["current_hp"] = current_hp
+	_cat_runtime[cat_id] = runtime
+	var node: CatNode = _get_cat_node(cat_id)
+	if node != null:
+		node.update_hp(current_hp)
+	_update_skill_slot_hp(cat_id, current_hp)
+
+
+func _apply_runtime_hot(cat_id: int, heal_per_second: float, duration: float) -> void:
+	if not _cat_runtime.has(cat_id):
+		return
+	var runtime: Dictionary = _cat_runtime[cat_id]
+	var hot_effects: Array = runtime.get("hot_effects", [])
+	hot_effects.append({
+		"heal_per_second": heal_per_second,
+		"remaining": duration,
+		"tick_accum": 0.0,
+	})
+	runtime["hot_effects"] = hot_effects
+	_cat_runtime[cat_id] = runtime
+	_update_skill_slot_buff(cat_id, duration)
+
+
+func _apply_runtime_shield(cat_id: int, amount: int) -> void:
+	if amount <= 0 or not _cat_runtime.has(cat_id):
+		return
+	var runtime: Dictionary = _cat_runtime[cat_id]
+	runtime["shield"] = int(runtime.get("shield", 0)) + amount
+	_cat_runtime[cat_id] = runtime
+
+
+func _apply_runtime_next_attack_buff(cat_id: int, value: float) -> void:
+	if not _cat_runtime.has(cat_id):
+		return
+	var runtime: Dictionary = _cat_runtime[cat_id]
+	runtime["next_attack_damage_bonus"] = maxf(float(runtime.get("next_attack_damage_bonus", 0.0)), value)
+	_cat_runtime[cat_id] = runtime
+
+
+func _apply_runtime_execute(target_id: int, threshold: float, source_id: int) -> void:
+	if not _cat_runtime.has(target_id):
+		return
+	var runtime: Dictionary = _cat_runtime[target_id]
+	var max_hp: int = max(1, int(runtime.get("max_hp", 1)))
+	var current_hp: int = int(runtime.get("current_hp", 0))
+	if float(current_hp) / float(max_hp) <= threshold:
+		_apply_runtime_damage(target_id, current_hp, source_id, false)
+		_check_runtime_death(target_id)
+
+
+func _apply_runtime_invincibility(cat_id: int, hit_count: int) -> void:
+	if not _cat_runtime.has(cat_id):
+		return
+	var runtime: Dictionary = _cat_runtime[cat_id]
+	runtime["invincible_hits"] = int(runtime.get("invincible_hits", 0)) + max(1, hit_count)
+	_cat_runtime[cat_id] = runtime
+
+
+func _apply_runtime_cd_reset(caster_id: int, value: float) -> void:
+	var caster_runtime: Dictionary = _cat_runtime.get(caster_id, {})
+	var caster_team: String = str(caster_runtime.get("team", ""))
+	var reduce_ratio: float = clampf(value, 0.0, 0.4)
+	var slots: Array = _player_skill_slots if caster_team == "player" else _enemy_skill_slots
+	for i in range(slots.size()):
+		var slot: Dictionary = slots[i]
+		slot["remaining_cd"] = maxf(0.0, float(slot.get("remaining_cd", 0.0)) * (1.0 - reduce_ratio))
+		slots[i] = slot
+
+
+func _apply_runtime_revive(caster_id: int, hp_ratio: float) -> void:
+	var caster_runtime: Dictionary = _cat_runtime.get(caster_id, {})
+	var caster_team: String = str(caster_runtime.get("team", ""))
+	var revive_id: int = -1
+	for id_variant: Variant in _defeated_runtime_records.keys():
+		var cat_id: int = int(id_variant)
+		var record: Dictionary = _defeated_runtime_records[cat_id]
+		if str(record.get("team", "")) == caster_team:
+			revive_id = cat_id
+			break
+	if revive_id < 0:
+		return
+	var record: Dictionary = _defeated_runtime_records[revive_id]
+	var cat_data_variant: Variant = record.get("data", null)
+	var cat_data: CatData = cat_data_variant as CatData
+	if cat_data == null:
+		return
+	var front: CatNode = _get_front_runtime_node(caster_team)
+	var fallback_x: float = PLAYER_FRONT_START_X if caster_team == "player" else ENEMY_FRONT_START_X
+	var pos_x: float = fallback_x if front == null else front.position.x + (-TEAM_ROW_SPACING if caster_team == "player" else TEAM_ROW_SPACING)
+	_spawn_runtime_cat(revive_id, caster_team, cat_data, pos_x)
+	if _cat_runtime.has(revive_id):
+		var runtime: Dictionary = _cat_runtime[revive_id]
+		var revive_hp: int = max(1, int(float(runtime.get("max_hp", 1)) * hp_ratio))
+		runtime["current_hp"] = revive_hp
+		_cat_runtime[revive_id] = runtime
+		_update_runtime_hp_display(revive_id, runtime)
+	_defeated_runtime_records.erase(revive_id)
 
 
 func _apply_skill_extra_knockback(caster_id: int, target_id: int, extra_kb: float) -> void:
@@ -857,6 +1107,32 @@ func _get_current_wall_left() -> float:
 func _get_current_wall_right() -> float:
 	var progress: float = clampf(_sim_time / BATTLE_WALL_SHRINK_DURATION, 0.0, 1.0)
 	return lerpf(BATTLE_WALL_START_RIGHT, BATTLE_WALL_RIGHT, progress)
+
+
+func _resolve_runtime_target_ids(caster_id: int, target: String) -> Array:
+	var caster_runtime: Dictionary = _cat_runtime.get(caster_id, {})
+	var caster_team: String = str(caster_runtime.get("team", ""))
+	var enemy_team: String = "enemy" if caster_team == "player" else "player"
+	match target:
+		"enemy_lowest_hp":
+			var enemy_lowest_id: int = _get_lowest_hp_cat_id(enemy_team)
+			return [] if enemy_lowest_id < 0 else [enemy_lowest_id]
+		"ally_lowest_hp":
+			var ally_lowest_id: int = _get_lowest_hp_cat_id(caster_team)
+			return [] if ally_lowest_id < 0 else [ally_lowest_id]
+		"enemy_all":
+			return _get_team_cat_ids(enemy_team)
+		"ally_all", "team":
+			return _get_team_cat_ids(caster_team)
+		"all":
+			var all_ids: Array = _get_team_cat_ids(caster_team)
+			all_ids.append_array(_get_team_cat_ids(enemy_team))
+			return all_ids
+		"self":
+			return [caster_id]
+		_:
+			var front: CatNode = _get_front_runtime_node(enemy_team)
+			return [] if front == null else [front.instance_id]
 
 
 func _resolve_runtime_target_id(caster_id: int, target: String) -> int:
@@ -909,14 +1185,34 @@ func _get_team_cat_ids(team_name: String) -> Array:
 
 
 func _calc_runtime_attack_damage(attacker_id: int, defender_id: int, raw_atk: float) -> int:
-	var damage: int = int(CatStats.calc_damage(raw_atk, _get_runtime_defense(defender_id)))
+	var attacker_runtime: Dictionary = _cat_runtime.get(attacker_id, {})
+	var defender_runtime: Dictionary = _cat_runtime.get(defender_id, {})
+	var evasion_chance: float = clampf(
+		float(defender_runtime.get("evasion", 0.0)) - float(attacker_runtime.get("accuracy", 0.0)),
+		0.0,
+		0.75
+	)
+	if evasion_chance > 0.0 and _rng.randf() < evasion_chance:
+		return 0
+	var next_attack_bonus: float = float(attacker_runtime.get("next_attack_damage_bonus", 0.0))
+	if next_attack_bonus > 0.0:
+		raw_atk *= 1.0 + next_attack_bonus
+		attacker_runtime["next_attack_damage_bonus"] = 0.0
+		_cat_runtime[attacker_id] = attacker_runtime
+	var effective_defense: float = _get_runtime_defense(defender_id)
+	var armor_pen: float = clampf(float(attacker_runtime.get("armor_pen", 0.0)), 0.0, 1.0)
+	var damage: int = int(CatStats.calc_damage(raw_atk, effective_defense, effective_defense * armor_pen))
 	if damage <= 0:
 		return 0
 	if _rng.randf() < _get_runtime_crit_rate(attacker_id):
 		damage = int(float(damage) * (BASE_CRIT_DAMAGE_MULT + _get_runtime_crit_damage_bonus(attacker_id)))
-	var defender_runtime: Dictionary = _cat_runtime.get(defender_id, {})
 	var reduction: float = float(defender_runtime.get("damage_reduction", 0.0))
-	return int(float(damage) * (1.0 - reduction))
+	damage = int(float(damage) * (1.0 - reduction) * (1.0 + float(defender_runtime.get("damage_taken_bonus", 0.0))))
+	var multi_hit_rate: float = clampf(float(attacker_runtime.get("multi_hit_rate", 0.0)), 0.0, 0.75)
+	if damage > 0 and multi_hit_rate > 0.0 and _rng.randf() < multi_hit_rate:
+		var multi_hit_damage: float = 0.5 + maxf(0.0, float(attacker_runtime.get("multi_hit_damage", 0.0)))
+		damage += int(float(damage) * multi_hit_damage)
+	return damage
 
 
 func _get_runtime_atk(cat_id: int) -> float:
@@ -931,17 +1227,18 @@ func _get_runtime_defense(cat_id: int) -> float:
 
 func _get_runtime_crit_rate(cat_id: int) -> float:
 	var runtime: Dictionary = _cat_runtime.get(cat_id, {})
-	return float(runtime.get("crit_rate", 0.0))
+	return clampf(float(runtime.get("crit_rate", 0.0)), 0.0, 1.0)
 
 
 func _get_runtime_crit_damage_bonus(cat_id: int) -> float:
 	var runtime: Dictionary = _cat_runtime.get(cat_id, {})
-	return float(runtime.get("crit_damage_bonus", 0.0))
+	var crit_overcap: float = maxf(0.0, float(runtime.get("crit_rate", 0.0)) - 1.0)
+	return float(runtime.get("crit_damage_bonus", 0.0)) + crit_overcap
 
 
 func _get_runtime_reflect(cat_id: int) -> float:
 	var runtime: Dictionary = _cat_runtime.get(cat_id, {})
-	return float(runtime.get("reflect", 0.0))
+	return clampf(float(runtime.get("reflect", 0.0)), 0.0, 1.0)
 
 
 func _is_runtime_dead(cat_id: int) -> bool:
@@ -1094,7 +1391,8 @@ func _refresh_initial_skill_slot_cooldowns() -> void:
 	for id_variant: Variant in _cat_runtime.keys():
 		var cat_id: int = int(id_variant)
 		var runtime: Dictionary = _cat_runtime.get(cat_id, {})
-		var cat_data: CatData = runtime.get("data", null) as CatData
+		var cat_data_variant: Variant = runtime.get("data", null)
+		var cat_data: CatData = cat_data_variant as CatData
 		if cat_data == null or cat_data.active_skills_data.is_empty():
 			continue
 		var slot: Dictionary = _get_skill_slot_entry(cat_id)

--- a/scripts/data/cats/cat_data.gd
+++ b/scripts/data/cats/cat_data.gd
@@ -9,10 +9,29 @@ var atk: int = 10
 var defense: int = 0
 var speed: float = 100.0
 var weight: float = 100.0
+var crit_rate: float = 0.0
+var crit_damage_bonus: float = 0.0
+var evasion: float = 0.0
+var accuracy: float = 0.0
+var armor_pen: float = 0.0
+var multi_hit_rate: float = 0.0
+var multi_hit_damage: float = 0.0
+var damage_reduction: float = 0.0
+var cooldown_reduction: float = 0.0
+var counter_damage_chance: float = 0.0
 var rarity: String = "common"
 var gacha_available: bool = false
 var enhancement_growth: Dictionary = {"hp": 1.5, "atk": 1.0, "def": 0.5}
-var rank_growth: Dictionary = {"hp_percent": 1.0, "atk_percent": 1.0, "def_percent": 1.0}
+var rank_growth: Dictionary = {
+	"hp_percent": 1.0,
+	"atk_percent": 1.0,
+	"def_percent": 1.0,
+	"crit_rate": 0.0,
+	"crit_damage": 0.0,
+	"evasion": 0.0,
+	"accuracy": 0.0,
+	"multi_hit_rate": 0.0,
+}
 var rank: int = 0
 var passive_skill_ids: Array = []
 var active_skill_configs: Array = []
@@ -41,6 +60,12 @@ static func _from_catalog(data: Dictionary) -> CatData:
 	cat.defense = int(data.get("base_def", 0))
 	cat.speed = float(data.get("base_speed", 100.0))
 	cat.weight = float(data.get("weight", 100.0))
+	cat.crit_rate = _read_rate(data, "base_crit_rate")
+	cat.crit_damage_bonus = _read_rate(data, "base_crit_damage")
+	cat.evasion = _read_rate(data, "base_evasion")
+	cat.accuracy = _read_rate(data, "base_accuracy")
+	cat.multi_hit_rate = _read_rate(data, "base_multi_hit_rate")
+	cat.multi_hit_damage = _read_rate(data, "base_multi_hit_damage")
 	cat.rarity = str(data.get("rarity", "common"))
 	cat.gacha_available = bool(data.get("gacha_available", false))
 
@@ -56,6 +81,11 @@ static func _from_catalog(data: Dictionary) -> CatData:
 		"hp_percent": float(rank_growth_data.get("hp_percent", 1.0)),
 		"atk_percent": float(rank_growth_data.get("atk_percent", 1.0)),
 		"def_percent": float(rank_growth_data.get("def_percent", 1.0)),
+		"crit_rate": _read_rate(data, "crit_rate_growth"),
+		"crit_damage": _read_rate(data, "crit_damage_growth"),
+		"evasion": _read_rate(data, "evasion_growth"),
+		"accuracy": _read_rate(data, "accuracy_growth"),
+		"multi_hit_rate": _read_rate(data, "multi_hit_rate_growth"),
 	}
 
 	cat.passive_skill_ids = data.get("passive_skills", [])
@@ -111,7 +141,17 @@ func apply_rank_bonus(player_cat: PlayerCatData) -> void:
 	max_hp = int(max_hp * (1.0 + rank * rank_growth.get("hp_percent", 1.0) / 100.0))
 	atk = int(atk * (1.0 + rank * rank_growth.get("atk_percent", 1.0) / 100.0))
 	defense = int(defense * (1.0 + rank * rank_growth.get("def_percent", 1.0) / 100.0))
+	crit_rate += rank * float(rank_growth.get("crit_rate", 0.0))
+	crit_damage_bonus += rank * float(rank_growth.get("crit_damage", 0.0))
+	evasion += rank * float(rank_growth.get("evasion", 0.0))
+	accuracy += rank * float(rank_growth.get("accuracy", 0.0))
+	multi_hit_rate += rank * float(rank_growth.get("multi_hit_rate", 0.0))
 
 
 static func get_scaled_effect_value(base_value: float, per_5_ranks: float, current_rank: int) -> float:
 	return base_value + floorf(current_rank / 5.0) * per_5_ranks
+
+
+static func _read_rate(data: Dictionary, key: String) -> float:
+	var value: float = float(data.get(key, 0.0))
+	return value / 100.0 if value > 1.0 else value

--- a/scripts/gamestate/GameState.gd
+++ b/scripts/gamestate/GameState.gd
@@ -1706,6 +1706,9 @@ func update_shop(data: Dictionary) -> void:
 				purchase_counts[str(bundle.get("bundleId", ""))] = int(bundle.get("purchaseCount", 0))
 	player_data.bundle_purchase_counts = purchase_counts
 	player_data.save()
+	var ability_upgrades_variant: Variant = shop_data.get("abilityUpgrades", null)
+	if ability_upgrades_variant is Array and not ability_upgrades_variant.is_empty():
+		update_scooper_ability(ability_upgrades_variant)
 	_emit_red_dot_state_changed()
 
 
@@ -2586,19 +2589,38 @@ func apply_player_combat_bonuses(data: CatData) -> void:
 			"hp", "max_hp":
 				data.max_hp += int(value)
 			"crit_rate":
-				data.set_meta("crit_rate", minf(float(data.get_meta("crit_rate", 0.0)) + value, 1.0))
+				data.crit_rate = maxf(0.0, data.crit_rate + value)
+				data.set_meta("crit_rate", data.crit_rate)
 			"crit_damage":
-				data.set_meta("crit_damage_bonus",
-						maxf(0.0, float(data.get_meta("crit_damage_bonus", 0.0)) + value))
+				data.crit_damage_bonus = maxf(0.0, data.crit_damage_bonus + value)
+				data.set_meta("crit_damage_bonus", data.crit_damage_bonus)
 			"damage_reduction":
-				data.set_meta("damage_reduction_bonus",
-						minf(float(data.get_meta("damage_reduction_bonus", 0.0)) + value, 0.9))
+				data.damage_reduction = minf(data.damage_reduction + value, 0.9)
+				data.set_meta("damage_reduction_bonus", data.damage_reduction)
 			"cooldown_reduction":
-				data.set_meta("cdr", minf(float(data.get_meta("cdr", 0.0)) + value, 0.5))
+				data.cooldown_reduction = minf(data.cooldown_reduction + value, 0.4)
+				data.set_meta("cdr", data.cooldown_reduction)
 			_:
-				if stat in ["armor_pen", "evasion", "accuracy", "multi_hit_rate", "multi_hit_damage",
-						"dungeon_damage_boost", "dungeon_damage_reduction", "life_steal",
-						"counter_damage_chance", "physical_damage_boost", "physical_damage_reduction"]:
+				if stat == "armor_pen":
+					data.armor_pen = maxf(0.0, data.armor_pen + value)
+					data.set_meta(stat, data.armor_pen)
+				elif stat == "evasion":
+					data.evasion = maxf(0.0, data.evasion + value)
+					data.set_meta(stat, data.evasion)
+				elif stat == "accuracy":
+					data.accuracy = maxf(0.0, data.accuracy + value)
+					data.set_meta(stat, data.accuracy)
+				elif stat == "multi_hit_rate":
+					data.multi_hit_rate = maxf(0.0, data.multi_hit_rate + value)
+					data.set_meta(stat, data.multi_hit_rate)
+				elif stat == "multi_hit_damage":
+					data.multi_hit_damage = maxf(0.0, data.multi_hit_damage + value)
+					data.set_meta(stat, data.multi_hit_damage)
+				elif stat == "counter_damage_chance":
+					data.counter_damage_chance = maxf(0.0, data.counter_damage_chance + value)
+					data.set_meta(stat, data.counter_damage_chance)
+				elif stat in ["dungeon_damage_boost", "dungeon_damage_reduction", "life_steal",
+						"physical_damage_boost", "physical_damage_reduction"]:
 					data.set_meta(stat, maxf(0.0, float(data.get_meta(stat, 0.0)) + value))
 
 

--- a/scripts/scooper/ScooperScene.gd
+++ b/scripts/scooper/ScooperScene.gd
@@ -407,10 +407,7 @@ func _refresh_shell_submenu(active_key: String) -> void:
 
 
 func _on_upgrade_ability_pressed(ability_id: int, expected_cost: int) -> void:
-	var body: Dictionary = {"expectedCost": expected_cost}
-	ApiClient.post_authenticated(
-		"/api/scooper/ability/%d/upgrade" % ability_id,
-		body,
+	ApiClient.upgrade_scooper_ability(ability_id, expected_cost,
 		func(ok: bool, data: Variant, _err: Dictionary) -> void:
 			if ok and data is Dictionary:
 				GameState.apply_ability_upgrade(data)

--- a/scripts/shop/ShopScene.gd
+++ b/scripts/shop/ShopScene.gd
@@ -35,6 +35,9 @@ const DIAMOND_STORE_ITEMS := [
 
 const TRAP_CAGE_DIAMOND_COST := 100
 const BUNDLE_ACTION_WIDTH := 220.0
+const SHOP_ABILITY_GROUP_ID := "15"
+const SHOP_ABILITY_UPGRADE_CONFIRM_BODY := "確定花費 %d 鑽石升級「%s」？"
+const SHOP_ABILITY_UPGRADE_SUCCESS := "升級成功！"
 const SHOP_PANEL_FILL := Color(0.16, 0.15, 0.18, 0.25)
 const SHOP_PAGE_SIDE_MARGIN := 10
 const SHOP_REWARD_SLOT_BASE_SIZE := Vector2(512.0, 512.0)
@@ -243,7 +246,8 @@ func _build_secondary_detail(tab_key: String, item_key: String) -> Control:
 
 func _build_bundle_group_detail(tab_key: String, group_id: String) -> Control:
 	var bundles: Array = _get_bundles_for_group(tab_key, group_id)
-	if bundles.is_empty():
+	var ability_upgrades: Array = _get_ability_upgrades_for_group(group_id)
+	if bundles.is_empty() and ability_upgrades.is_empty():
 		return _build_empty_state(UiText.SHOP_EMPTY_CATEGORY)
 
 	var root: VBoxContainer = VBoxContainer.new()
@@ -254,7 +258,108 @@ func _build_bundle_group_detail(tab_key: String, group_id: String) -> Control:
 		if bundle_variant is Dictionary:
 			root.add_child(_build_bundle_detail_card(bundle_variant))
 
+	for ability_variant: Variant in ability_upgrades:
+		if ability_variant is Dictionary:
+			root.add_child(_build_ability_upgrade_card(ability_variant))
+
 	return root
+
+
+func _get_ability_upgrades_for_group(group_id: String) -> Array:
+	if group_id != SHOP_ABILITY_GROUP_ID:
+		return []
+	var result: Array = []
+	for item: Variant in GameState.scooper_ability_data:
+		if not (item is Dictionary):
+			continue
+		var ability: Dictionary = item
+		var next_cost = ability.get("nextUpgradeCost", null)
+		if next_cost != null and int(next_cost) > 0:
+			result.append(ability)
+	return result
+
+
+func _build_ability_upgrade_card(ability: Dictionary) -> Control:
+	var panel: PanelContainer = _make_shop_panel(OverlaySceneChrome.PANEL_BORDER)
+	panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+
+	var margin: MarginContainer = OverlaySceneChrome.make_content_margin(14)
+	panel.add_child(margin)
+
+	var card: VBoxContainer = VBoxContainer.new()
+	card.add_theme_constant_override("separation", 8)
+	margin.add_child(card)
+
+	var title_row: HBoxContainer = HBoxContainer.new()
+	title_row.add_theme_constant_override("separation", 8)
+	card.add_child(title_row)
+
+	var title: Label = Label.new()
+	title.text = str(ability.get("displayName", ""))
+	title.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	title.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	title.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_HEADING)
+	title.add_theme_color_override("font_color", OverlaySceneChrome.TITLE_TEXT_COLOR)
+	title_row.add_child(title)
+
+	var current_tier: int = int(ability.get("currentTier", ability.get("quantity", 1)))
+	var max_tier = ability.get("maxTier", null)
+	var tier_label: Label = Label.new()
+	if max_tier != null and int(max_tier) > 0:
+		tier_label.text = "Lv %d / %d" % [current_tier, int(max_tier)]
+	else:
+		tier_label.text = "Lv %d" % current_tier
+	tier_label.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_LABEL)
+	tier_label.add_theme_color_override("font_color", Color(0.92, 0.80, 0.48, 1.0))
+	title_row.add_child(tier_label)
+
+	var desc: Label = Label.new()
+	desc.text = str(ability.get("description", ""))
+	desc.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	desc.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY)
+	desc.add_theme_color_override("font_color", OverlaySceneChrome.MUTED_TEXT_COLOR)
+	card.add_child(desc)
+
+	var next_cost: int = int(ability.get("nextUpgradeCost", 0))
+	var ability_id: int = int(ability.get("abilityId", 0))
+	var ability_name: String = str(ability.get("displayName", ""))
+
+	var action_button: Button = Button.new()
+	action_button.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	action_button.custom_minimum_size = Vector2(0.0, 48.0)
+	UiPalette.apply_button_kind(action_button, "confirm")
+	action_button.text = UiText.SCOOPER_ABILITY_UPGRADE_FORMAT % next_cost
+	action_button.pressed.connect(Callable(self, "_confirm_ability_upgrade").bind(ability_id, ability_name, next_cost))
+	card.add_child(action_button)
+
+	return panel
+
+
+func _confirm_ability_upgrade(ability_id: int, ability_name: String, expected_cost: int) -> void:
+	var message: String = SHOP_ABILITY_UPGRADE_CONFIRM_BODY % [expected_cost, ability_name]
+	DialogManager.show_confirm(
+		UiText.SHOP_PURCHASE_BUNDLE_TITLE,
+		message,
+		Callable(self, "_execute_ability_upgrade").bind(ability_id, expected_cost)
+	)
+
+
+func _execute_ability_upgrade(ability_id: int, expected_cost: int) -> void:
+	_api_client.upgrade_scooper_ability(ability_id, expected_cost, Callable(self, "_on_ability_upgrade_completed"))
+
+
+func _on_ability_upgrade_completed(success: bool, data: Variant, error: Dictionary) -> void:
+	if not success:
+		ToastManager.error(UiText.SHOP_PURCHASE_FAILED_TITLE, str(error.get("message", UiText.SCOOPER_ABILITY_UPGRADE_FAILED)))
+		return
+	if data is Dictionary:
+		GameState.apply_ability_upgrade(data)
+		var remaining: int = int(data.get("remainingDiamonds", -1))
+		if remaining >= 0 and GameState.player_data != null:
+			GameState.player_data.diamonds = remaining
+			GameState.player_data.save()
+	_refresh_content()
+	ToastManager.success(UiText.SHOP_PURCHASE_SUCCESS_TITLE, SHOP_ABILITY_UPGRADE_SUCCESS)
 
 
 func _build_bundle_detail_card(bundle: Dictionary) -> Control:


### PR DESCRIPTION
## 內容
- 擴充 CatData 與 GameState，讓後端提供的戰鬥數值與被動加成能進入實際戰鬥。
- 更新 BattleManager 的衝撞與技能流程，套用攻擊/防禦、暴擊、閃避、連擊、反傷、護盾與狀態效果。
- 補充戰鬥與技能 GDD 的缺口，明確化暴擊率、連擊率與反傷等規則。
- 保留並納入商店能力升級 UI/API 呼叫，對齊目前 API response。

## 驗證
- Godot headless 專案載入通過。
- git diff --check 通過。

Closes #357