### PR TITLE
feat:CDN 圖片預載與修正主子頁面貓咪 icon 無法顯示

### DIFF
--- a/scripts/StartScene.gd
+++ b/scripts/StartScene.gd
@@ -1190,6 +1190,7 @@ func _on_request_completed(result: int, response_code: int, _headers: PackedStri
 				return
 			_cancel_bootstrap_retry()
 			GameState.apply_player_bootstrap(data)
+			CdnTextureLoader.warm_cache(AssetResolver.collect_warmup_cdn_urls(GameState.get_owned_cats()))
 			_bootstrap_completed = true
 			_complete_loading_state()
 			return

--- a/scripts/ui/CdnTextureLoader.gd
+++ b/scripts/ui/CdnTextureLoader.gd
@@ -6,6 +6,20 @@ var _texture_cache: Dictionary = {}
 var _pending_targets: Dictionary = {}
 
 
+func warm_cache(remote_urls: Array[String]) -> void:
+	for url: String in remote_urls:
+		if url == "" or _texture_cache.has(url) or _pending_targets.has(url):
+			continue
+		_pending_targets[url] = []
+		var request: HTTPRequest = HTTPRequest.new()
+		add_child(request)
+		request.request_completed.connect(_on_request_completed.bind(url, request))
+		var request_error: int = request.request(url)
+		if request_error != OK:
+			request.queue_free()
+			_pending_targets.erase(url)
+
+
 func apply_texture(texture_rect: TextureRect, remote_url: String, fallback_texture: Texture2D) -> void:
 	if texture_rect == null:
 		return

--- a/scripts/ui/asset_resolver.gd
+++ b/scripts/ui/asset_resolver.gd
@@ -845,6 +845,29 @@ static func resolve_cdn_asset_url(path: String) -> String:
 	return "%s/%s" % [RuntimeConfig.get_assets_base_url(), normalized_path.trim_prefix("res://")]
 
 
+static func collect_warmup_cdn_urls(owned_cat_ids: Array[String]) -> Array[String]:
+	if not RuntimeConfig.should_use_cdn_assets():
+		return []
+	var seen: Dictionary = {}
+	var urls: Array[String] = []
+	for cat_id: String in owned_cat_ids:
+		var url: String = resolve_cdn_asset_url(_resolve_cat_icon_path(cat_id))
+		if url != "" and not seen.has(url):
+			seen[url] = true
+			urls.append(url)
+	for rarity_path: Variant in CAT_CARD_SQUARE_FRAMES.values():
+		var url: String = resolve_cdn_asset_url(str(rarity_path))
+		if url != "" and not seen.has(url):
+			seen[url] = true
+			urls.append(url)
+	for type_path: Variant in CAT_TYPE_ICONS.values():
+		var url: String = resolve_cdn_asset_url(str(type_path))
+		if url != "" and not seen.has(url):
+			seen[url] = true
+			urls.append(url)
+	return urls
+
+
 static func apply_background_texture(texture_rect: TextureRect, slot: String) -> void:
 	if texture_rect == null:
 		return
@@ -1133,8 +1156,9 @@ static func get_cat_battle_animation_names() -> Array[String]:
 
 static func _resolve_cat_icon_path(cat_id: String) -> String:
 	var mapped_path: String = str(CAT_ICONS.get(cat_id, ""))
-	if mapped_path != "" and ResourceLoader.exists(mapped_path):
-		return mapped_path
+	if mapped_path != "":
+		if mapped_path.begins_with(UI_CDN_ROOT) or ResourceLoader.exists(mapped_path):
+			return mapped_path
 	return _resolve_character_ref_path(cat_id, "icon_v1")
 
 
@@ -1143,7 +1167,7 @@ static func _resolve_character_ref_path(cat_id: String, suffix: String) -> Strin
 		return ""
 	for root: String in _get_character_ref_roots(cat_id):
 		var candidate_path: String = "%s%s/%s_%s.png" % [root, cat_id, cat_id, suffix]
-		if ResourceLoader.exists(candidate_path):
+		if root.begins_with(UI_CDN_ROOT) or ResourceLoader.exists(candidate_path):
 			return candidate_path
 	return ""
 


### PR DESCRIPTION
## 關聯 Issue
Closes #378

## 變更內容

### Bug 修正：主子頁面貓咪 icon 無法顯示
- **scripts/ui/asset_resolver.gd**：_resolve_cat_icon_path 與 _resolve_character_ref_path 對 CDN 路徑（es://assets/sprites/cdn/ 開頭）跳過 ResourceLoader.exists() 檢查，直接回傳路徑以供 CDN URL 解析。

### 功能新增：Bootstrap 期間 CDN 圖片預載
- **scripts/ui/CdnTextureLoader.gd**：新增 warm_cache(remote_urls: Array[String]) 方法，對一組 URL 發起背景 HTTP 請求並快取，不需要 TextureRect 目標。
- **scripts/ui/asset_resolver.gd**：新增 collect_warmup_cdn_urls(owned_cat_ids) 靜態方法，收集玩家擁有的貓咪 icon、所有稀有度卡框、所有角色類型 icon 的 CDN URL（去重）。
- **scripts/StartScene.gd**：Bootstrap 成功後立即呼叫 CdnTextureLoader.warm_cache()，在 loading bar 結束前於背景完成常用圖片預載。

## 影響範圍
- 登入 loading 時間略微延長（背景平行下載，不阻擋畫面切換）
- 進入主子、陣容、轉蛋等頁面後圖片直接從 cache 讀取，不再逐一跑出