### PR TITLE
feat:啟動頁面預載所有CDN圖片並調整讀條速度

### DIFF
--- a/scripts/StartScene.gd
+++ b/scripts/StartScene.gd
@@ -10,7 +10,7 @@ const REQUEST_TIMEOUT_SECONDS := 15.0
 const BOOTSTRAP_MAX_RETRY_COUNT := 2
 const BOOTSTRAP_RETRY_DELAY_SECONDS := 5.0
 const BOOTSTRAP_PROGRESS_MAX_PERCENT := 96.0
-const BOOTSTRAP_PROGRESS_DURATION_SECONDS := 12.0
+const BOOTSTRAP_PROGRESS_DURATION_SECONDS := 36.0
 const NGROK_SKIP_WARNING_HEADER := "ngrok-skip-browser-warning: true"
 const REQUEST_KIND_AUTH := "auth"
 const REQUEST_KIND_BOOTSTRAP := "bootstrap"
@@ -117,6 +117,7 @@ var _loading_fill_tween: Tween
 var _loading_percent_tween: Tween
 var _loading_animation_finished := false
 var _bootstrap_completed := false
+var _cdn_warmup_completed := false
 var _bootstrap_retry_count: int = 0
 var _auth_request_mode: AuthMode = AuthMode.LOGIN
 var _bootstrap_retry_timer: Timer
@@ -1190,9 +1191,12 @@ func _on_request_completed(result: int, response_code: int, _headers: PackedStri
 				return
 			_cancel_bootstrap_retry()
 			GameState.apply_player_bootstrap(data)
+			_cdn_warmup_completed = false
+			if not CdnTextureLoader.warmup_completed.is_connected(_on_cdn_warmup_completed):
+				CdnTextureLoader.warmup_completed.connect(_on_cdn_warmup_completed, CONNECT_ONE_SHOT)
 			CdnTextureLoader.warm_cache(AssetResolver.collect_warmup_cdn_urls(GameState.get_owned_cats()))
 			_bootstrap_completed = true
-			_complete_loading_state()
+			_try_finish_loading()
 			return
 		if completed_request_kind == REQUEST_KIND_LOGOUT_REFRESH:
 			GameState.set_auth_session(GameState.api_base_url, data)
@@ -1460,6 +1464,7 @@ func _begin_refresh_then_bootstrap() -> void:
 func _show_loading_state() -> void:
 	_input_ready = false
 	_bootstrap_completed = false
+	_cdn_warmup_completed = false
 	_bootstrap_retry_count = 0
 	_loading_animation_finished = false
 	_cancel_loading_tweens()
@@ -1499,7 +1504,16 @@ func _on_loading_animation_finished() -> void:
 	_loading_fill_tween = null
 	_loading_percent_tween = null
 	_loading_animation_finished = true
-	if _bootstrap_completed:
+	_try_finish_loading()
+
+
+func _on_cdn_warmup_completed() -> void:
+	_cdn_warmup_completed = true
+	_try_finish_loading()
+
+
+func _try_finish_loading() -> void:
+	if _bootstrap_completed and _loading_animation_finished and _cdn_warmup_completed:
 		_complete_loading_state()
 
 
@@ -1542,7 +1556,10 @@ func _abort_loading_state() -> void:
 	_cancel_bootstrap_retry()
 	_bootstrap_retry_count = 0
 	_bootstrap_completed = false
+	_cdn_warmup_completed = false
 	_loading_animation_finished = false
+	if CdnTextureLoader.warmup_completed.is_connected(_on_cdn_warmup_completed):
+		CdnTextureLoader.warmup_completed.disconnect(_on_cdn_warmup_completed)
 	if _auth_block != null:
 		_auth_block.visible = true
 	if _loading_block != null:

--- a/scripts/ui/CdnTextureLoader.gd
+++ b/scripts/ui/CdnTextureLoader.gd
@@ -1,14 +1,34 @@
 extends Node
 
+signal warmup_completed
+
 const META_PENDING_URL := "_cdn_pending_texture_url"
 
 var _texture_cache: Dictionary = {}
 var _pending_targets: Dictionary = {}
+var _warmup_urls: Dictionary = {}
+var _warmup_total: int = 0
+var _warmup_loaded: int = 0
 
 
 func warm_cache(remote_urls: Array[String]) -> void:
+	_warmup_urls.clear()
+	_warmup_loaded = 0
+	var urls_to_fetch: Array[String] = []
 	for url: String in remote_urls:
-		if url == "" or _texture_cache.has(url) or _pending_targets.has(url):
+		if url == "":
+			continue
+		if _texture_cache.has(url):
+			continue
+		if not _warmup_urls.has(url):
+			_warmup_urls[url] = true
+			urls_to_fetch.append(url)
+	_warmup_total = urls_to_fetch.size()
+	if _warmup_total == 0:
+		warmup_completed.emit()
+		return
+	for url: String in urls_to_fetch:
+		if _pending_targets.has(url):
 			continue
 		_pending_targets[url] = []
 		var request: HTTPRequest = HTTPRequest.new()
@@ -18,6 +38,19 @@ func warm_cache(remote_urls: Array[String]) -> void:
 		if request_error != OK:
 			request.queue_free()
 			_pending_targets.erase(url)
+			_on_warmup_url_done()
+
+
+func get_warmup_progress() -> float:
+	if _warmup_total <= 0:
+		return 1.0
+	return float(_warmup_loaded) / float(_warmup_total)
+
+
+func _on_warmup_url_done() -> void:
+	_warmup_loaded += 1
+	if _warmup_loaded >= _warmup_total:
+		warmup_completed.emit()
 
 
 func apply_texture(texture_rect: TextureRect, remote_url: String, fallback_texture: Texture2D) -> void:
@@ -82,6 +115,9 @@ func _on_request_completed(
 		if texture != null:
 			texture_rect.texture = texture
 			texture_rect.visible = true
+
+	if _warmup_urls.has(remote_url):
+		_on_warmup_url_done()
 
 
 func _decode_texture(remote_url: String, result: int, response_code: int, body: PackedByteArray) -> Texture2D:

--- a/scripts/ui/asset_resolver.gd
+++ b/scripts/ui/asset_resolver.gd
@@ -850,21 +850,112 @@ static func collect_warmup_cdn_urls(owned_cat_ids: Array[String]) -> Array[Strin
 		return []
 	var seen: Dictionary = {}
 	var urls: Array[String] = []
+
+	# Cat icons (owned)
 	for cat_id: String in owned_cat_ids:
 		var url: String = resolve_cdn_asset_url(_resolve_cat_icon_path(cat_id))
 		if url != "" and not seen.has(url):
 			seen[url] = true
 			urls.append(url)
+
+	# Card square frames (all rarities)
 	for rarity_path: Variant in CAT_CARD_SQUARE_FRAMES.values():
 		var url: String = resolve_cdn_asset_url(str(rarity_path))
 		if url != "" and not seen.has(url):
 			seen[url] = true
 			urls.append(url)
+
+	# Cat type icons
 	for type_path: Variant in CAT_TYPE_ICONS.values():
 		var url: String = resolve_cdn_asset_url(str(type_path))
 		if url != "" and not seen.has(url):
 			seen[url] = true
 			urls.append(url)
+
+	# Equipment icons
+	for equip_path: Variant in SCOOPER_EQUIPMENT.values():
+		var url: String = resolve_cdn_asset_url(str(equip_path))
+		if url != "" and not seen.has(url):
+			seen[url] = true
+			urls.append(url)
+
+	# Ability icons
+	for ability_path: Variant in SCOOPER_ABILITIES.values():
+		var url: String = resolve_cdn_asset_url(str(ability_path))
+		if url != "" and not seen.has(url):
+			seen[url] = true
+			urls.append(url)
+
+	# Gacha frames
+	for gacha_path: Variant in GACHA_FRAMES.values():
+		var url: String = resolve_cdn_asset_url(str(gacha_path))
+		if url != "" and not seen.has(url):
+			seen[url] = true
+			urls.append(url)
+
+	# Rewards
+	var reward_files: Array[String] = [
+		"arena_ticket.png", "battle_speed_ticket.png", "cat_food.png",
+		"cat_food_dungeon_ticket.png", "diamond_dungeon_ticket.png",
+		"gold_dungeon_ticket.png", "memory_shards.png", "party_cheer_coupon.png",
+		"poop_dungeon_ticket.png", "special_cat_food.png", "trap_cages.png",
+		"trap_points.png", "whisker_dungeon_ticket.png", "whisker_shards.png",
+	]
+	for f: String in reward_files:
+		var url: String = resolve_cdn_asset_url(UI_CDN_REWARDS_ROOT + f)
+		if url != "" and not seen.has(url):
+			seen[url] = true
+			urls.append(url)
+
+	# Dungeon resource icons
+	var dungeon_files: Array[String] = ["cat_food.png", "diamond.png", "gold.png", "poop.png", "whisker.png"]
+	for f: String in dungeon_files:
+		var url: String = resolve_cdn_asset_url(UI_CDN_DUNGEON_ROOT + f)
+		if url != "" and not seen.has(url):
+			seen[url] = true
+			urls.append(url)
+
+	# Treasure icons
+	var treasure_files: Array[String] = [
+		"assassin_gear.png", "bastion_whisker_knot.png", "gilded_litter_scoop.png",
+		"iron_armor.png", "moon_chime.png", "night_gem.png", "shadow_fang_medal.png",
+		"speed_gear.png", "spring_paw_clockwork.png", "tank_shield.png", "velvet_guard_pin.png",
+	]
+	for f: String in treasure_files:
+		var url: String = resolve_cdn_asset_url(UI_CDN_TREASURE_ROOT + f)
+		if url != "" and not seen.has(url):
+			seen[url] = true
+			urls.append(url)
+
+	# Arena rank badges
+	var arena_rank_files: Array[String] = [
+		"bronze_1.png", "bronze_2.png", "bronze_3.png",
+		"silver_1.png", "silver_2.png", "silver_3.png",
+		"gold_1.png", "gold_2.png", "gold_3.png",
+		"platinum_1.png", "platinum_2.png", "platinum_3.png",
+		"diamond_1.png", "diamond_2.png", "diamond_3.png",
+		"master_1.png", "master_2.png", "master_3.png", "elite.png",
+	]
+	for f: String in arena_rank_files:
+		var url: String = resolve_cdn_asset_url(UI_CDN_ARENA_RANKS_ROOT + f)
+		if url != "" and not seen.has(url):
+			seen[url] = true
+			urls.append(url)
+
+	# Activity backgrounds
+	var activity_files: Array[String] = [
+		"activity_background_v1.png", "arena_background_v1.png",
+		"chat_background_v1.png", "config_background_v1.png",
+		"dungeon_background_v1.png", "enhance_background_v1.png",
+		"gacha_background_v1.png", "mail_background_v1.png",
+		"scooper_background_v1.png", "shop_background_v1.png",
+	]
+	for f: String in activity_files:
+		var url: String = resolve_cdn_asset_url(UI_CDN_ACTIVITY_ROOT + f)
+		if url != "" and not seen.has(url):
+			seen[url] = true
+			urls.append(url)
+
 	return urls
 
 


### PR DESCRIPTION
## 變更說明
修正CDN圖片缺圖問題，在啟動頁面預載所有CDN資源。

### 改動重點
- **CdnTextureLoader**: 新增 `warmup_completed` signal，追蹤所有warm_cache URL的下載進度
- **AssetResolver**: `collect_warmup_cdn_urls()` 擴展涵蓋所有CDN資源（裝備、技能、獎勵、地城、寶物、段位、活動背景、轉蛋框）
- **StartScene**: 讀條時間 12s → 36s，新增CDN預載完成作為進入遊戲的必要條件

### 流程變更
進入遊戲前必須滿足三個條件：
1. Bootstrap API 完成
2. 讀條動畫跑完（36秒到96%）
3. 所有CDN圖片下載完成

Closes #381