### PR TITLE
fix:修復主子 Dialog 上下滑動跳動與部分區域無法滑動

### DIFF
--- a/scripts/DialogManager.gd
+++ b/scripts/DialogManager.gd
@@ -37,13 +37,7 @@ func show_info(title: String, text: String, on_close: Callable = Callable(), wid
 
 ## Returns a Callable that can be called externally to close this dialog
 func show_info_node(title: String, content: Control, on_close: Callable = Callable(), width_size: String = "small") -> Callable:
-	# If the content is a ScrollContainer, attach the inertial scroller helper so touch drag has inertia/bounce
-	if content is ScrollContainer:
-		# Prefer calling the registered class; fallback to the preloaded script if needed
-		if typeof(InertialScroller) != TYPE_NIL:
-			InertialScroller.attach(content)
-		elif _INERTIAL_SCROLL != null:
-			_INERTIAL_SCROLL.attach(content)
+	# InertialScroller attachment is handled inside _build for all content types
 	return _build(title, content, false, on_close, Callable(), UiText.COMMON_CONFIRM, UiText.COMMON_CANCEL, width_size)
 
 
@@ -121,6 +115,13 @@ func _build(
 	content.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	content.size_flags_vertical = Control.SIZE_EXPAND_FILL if content is ScrollContainer else 0
 
+	# Attach inertial scroller when content is a ScrollContainer
+	if content is ScrollContainer:
+		if typeof(InertialScroller) != TYPE_NIL:
+			InertialScroller.attach(content, "vertical")
+		elif _INERTIAL_SCROLL != null:
+			_INERTIAL_SCROLL.attach(content, "vertical")
+
 	var canvas := CanvasLayer.new()
 	canvas.layer = 100
 	add_child(canvas)
@@ -146,6 +147,7 @@ func _build(
 	canvas.add_child(center)
 
 	var dialog_stack := VBoxContainer.new()
+	dialog_stack.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	dialog_stack.alignment = BoxContainer.ALIGNMENT_CENTER
 	dialog_stack.add_theme_constant_override("separation", 10)
 	dialog_stack.custom_minimum_size.x = panel_width
@@ -172,12 +174,14 @@ func _build(
 	dialog_stack.add_child(panel)
 
 	var margin := MarginContainer.new()
+	margin.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	margin.size_flags_vertical = 0
 	for side: String in ["left", "right", "top", "bottom"]:
 		margin.add_theme_constant_override("margin_" + side, 16)
 	panel.add_child(margin)
 
 	var vbox := VBoxContainer.new()
+	vbox.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	vbox.add_theme_constant_override("separation", 12)
 	vbox.size_flags_vertical = 0
 	margin.add_child(vbox)
@@ -186,12 +190,14 @@ func _build(
 
 	# Title row
 	var title_row := HBoxContainer.new()
+	title_row.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	title_row.add_theme_constant_override("separation", 8)
 	title_row.size_flags_vertical = 0
 	vbox.add_child(title_row)
 
 	var title_lbl := Label.new()
 	title_lbl.text = title
+	title_lbl.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	title_lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	title_lbl.add_theme_font_size_override("font_size", _FONT_TITLE)
 	title_row.add_child(title_lbl)

--- a/scripts/enhance/EnhanceSceneUI.gd
+++ b/scripts/enhance/EnhanceSceneUI.gd
@@ -526,11 +526,13 @@ static func rebuild_detail_panel(scene) -> void:
 
 	var stats_title := Label.new()
 	stats_title.text = UiText.ENHANCE_SPECIAL_ALLOC_TITLE
+	stats_title.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	stats_title.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SUBHEADING)
 	stats_title.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	stats_header.add_child(stats_title)
 
 	scene._special_cost_label = Label.new()
+	scene._special_cost_label.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	scene._special_cost_label.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_LABEL)
 	scene._special_cost_label.add_theme_color_override("font_color", MUTED_TEXT_COLOR)
 	stats_header.add_child(scene._special_cost_label)
@@ -558,6 +560,7 @@ static func rebuild_detail_panel(scene) -> void:
 		row.add_child(stat_stack)
 
 		var stat_lbl := Label.new()
+		stat_lbl.mouse_filter = Control.MOUSE_FILTER_IGNORE
 		stat_lbl.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY_LG)
 		stat_lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 		scene._stat_labels[stat_key] = stat_lbl
@@ -579,6 +582,7 @@ static func rebuild_detail_panel(scene) -> void:
 	Refresh.refresh_special_buttons(scene, player_cat)
 
 	var special_action_row := HBoxContainer.new()
+	special_action_row.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	special_action_row.add_theme_constant_override("separation", 8)
 	special_action_row.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	stats_vbox.add_child(special_action_row)
@@ -785,75 +789,91 @@ static func _compare_catalog_rows(a: Dictionary, b: Dictionary) -> bool:
 static func _build_catalog_detail_panel(scene, cat_data: CatData, preview_cat: PlayerCatData) -> void:
 	var summary_panel := _make_card_panel(OverlaySceneChrome.PANEL_BORDER)
 	summary_panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	summary_panel.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	scene._detail_panel.add_child(summary_panel)
 
 	var summary_margin := _make_content_margin(16)
+	summary_margin.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	summary_panel.add_child(summary_margin)
 
 	var summary_stack := VBoxContainer.new()
+	summary_stack.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	summary_stack.add_theme_constant_override("separation", 12)
 	summary_margin.add_child(summary_stack)
 
 	var catalog_hint := Label.new()
 	catalog_hint.text = UiText.ENHANCE_CATALOG_HINT
+	catalog_hint.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	catalog_hint.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	catalog_hint.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY)
 	catalog_hint.add_theme_color_override("font_color", MUTED_TEXT_COLOR)
 	summary_stack.add_child(catalog_hint)
 
 	var summary_row := HBoxContainer.new()
+	summary_row.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	summary_row.add_theme_constant_override("separation", 14)
 	summary_stack.add_child(summary_row)
 
 	var left_column := VBoxContainer.new()
+	left_column.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	left_column.custom_minimum_size = Vector2(152.0, 0.0)
 	left_column.add_theme_constant_override("separation", 8)
 	summary_row.add_child(left_column)
 
 	var icon_shell := PanelContainer.new()
+	icon_shell.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	icon_shell.custom_minimum_size = Vector2(152.0, 152.0)
 	icon_shell.add_theme_stylebox_override("panel", OverlaySceneChrome.make_panel_style(ART_FILL, ART_BORDER, 14))
 	left_column.add_child(icon_shell)
 
 	var icon_center := CenterContainer.new()
+	icon_center.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	icon_center.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 	icon_shell.add_child(icon_center)
 	icon_center.add_child(_make_idle_preview(scene._selected_cat_id, Vector2(120.0, 120.0)))
 
 	var left_meta_row := HBoxContainer.new()
+	left_meta_row.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	left_meta_row.add_theme_constant_override("separation", 8)
 	left_meta_row.alignment = BoxContainer.ALIGNMENT_CENTER
 	left_column.add_child(left_meta_row)
 
 	var level_label := Label.new()
+	level_label.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	level_label.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_LABEL)
 	level_label.add_theme_color_override("font_color", SLOT_NAME_COLOR)
 	level_label.text = UiText.ENHANCE_CAT_LEVEL_FORMAT % [preview_cat.cat_food_level]
 	left_meta_row.add_child(_make_info_chip(level_label, Color(0.20, 0.16, 0.18, 0.92), OverlaySceneChrome.CARD_BORDER))
 
 	var rank_label := Label.new()
+	rank_label.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	rank_label.add_theme_font_size_override("font_size", 17)
 	rank_label.add_theme_color_override("font_color", SLOT_NAME_COLOR)
 	rank_label.text = UiText.ENHANCE_CAT_RANK_FORMAT % [preview_cat.rank]
 	left_meta_row.add_child(_make_info_chip(rank_label, Color(0.20, 0.16, 0.18, 0.92), OverlaySceneChrome.CARD_BORDER))
 
 	var right_column := VBoxContainer.new()
+	right_column.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	right_column.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	right_column.add_theme_constant_override("separation", 12)
 	summary_row.add_child(right_column)
 
 	var skill_panel := _make_card_panel(OverlaySceneChrome.CARD_BORDER)
+	skill_panel.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	skill_panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	right_column.add_child(skill_panel)
 
 	var skill_margin := _make_content_margin(12)
+	skill_margin.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	skill_panel.add_child(skill_margin)
 
 	var skill_box := VBoxContainer.new()
+	skill_box.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	skill_box.add_theme_constant_override("separation", 10)
 	skill_margin.add_child(skill_box)
 
 	var skill_title := Label.new()
+	skill_title.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	skill_title.text = UiText.ENHANCE_SKILL_TITLE
 	skill_title.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SUBHEADING)
 	skill_box.add_child(skill_title)
@@ -864,17 +884,21 @@ static func _build_catalog_detail_panel(scene, cat_data: CatData, preview_cat: P
 	scene._detail_panel = skill_root
 
 	var stats_panel := _make_card_panel(ART_BORDER)
+	stats_panel.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	stats_panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	scene._detail_panel.add_child(stats_panel)
 
 	var stats_margin := _make_content_margin(12)
+	stats_margin.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	stats_panel.add_child(stats_margin)
 
 	var stats_box := VBoxContainer.new()
+	stats_box.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	stats_box.add_theme_constant_override("separation", 10)
 	stats_margin.add_child(stats_box)
 
 	var stats_title := Label.new()
+	stats_title.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	stats_title.text = UiText.ENHANCE_STATS_TITLE
 	stats_title.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SUBHEADING)
 	stats_box.add_child(stats_title)
@@ -885,13 +909,16 @@ static func _build_catalog_detail_panel(scene, cat_data: CatData, preview_cat: P
 		{"label": UiText.ENHANCE_STAT_DEF, "value": cat_data.defense},
 	]:
 		var row_card := PanelContainer.new()
+		row_card.mouse_filter = Control.MOUSE_FILTER_IGNORE
 		row_card.add_theme_stylebox_override("panel", OverlaySceneChrome.make_panel_style(Color(0.13, 0.12, 0.14, 0.94), OverlaySceneChrome.CARD_BORDER, 12))
 		stats_box.add_child(row_card)
 
 		var row_margin := _make_content_margin(10)
+		row_margin.mouse_filter = Control.MOUSE_FILTER_IGNORE
 		row_card.add_child(row_margin)
 
 		var row_label := Label.new()
+		row_label.mouse_filter = Control.MOUSE_FILTER_IGNORE
 		row_label.text = "%s: %s" % [str(stat_item.get("label", "")), GameState.format_number(int(stat_item.get("value", 0)))]
 		row_label.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_BODY_LG)
 		row_margin.add_child(row_label)
@@ -973,12 +1000,14 @@ static func _build_stat_overview_panel(scene) -> void:
 
 	var title: Label = Label.new()
 	title.text = UiText.ENHANCE_STAT_OVERVIEW_TITLE
+	title.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	title.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	title.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SUBHEADING)
 	title.add_theme_color_override("font_color", SLOT_NAME_COLOR)
 	header_row.add_child(title)
 
 	var tabs: HBoxContainer = HBoxContainer.new()
+	tabs.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	tabs.add_theme_constant_override("separation", 6)
 	header_row.add_child(tabs)
 
@@ -1028,6 +1057,7 @@ static func refresh_stat_overview_tab_state(scene) -> void:
 
 	var desc: Label = Label.new()
 	desc.text = UiText.ENHANCE_STAT_OVERVIEW_EFFECTIVE_DESC if is_effective else UiText.ENHANCE_STAT_OVERVIEW_BASE_DESC
+	desc.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	desc.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	desc.add_theme_font_size_override("font_size", UiPalette.FONT_SIZE_SMALL)
 	desc.add_theme_color_override("font_color", MUTED_TEXT_COLOR)

--- a/scripts/ui/inertial_scroll.gd
+++ b/scripts/ui/inertial_scroll.gd
@@ -36,6 +36,12 @@ var fade_timer: Timer
 var is_scrolling: bool = false
 var _last_haptic_us: int = 0
 var _last_boundary_state: int = 0 # -1 = over top/left, 0 = inside, 1 = over bottom/right
+var _canvas_layer_depth: int = 0
+var _drag_input_device: int = -99  # tracks which device started the drag
+
+# ── Static registry — used for canvas-layer priority ───
+
+static var _instances: Array[WeakRef] = []
 
 # ── Static attach ──────────────────────────────────────
 
@@ -76,15 +82,24 @@ static func detach(scroll: ScrollContainer) -> void:
 # ── Init ───────────────────────────────────────────────
 
 func _init_attach() -> void:
-	set_process_input(true)
 	set_process(true)
 	target.mouse_filter = Control.MOUSE_FILTER_STOP
+
+	# Disable Godot's built-in drag scrolling — InertialScroller owns all drag
+	# positioning. Without this, ScrollContainer._gui_input() also moves the
+	# scroll on every drag event, causing a double-move jump. Setting
+	# scroll_deadzone to INT_MAX makes the native drag threshold unreachable.
+	target.scroll_deadzone = 2147483647
+
 	if not target.gui_input.is_connected(_on_target_gui_input):
 		target.gui_input.connect(_on_target_gui_input)
 
-	# Key: hidden by default, shown automatically during interaction (auto mode)
-	target.vertical_scroll_mode = ScrollContainer.SCROLL_MODE_AUTO
-	target.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_AUTO
+	# Only override the managed axis; leave the other axis untouched so callers
+	# can explicitly disable horizontal/vertical scrolling before attaching.
+	if axis == "vertical":
+		target.vertical_scroll_mode = ScrollContainer.SCROLL_MODE_AUTO
+	else:
+		target.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_AUTO
 	
 	fade_timer = Timer.new()
 	fade_timer.wait_time = 0.5
@@ -93,6 +108,36 @@ func _init_attach() -> void:
 	add_child(fade_timer)
 
 	_force_hide_scrollbars()
+
+	# Compute canvas layer depth for priority resolution
+	_canvas_layer_depth = _compute_canvas_layer_depth()
+	_instances.append(weakref(self))
+
+
+func _exit_tree() -> void:
+	# Remove self from the static registry
+	for i in range(_instances.size() - 1, -1, -1):
+		var ref: WeakRef = _instances[i]
+		var inst = ref.get_ref()
+		if inst == null or inst == self:
+			_instances.remove_at(i)
+
+
+func _enter_tree() -> void:
+	# Recompute canvas layer depth when (re-)added to the tree, since the
+	# scroller may have been attached before its ScrollContainer was parented
+	# under the final CanvasLayer (e.g. DialogManager adds content later).
+	_canvas_layer_depth = _compute_canvas_layer_depth()
+
+
+func _compute_canvas_layer_depth() -> int:
+	var depth: int = 0
+	var node: Node = target
+	while node:
+		if node is CanvasLayer:
+			depth = maxi(depth, node.layer)
+		node = node.get_parent()
+	return depth
 
 # ── Helpers ────────────────────────────────────────────
 
@@ -124,13 +169,35 @@ func _event_inside_target(event: InputEvent) -> bool:
 		or event is InputEventScreenTouch \
 		or event is InputEventScreenDrag):
 		return false
-	return target.get_global_rect().has_point(event.position)
+	if not target.get_global_rect().has_point(event.position):
+		return false
+	if not target.is_visible_in_tree():
+		return false
+	return true
+
+
+## Returns true if another visible InertialScroller covers the same point
+## at a higher canvas layer, meaning this scroller should yield.
+func _is_occluded_at(pos: Vector2) -> bool:
+	for ref: WeakRef in _instances:
+		var inst = ref.get_ref() as InertialScroller
+		if inst == null or inst == self:
+			continue
+		if inst.target == null or not inst.target.is_visible_in_tree():
+			continue
+		if inst._canvas_layer_depth <= _canvas_layer_depth:
+			continue
+		if inst.target.get_global_rect().has_point(pos):
+			return true
+	return false
 
 # ── Input ──────────────────────────────────────────────
 
-func _input(event: InputEvent) -> void:
-	_handle_scroll_input(event)
-
+# NOTE: We use ONLY gui_input (not _input) so that event positions are always
+# in the same coordinate space as the ScrollContainer. Using _input() gives
+# viewport-global coordinates which differ from gui_input's CanvasLayer-local
+# coordinates, causing two PRESS events with different _last_pos values and a
+# huge spurious delta on the first MOTION.
 
 func _on_target_gui_input(event: InputEvent) -> void:
 	_handle_scroll_input(event)
@@ -143,10 +210,17 @@ func _handle_scroll_input(event: InputEvent) -> void:
 	if event_id == _last_handled_event_id:
 		return
 
+	# ── Skip touch-emulated mouse events to avoid double processing ──
+	if dragging and _drag_input_device >= 0:
+		if (event is InputEventMouseButton or event is InputEventMouseMotion) and event.device < 0:
+			return
+
 	# press
 	if (event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed) \
 	or (event is InputEventScreenTouch and event.pressed):
 		if not _event_inside_target(event):
+			return
+		if _is_occluded_at(event.position):
 			return
 
 		_last_handled_event_id = event_id
@@ -157,20 +231,22 @@ func _handle_scroll_input(event: InputEvent) -> void:
 		_drag_accum = 0.0
 		_last_pos = _get_pos(event)
 		_last_ev_time_us = Time.get_ticks_usec()
+		_drag_input_device = event.device
 		_show_scrollbar()
 		return
 
 	# release
 	if (event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and not event.pressed) \
 	or (event is InputEventScreenTouch and not event.pressed):
-
 		if not dragging:
 			return
 		_last_handled_event_id = event_id
 		dragging = false
+		_drag_input_device = -99
 		if moved:
 			velocity = clamp(_last_velocity_sample, -MAX_VELOCITY, MAX_VELOCITY)
 			_show_scrollbar()
+			get_viewport().set_input_as_handled()
 		return
 
 	# motion
@@ -193,27 +269,21 @@ func _handle_scroll_input(event: InputEvent) -> void:
 	if _drag_accum > drag_threshold:
 		moved = true
 	else:
-		# Below drag threshold: do not intercept button taps or move the scroll position.
 		return
 
-	# Use desired-scroll to compute overscroll, avoiding direction / max_scroll inference errors
 	var cur_scroll := _get_scroll()
 	var max_s = max(_get_max_scroll(), 0.0)
 	var desired = cur_scroll - delta
 
 	if desired < 0.0:
-		# moved beyond top; clamp scroll
 		_set_scroll(0.0)
 	elif desired > max_s:
-		# moved beyond bottom/right; clamp
 		_set_scroll(max_s)
 	else:
 		_set_scroll(desired)
 
-	# Show scrollbar during active interaction
 	_show_scrollbar()
 
-	# Velocity sampling (improved)
 	if dt > 0.0005:
 		var v_sample = -delta / dt
 		_last_velocity_sample = v_sample
@@ -282,14 +352,23 @@ func _force_hide_scrollbars():
 
 	if vsb:
 		vsb.modulate.a = 0.0
+		vsb.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	if hsb:
 		hsb.modulate.a = 0.0
+		hsb.mouse_filter = Control.MOUSE_FILTER_IGNORE
 
 func _show_scrollbar():
 	if fade_timer == null:
 		return
 	var vsb = target.get_v_scroll_bar()
 	var hsb = target.get_h_scroll_bar()
+
+	# Always keep scrollbars non-interactive — InertialScroller owns scroll positioning.
+	# Scrollbars are visual-only indicators.
+	if vsb:
+		vsb.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	if hsb:
+		hsb.mouse_filter = Control.MOUSE_FILTER_IGNORE
 
 	if axis == "vertical":
 		if vsb:


### PR DESCRIPTION
## 關聯 Issue

Closes #368

## 修改內容

### scripts/ui/inertial_scroll.gd
- 移除 _input() 全域處理，只保留 gui_input（最關鍵修復）
- 新增 scroll_deadzone = INT_MAX 停用原生拖曳雙重寫入
- Scrollbar 設為 MOUSE_FILTER_IGNORE
- 只覆蓋管理軸向的 scroll_mode
- 新增 canvas layer 優先權機制
- 新增 _drag_input_device 跳過觸控模擬滑鼠事件

### scripts/enhance/EnhanceSceneUI.gd
- 能力總覽、屬性加成等非互動控件補齊 mouse_filter = MOUSE_FILTER_IGNORE

### scripts/DialogManager.gd
- 移除錯誤的自動包 ScrollContainer 邏輯
- 非互動容器設為 MOUSE_FILTER_IGNORE