### PR TITLE
fix:掛機獎勵自動彈窗改為四小時門檻

### DIFF
--- a/docs/gdd/26_home_scooper_shortcut.md
+++ b/docs/gdd/26_home_scooper_shortcut.md
@@ -105,7 +105,7 @@
 
 ## 7. 2026-04-24 主畫面進入與按鈕可用性更新
 
-- 登入 / bootstrap 完成後第一次進入主畫面時，若 `GameState.has_pending_idle_rewards()` 為 true，`BattleScene` 會自動開啟放置獎勵 Dialog。
+- 登入 / bootstrap 完成後第一次進入主畫面時，只有在已有未領取放置獎勵且累積時間達 `4` 小時以上時，`BattleScene` 才會自動開啟放置獎勵 Dialog。
 - 外層 `清理貓砂盆` / `乾淨貓砂盆` 按鈕不可因累積時間未滿 1 分鐘而 disabled；玩家任何時間都可以自行開啟 Dialog 查看收益券與目前狀態。
 - 未滿 1 分鐘時，Dialog 不顯示 `領取獎勵` CTA，但仍可顯示收益券與清理相關資訊。
 - 放置獎勵 Dialog 的獎勵內容使用 `scenes/ui/ItemSlotTemplate.tscn` 呈現圖示、名稱與數量，獎勵 Grid 每行最多顯示 5 個 slot。

--- a/scripts/battle/battle_scene.gd
+++ b/scripts/battle/battle_scene.gd
@@ -3422,6 +3422,8 @@ func _show_startup_idle_rewards_dialog_if_needed() -> void:
 		return
 	if not GameState.has_pending_idle_rewards():
 		return
+	if GameState.get_idle_elapsed_seconds() < IDLE_CLAIM_RED_DOT_THRESHOLD_SECONDS:
+		return
 	_show_sandbox_dialog()
 
 


### PR DESCRIPTION
## 變更內容
- 將登入後自動開啟放置獎勵 Dialog 的條件改為：已有未領取掛機獎勵，且累積時間達 4 小時以上。
- 同步更新主畫面貓砂盆捷徑 GDD，記錄新的自動彈窗門檻。

## 原因
原本只要 GameState.has_pending_idle_rewards() 為 true，也就是累積滿 1 分鐘可領，就會在登入後自動跳出 Dialog，太容易打斷玩家。

## 驗證
- 已用 Godot MCP 啟動專案，debug output 無 errors。
- 已確認沒有其他登入自動開啟放置獎勵 Dialog 的路徑。

Closes #361