### PR TITLE
fix:調整起始讀條曲線為TRANS_SINE使進度更均勻

### DIFF
--- a/scripts/StartScene.gd
+++ b/scripts/StartScene.gd
@@ -1495,7 +1495,7 @@ func _start_fake_loading() -> void:
 		0.0,
 		BOOTSTRAP_PROGRESS_MAX_PERCENT,
 		BOOTSTRAP_PROGRESS_DURATION_SECONDS
-	).set_trans(Tween.TRANS_EXPO).set_ease(Tween.EASE_OUT)
+	).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_OUT)
 	_loading_fill_tween.finished.connect(_on_loading_animation_finished)
 	_loading_percent_tween = _loading_fill_tween
 


### PR DESCRIPTION
將讀條動畫從 TRANS_EXPO 改為 TRANS_SINE，避免開頭速度過快後段幾乎不動的體感問題。