### PR TITLE
fix:全場景CDN圖片改用非同步載入修正

### DIFF
--- a/scripts/arenaScene/ArenaScene.gd
+++ b/scripts/arenaScene/ArenaScene.gd
@@ -472,7 +472,10 @@ func _build_team_member_card(member: Dictionary) -> PanelContainer:
 
 	var cat_icon: Texture2D = Helpers.resolve_cat_icon_by_catalog_id(int(member.get("catCatalogId", 0))) if is_filled else null
 	if cat_icon != null:
-		art_center.add_child(AssetResolver.create_icon_rect(cat_icon, Vector2(42.0, 42.0)))
+		var cat_icon_rect: TextureRect = AssetResolver.create_icon_rect(cat_icon, Vector2(42.0, 42.0))
+		var _cat_file_id: String = GameState.get_cat_file_id_by_catalog_id(int(member.get("catCatalogId", 0)))
+		AssetResolver.apply_cat_icon_texture(cat_icon_rect, _cat_file_id)
+		art_center.add_child(cat_icon_rect)
 	else:
 		var fallback: Label = Label.new()
 		fallback.text = Helpers.get_name_fallback(str(member.get("catDisplayName", ""))) if is_filled else UiText.CONFIG_EMPTY_SLOT_ICON
@@ -571,7 +574,10 @@ func _build_opponent_member_card(member: Dictionary) -> PanelContainer:
 	var cat_catalog_id: int = int(member.get("catCatalogId", 0)) if is_filled else 0
 	var cat_icon: Texture2D = Helpers.resolve_cat_icon_by_catalog_id(cat_catalog_id) if is_filled else null
 	if cat_icon != null:
-		art_center.add_child(AssetResolver.create_icon_rect(cat_icon, Vector2(52.0, 52.0)))
+		var cat_icon_rect: TextureRect = AssetResolver.create_icon_rect(cat_icon, Vector2(52.0, 52.0))
+		var _cat_file_id: String = GameState.get_cat_file_id_by_catalog_id(cat_catalog_id)
+		AssetResolver.apply_cat_icon_texture(cat_icon_rect, _cat_file_id)
+		art_center.add_child(cat_icon_rect)
 	else:
 		var fallback: Label = Label.new()
 		fallback.text = Helpers.get_name_fallback(str(member.get("catDisplayName", ""))) if is_filled else UiText.CONFIG_EMPTY_SLOT_ICON
@@ -885,9 +891,7 @@ func _build_reward_card(rank: Dictionary) -> Control:
 			icon.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
 			icon.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
 			icon.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
-			var tex: Texture2D = AssetResolver.resolve_catalog_texture(str(entry.get("path", "")))
-			if tex != null:
-				icon.texture = tex
+			AssetResolver.apply_catalog_texture(icon, str(entry.get("path", "")))
 			slot.add_child(icon)
 
 			var qty_lbl: Label = Label.new()
@@ -914,12 +918,8 @@ func _apply_reward_slot(slot: Control, reward_entry: Dictionary) -> void:
 	var name_label: Label = slot.get_node("ItemNameLabel") as Label
 	var qty_label: Label = slot.get_node("CountLabel") as Label
 
-	var texture: Texture2D = AssetResolver.resolve_catalog_texture(str(reward_entry.get("path", "")))
-	if texture != null:
-		icon.texture = texture
-		icon.visible = true
-	else:
-		icon.visible = false
+	AssetResolver.apply_catalog_texture(icon, str(reward_entry.get("path", "")))
+	icon.visible = str(reward_entry.get("path", "")) != ""
 
 	name_label.text = str(reward_entry.get("name", ""))
 	name_label.tooltip_text = name_label.text

--- a/scripts/battle/battle_manager.gd
+++ b/scripts/battle/battle_manager.gd
@@ -1472,13 +1472,8 @@ func _refresh_skill_slot_ui(i: int, slot: Dictionary) -> void:
 
 	var icon_rect: TextureRect = slot_node.get_node_or_null("Icon")
 	if icon_rect:
-		var cat_icon: Texture2D = AssetResolver.resolve_cat_icon(cat_id)
-		if cat_icon != null:
-			icon_rect.texture = cat_icon
-			icon_rect.visible = true
-		else:
-			icon_rect.texture = null
-			icon_rect.visible = false
+		AssetResolver.apply_cat_icon_texture(icon_rect, cat_id)
+		icon_rect.visible = cat_id != ""
 		icon_rect.modulate = Color(1.0, 1.0, 1.0, 1.0)
 
 	var death_overlay: ColorRect = slot_node.get_node_or_null("DeathOverlay")

--- a/scripts/battle/battle_scene.gd
+++ b/scripts/battle/battle_scene.gd
@@ -3042,12 +3042,14 @@ func _refresh_boss_warning_overlay_content() -> void:
 		return
 
 	_boss_warning_text_label.text = BOSS_WARNING_TEXT
-	var icon_texture: Texture2D = null
 	if not _current_enemy_cats.is_empty():
 		var boss_cat: CatData = _current_enemy_cats[0] as CatData
 		if boss_cat != null:
-			icon_texture = AssetResolver.resolve_cat_icon(boss_cat.id)
-	_boss_warning_icon.texture = icon_texture
+			AssetResolver.apply_cat_icon_texture(_boss_warning_icon, boss_cat.id)
+		else:
+			_boss_warning_icon.texture = null
+	else:
+		_boss_warning_icon.texture = null
 	_set_boss_warning_overlay_content_visible(_result_backdrop != null and _result_backdrop.visible)
 
 

--- a/scripts/chat/chat_message_item.gd
+++ b/scripts/chat/chat_message_item.gd
@@ -34,6 +34,7 @@ func setup(channel_key: String, message: Dictionary) -> void:
 		AssetResolver.resolve_profile_avatar(avatar_id),
 		Vector2(34.0, 34.0)
 	)
+	AssetResolver.apply_profile_avatar_texture(avatar_rect, avatar_id)
 	row.add_child(avatar_rect)
 
 	var body: Label = Label.new()

--- a/scripts/expedition/ExpeditionScene.gd
+++ b/scripts/expedition/ExpeditionScene.gd
@@ -362,6 +362,7 @@ func _make_cat_picker_row(zone_name: String, zone_id: int, cat_id: String) -> Co
 	margin.add_child(layout)
 
 	var icon: TextureRect = AssetResolver.create_icon_rect(AssetResolver.resolve_cat_icon(cat_id), Vector2(56.0, 56.0))
+	AssetResolver.apply_cat_icon_texture(icon, cat_id)
 	layout.add_child(icon)
 
 	var text_box: VBoxContainer = VBoxContainer.new()

--- a/scripts/social/SocialScene.gd
+++ b/scripts/social/SocialScene.gd
@@ -1461,6 +1461,7 @@ func _build_friend_row(item_variant: Variant) -> Control:
 		AssetResolver.resolve_profile_avatar(avatar_id),
 		Vector2(56.0, 56.0)
 	)
+	AssetResolver.apply_profile_avatar_texture(avatar_rect, avatar_id)
 	row.add_child(avatar_rect)
 
 	if _is_overlay_panel_mode():
@@ -1584,6 +1585,7 @@ func _build_friend_inbox_row(item_variant: Variant) -> Control:
 		AssetResolver.resolve_profile_avatar(avatar_id),
 		Vector2(56.0, 56.0)
 	)
+	AssetResolver.apply_profile_avatar_texture(avatar_rect, avatar_id)
 	row.add_child(avatar_rect)
 
 	if _is_overlay_panel_mode():
@@ -1702,6 +1704,7 @@ func _build_friend_outbox_row(item_variant: Variant) -> Control:
 		AssetResolver.resolve_profile_avatar(avatar_id),
 		Vector2(56.0, 56.0)
 	)
+	AssetResolver.apply_profile_avatar_texture(avatar_rect, avatar_id)
 	row.add_child(avatar_rect)
 
 	if _is_overlay_panel_mode():
@@ -2724,6 +2727,7 @@ func _build_friend_search_candidate_row(dialog_state: Dictionary, candidate: Dic
 		AssetResolver.resolve_profile_avatar(avatar_id),
 		Vector2(64.0, 64.0)
 	)
+	AssetResolver.apply_profile_avatar_texture(avatar_rect, avatar_id)
 	row.add_child(avatar_rect)
 
 	var info_box: VBoxContainer = VBoxContainer.new()
@@ -3038,6 +3042,7 @@ func _build_invite_party_candidate_row(dialog_state: Dictionary, candidate: Dict
 		AssetResolver.resolve_profile_avatar(avatar_id),
 		Vector2(64.0, 64.0)
 	)
+	AssetResolver.apply_profile_avatar_texture(avatar_rect, avatar_id)
 	row.add_child(avatar_rect)
 
 	var info_box: VBoxContainer = VBoxContainer.new()


### PR DESCRIPTION
## 變更摘要
修復 Chrome 透過 GitHub Pages 開啟遊戲時完全沒有音效的問題。

## 根本原因
- `notifyUserGesture()` 在無使用者互動時就回傳 true，導致 BGM 在 AudioContext suspended 狀態下播放
- retry 邏輯誤判 `_bgm_player.playing` 為 true 而跳過重播

## 修正方式
- JS `notifyUserGesture()` 改為只在 context 實際為 running 時回傳 true
- Document event listener 獨立處理 `userActivated` flag
- `resumeAllContexts()` 加入 Promise 追蹤非同步狀態轉換
- `_retry_pending_bgm_after_unlock()` 強制 restart BGM