### PR TITLE
修正鏟屎官裝備圖改走 CDN 遠端載入

### DIFF
--- a/scripts/scooper/scooper_tab_scooper.gd
+++ b/scripts/scooper/scooper_tab_scooper.gd
@@ -241,10 +241,9 @@ func _make_equip_card(scene: Control, item: Dictionary) -> Control:
 	_prepare_flat_button(action_btn)
 	_set_panel_fill(progress_frame, Color(0.19, 0.17, 0.15, 0.92))
 
-	var equipment_icon: Texture2D = AssetResolver.resolve_equipment_icon(item)
 	if icon_rect != null:
-		icon_rect.texture = equipment_icon
-		icon_rect.visible = equipment_icon != null
+		AssetResolver.apply_equipment_icon_texture(icon_rect, item)
+		icon_rect.visible = icon_rect.texture != null
 	level_lbl.visible = owned
 	level_lbl.text = str(level)
 	title_lbl.text = _format_equipment_title(name_str, level if owned else 0)

--- a/scripts/ui/asset_resolver.gd
+++ b/scripts/ui/asset_resolver.gd
@@ -1182,7 +1182,19 @@ static func resolve_gacha_frame(result: Dictionary) -> Texture2D:
 
 
 static func resolve_equipment_icon(item: Dictionary) -> Texture2D:
-	return resolve_texture_or_placeholder(str(SCOOPER_EQUIPMENT.get(int(item.get("equipmentId", 0)), "")))
+	return resolve_texture_or_placeholder(resolve_equipment_icon_path(item))
+
+
+static func apply_equipment_icon_texture(texture_rect: TextureRect, item: Dictionary) -> void:
+	if texture_rect == null:
+		return
+	var resolved_path: String = resolve_equipment_icon_path(item)
+	var fallback_texture: Texture2D = resolve_equipment_icon(item)
+	_apply_remote_texture(texture_rect, resolved_path, fallback_texture)
+
+
+static func resolve_equipment_icon_path(item: Dictionary) -> String:
+	return str(SCOOPER_EQUIPMENT.get(int(item.get("equipmentId", 0)), ""))
 
 
 static func resolve_ability_icon(item: Dictionary) -> Texture2D:


### PR DESCRIPTION
## 變更\n- 補上鏟屎官裝備 icon 的 CDN 遠端載入流程\n- 保留本地貼圖作為 fallback\n- 修正裝備卡片直接讀本地 es:// 導致線上 CDN 圖不顯示的問題\n\n## 驗證\n- dotnet build MeowPartyDashClient.csproj\n- 確認對應 R2 圖檔與 CORS 回應正常