### PR TITLE
fix:修復 Chrome 透過 GitHub Pages 開啟時無音效

### DIFF
--- a/scripts/ui/UiAudio.gd
+++ b/scripts/ui/UiAudio.gd
@@ -266,11 +266,16 @@ func _install_web_audio_unlock_hooks() -> void:
 			let unlocked = false;
 			for (const context of this.contexts) {
 				if (!context) continue;
-				if (context.state !== 'running') {
-					try {
-						context.resume();
-					} catch (_err) {}
+				if (context.state === 'running') {
+					unlocked = true;
+					continue;
 				}
+				try {
+					const p = context.resume();
+					if (p && typeof p.then === 'function') {
+						p.then(() => { this.userActivated = true; });
+					}
+				} catch (_err) {}
 				if (context.state === 'running') {
 					unlocked = true;
 				}
@@ -279,15 +284,20 @@ func _install_web_audio_unlock_hooks() -> void:
 			return unlocked;
 		},
 		notifyUserGesture() {
-			this.userActivated = true;
 			this.ensureFallbackContext();
-			return this.resumeAllContexts() || this.userActivated;
+			const unlocked = this.resumeAllContexts();
+			this.userActivated = this.userActivated || unlocked;
+			return unlocked;
 		},
 		install() {
 			if (this.installed) return;
 			this.installConstructorHook('AudioContext');
 			this.installConstructorHook('webkitAudioContext');
-			const resume = () => this.notifyUserGesture();
+			const resume = () => {
+				this.userActivated = true;
+				this.ensureFallbackContext();
+				this.resumeAllContexts();
+			};
 			['click', 'touchend', 'pointerup', 'keydown'].forEach((eventName) => {
 				document.addEventListener(eventName, resume, { capture: true, passive: true });
 			});
@@ -323,9 +333,7 @@ func _retry_pending_bgm_after_unlock() -> void:
 		return
 	if _bgm_player == null:
 		return
-	if _bgm_player.playing and not _pending_bgm_restart:
-		return
-	play_bgm(_pending_bgm_stream, _pending_bgm_restart)
+	play_bgm(_pending_bgm_stream, true)
 
 
 func _schedule_web_audio_unlock_retry() -> void:


### PR DESCRIPTION
## 變更摘要
修復 Chrome 透過 GitHub Pages 開啟遊戲時完全沒有音效的問題。

## 根本原因
- `notifyUserGesture()` 在無使用者互動時就回傳 true，導致 BGM 在 AudioContext suspended 狀態下播放
- retry 邏輯誤判 `_bgm_player.playing` 為 true 而跳過重播

## 修正方式
- JS `notifyUserGesture()` 改為只在 context 實際為 running 時回傳 true
- Document event listener 獨立處理 `userActivated` flag
- `resumeAllContexts()` 加入 Promise 追蹤非同步狀態轉換
- `_retry_pending_bgm_after_unlock()` 強制 restart BGM