### PR TITLE
feat:新增三項廣告功能客戶端實作

### DIFF
--- a/scripts/ApiClient.gd
+++ b/scripts/ApiClient.gd
@@ -519,6 +519,10 @@ func claim_expedition(zone_id: int, callback: Callable) -> void:
 	_api_post("expedition/%d/claim" % zone_id, {}, callback)
 
 
+func expedition_ad_speedup(zone_id: int, callback: Callable) -> void:
+	_api_post("expedition/%d/ad-speedup" % zone_id, {}, _with_daily_task_event(callback, "watch_ad"))
+
+
 func get_gacha_overview(callback: Callable) -> void:
 	_api_get("gacha", callback)
 
@@ -530,6 +534,10 @@ func perform_gacha_pull(pull_count: int, use_free_pull: bool, spend_trap_cages_f
 		"useFreePull": use_free_pull,
 		"spendTrapCagesFirst": spend_trap_cages_first,
 	}, request_callback)
+
+
+func perform_gacha_ad_pull(callback: Callable) -> void:
+	_api_post("gacha/ad-pull", {}, _with_daily_task_event(callback, "watch_ad"))
 
 
 func get_shop_overview(callback: Callable) -> void:
@@ -589,6 +597,14 @@ func complete_arena_battle(opponent_id: String, is_win: bool, callback: Callable
 
 func grant_dungeon_ad_ticket(dungeon_id: int, callback: Callable) -> void:
 	_api_post("dungeon/%d/ad-ticket" % dungeon_id, {}, callback)
+
+
+func get_ad_speed_boost_status(callback: Callable) -> void:
+	_api_get("scooper/profile/ad-speed-boost", callback)
+
+
+func use_ad_speed_boost(callback: Callable) -> void:
+	_api_post("scooper/profile/ad-speed-boost", {}, _with_daily_task_event(callback, "watch_ad"))
 
 
 func sweep_dungeon(dungeon_id: int, callback: Callable) -> void:

--- a/scripts/battle/battle_scene.gd
+++ b/scripts/battle/battle_scene.gd
@@ -163,7 +163,9 @@ const SKILL_PANEL_H := NAV_Y - SKILL_PANEL_Y
 const SKILL_PANEL_ALL_H := NAV_Y - SKILL_PANEL_Y
 const DEFAULT_FREE_SPEED_BOOST_MULT: float = 1.2
 const FREE_SPEED_BOOST_DURATION_SECONDS: int = 30 * 60
-const FREE_SPEED_BOOST_MAX_USES: int = 2
+const FREE_SPEED_BOOST_MAX_USES: int = 1
+const AD_SPEED_BOOST_DURATION_SECONDS: int = 30 * 60
+const AD_SPEED_BOOST_MAX_USES: int = 1
 const ENHANCE_APPLY_DISABLED_BG := Color(0.24, 0.21, 0.18, 0.86)
 const ENHANCE_APPLY_DISABLED_FG := Color(0.72, 0.69, 0.64, 1.0)
 const ENHANCE_DETAIL_TAB_ACTIVE_FILL := Color(0.43, 0.31, 0.14, 0.98)
@@ -343,6 +345,9 @@ var _current_speed_mult: float = 1.0
 var _free_speed_boost_end_unix: int = 0
 var _free_speed_boost_mult: float = 1.0
 var _free_speed_boost_remaining_uses: int = FREE_SPEED_BOOST_MAX_USES
+var _ad_speed_boost_end_unix: int = 0
+var _ad_speed_boost_remaining_uses: int = AD_SPEED_BOOST_MAX_USES
+var _ad_speed_boost_checked: bool = false
 var _boss_warning_flash_tween: Tween
 var _boss_warning_pulse_tween: Tween
 var _result_animation_tween: Tween
@@ -2509,12 +2514,17 @@ func _set_speed(mult: float, active_btn: Button) -> void:
 
 
 func _cycle_speed() -> void:
-	if _is_free_speed_boost_active() or _free_speed_boost_remaining_uses <= 0:
+	if _is_free_speed_boost_active() or _is_ad_speed_boost_active():
 		return
-	_free_speed_boost_mult = _get_free_speed_boost_mult()
-	_free_speed_boost_end_unix = int(Time.get_unix_time_from_system()) + FREE_SPEED_BOOST_DURATION_SECONDS
-	_free_speed_boost_remaining_uses -= 1
-	_set_speed(_free_speed_boost_mult, _speed_1x)
+	if _free_speed_boost_remaining_uses > 0:
+		_free_speed_boost_mult = _get_free_speed_boost_mult()
+		_free_speed_boost_end_unix = int(Time.get_unix_time_from_system()) + FREE_SPEED_BOOST_DURATION_SECONDS
+		_free_speed_boost_remaining_uses -= 1
+		_set_speed(_free_speed_boost_mult, _speed_1x)
+		return
+	if _ad_speed_boost_remaining_uses > 0:
+		_prompt_ad_speed_boost()
+		return
 
 
 func _get_available_speed_options() -> Array[float]:
@@ -2537,6 +2547,7 @@ func _format_speed_label(mult: float) -> String:
 
 func _apply_speed_unlocks() -> void:
 	_refresh_speed_boost_button()
+	_check_ad_speed_boost_status()
 
 
 func _highlight_speed_btn(active: Button) -> void:
@@ -2547,15 +2558,26 @@ func _highlight_speed_btn(active: Button) -> void:
 
 
 func _refresh_speed_boost_state() -> void:
-	var boost_active: bool = _is_free_speed_boost_active()
-	if boost_active and not is_equal_approx(_current_speed_mult, _free_speed_boost_mult):
+	var free_active: bool = _is_free_speed_boost_active()
+	var ad_active: bool = _is_ad_speed_boost_active()
+	if free_active and not is_equal_approx(_current_speed_mult, _free_speed_boost_mult):
 		_set_speed(_free_speed_boost_mult, _speed_1x)
-	elif not boost_active and _free_speed_boost_end_unix != 0:
+	elif not free_active and _free_speed_boost_end_unix != 0:
 		_free_speed_boost_end_unix = 0
 		_free_speed_boost_mult = 1.0
+		if not ad_active:
+			_set_speed(1.0, _speed_1x)
+	elif ad_active and not is_equal_approx(_current_speed_mult, _get_free_speed_boost_mult()):
+		_set_speed(_get_free_speed_boost_mult(), _speed_1x)
+	elif not ad_active and _ad_speed_boost_end_unix != 0:
+		_ad_speed_boost_end_unix = 0
 		_set_speed(1.0, _speed_1x)
 	else:
 		_refresh_speed_boost_button()
+
+
+func _is_ad_speed_boost_active() -> bool:
+	return _ad_speed_boost_end_unix > int(Time.get_unix_time_from_system())
 
 
 func _is_free_speed_boost_active() -> bool:
@@ -2565,23 +2587,35 @@ func _is_free_speed_boost_active() -> bool:
 func _refresh_speed_boost_button() -> void:
 	if _speed_1x == null:
 		return
+	var total_max: int = FREE_SPEED_BOOST_MAX_USES + AD_SPEED_BOOST_MAX_USES
 	if _is_free_speed_boost_active():
 		var remaining_seconds: int = _free_speed_boost_end_unix - int(Time.get_unix_time_from_system())
 		_speed_1x.text = "戰鬥加速\n%s" % _format_countdown_time(remaining_seconds)
 		_speed_1x.disabled = true
-	elif _free_speed_boost_remaining_uses <= 0:
-		_speed_1x.text = "戰鬥加速\n(0/%d)" % FREE_SPEED_BOOST_MAX_USES
+	elif _is_ad_speed_boost_active():
+		var remaining_seconds: int = _ad_speed_boost_end_unix - int(Time.get_unix_time_from_system())
+		_speed_1x.text = "戰鬥加速\n%s" % _format_countdown_time(remaining_seconds)
 		_speed_1x.disabled = true
-	else:
-		_speed_1x.text = "戰鬥加速\n(%d/%d)" % [_free_speed_boost_remaining_uses, FREE_SPEED_BOOST_MAX_USES]
+	elif _free_speed_boost_remaining_uses > 0:
+		var total_remaining: int = _free_speed_boost_remaining_uses + _ad_speed_boost_remaining_uses
+		_speed_1x.text = "戰鬥加速\n(%d/%d)" % [total_remaining, total_max]
 		_speed_1x.disabled = false
+	elif _ad_speed_boost_remaining_uses > 0:
+		var ad_free_label: String = "免費" if GameState.is_ad_free() else "廣告"
+		_speed_1x.text = "%s加速\n(%d/%d)" % [ad_free_label, _ad_speed_boost_remaining_uses, AD_SPEED_BOOST_MAX_USES]
+		_speed_1x.disabled = false
+	else:
+		_speed_1x.text = "戰鬥加速\n(0/%d)" % total_max
+		_speed_1x.disabled = true
 	if _speed_boost_visual_btn != null:
 		_speed_boost_visual_btn.disabled = _speed_1x.disabled
-		_speed_boost_visual_btn.modulate = Color(1.0, 1.0, 1.0, 0.58) if _speed_1x.disabled and not _is_free_speed_boost_active() else Color(1.0, 1.0, 1.0, 1.0)
+		var boost_active: bool = _is_free_speed_boost_active() or _is_ad_speed_boost_active()
+		_speed_boost_visual_btn.modulate = Color(1.0, 1.0, 1.0, 0.58) if _speed_1x.disabled and not boost_active else Color(1.0, 1.0, 1.0, 1.0)
 	if _speed_boost_status_label != null:
 		_speed_boost_status_label.text = _speed_1x.text
-	_highlight_speed_btn(_speed_1x if _is_free_speed_boost_active() else null)
-	_apply_skill_speed_button_style(_speed_1x, _is_free_speed_boost_active() or not _speed_1x.disabled)
+	var boost_active_for_highlight: bool = _is_free_speed_boost_active() or _is_ad_speed_boost_active()
+	_highlight_speed_btn(_speed_1x if boost_active_for_highlight else null)
+	_apply_skill_speed_button_style(_speed_1x, boost_active_for_highlight or not _speed_1x.disabled)
 
 
 func _format_countdown_time(total_seconds: int) -> String:
@@ -2600,6 +2634,47 @@ func _get_free_speed_boost_mult() -> float:
 	if speed_cap >= 1.5:
 		return 1.5
 	return DEFAULT_FREE_SPEED_BOOST_MULT
+
+
+func _prompt_ad_speed_boost() -> void:
+	var ad_free_label: String = "免費" if GameState.is_ad_free() else "觀看廣告"
+	DialogManager.show_confirm(
+		"戰鬥加速",
+		"%s以獲得30分鐘戰鬥加速？" % ad_free_label,
+		Callable(self, "_confirm_ad_speed_boost"),
+		"confirm"
+	)
+
+
+func _confirm_ad_speed_boost() -> void:
+	_speed_1x.disabled = true
+	ApiClient.use_ad_speed_boost(Callable(self, "_on_ad_speed_boost_completed"))
+
+
+func _on_ad_speed_boost_completed(ok: bool, data: Variant, err: Dictionary) -> void:
+	if not ok:
+		ToastManager.error("戰鬥加速", str(err.get("message", "廣告加速失敗")))
+		_refresh_speed_boost_button()
+		return
+	_ad_speed_boost_remaining_uses -= 1
+	_ad_speed_boost_end_unix = int(Time.get_unix_time_from_system()) + AD_SPEED_BOOST_DURATION_SECONDS
+	_set_speed(_get_free_speed_boost_mult(), _speed_1x)
+	ToastManager.success("戰鬥加速", "已加速30分鐘！")
+
+
+func _check_ad_speed_boost_status() -> void:
+	if _ad_speed_boost_checked:
+		return
+	_ad_speed_boost_checked = true
+	ApiClient.get_ad_speed_boost_status(Callable(self, "_on_ad_speed_boost_status"))
+
+
+func _on_ad_speed_boost_status(ok: bool, data: Variant, _err: Dictionary) -> void:
+	if not ok or not (data is Dictionary):
+		return
+	var remaining: int = int(data.get("remainingAdSpeedBoostCount", AD_SPEED_BOOST_MAX_USES))
+	_ad_speed_boost_remaining_uses = remaining
+	_refresh_speed_boost_button()
 
 
 func _refresh_ui() -> void:

--- a/scripts/expedition/ExpeditionScene.gd
+++ b/scripts/expedition/ExpeditionScene.gd
@@ -265,7 +265,20 @@ func _make_zone_card(zone: Dictionary) -> Control:
 	action_button.text = UiText.EXPEDITION_REMAINING_TIME_FORMAT % _format_remaining_time(maxi(int(expedition.get("completesAtUnixSeconds", 0)) - int(Time.get_unix_time_from_system()), 0))
 	action_button.disabled = true
 	UiPalette.apply_button_kind(action_button, "neutral")
-	return card
+	var ad_speedup_count: int = int(expedition.get(\"adSpeedupCount\", 0))
+	var max_ad_speedup: int = int(expedition.get(\"maxAdSpeedupCount\", 2))
+	if ad_speedup_count < max_ad_speedup:
+		var speedup_btn: Button = Button.new()
+		speedup_btn.custom_minimum_size = Vector2(0.0, 44.0)
+		speedup_btn.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		var ad_free_label: String = \"免費\" if GameState.is_ad_free() else \"廣告\"
+		speedup_btn.text = \"%s加速30分鐘 (%d/%d)\" % [ad_free_label, ad_speedup_count, max_ad_speedup]
+		speedup_btn.disabled = _is_loading
+		UiPalette.apply_button_kind(speedup_btn, \"secondary\")
+		speedup_btn.pressed.connect(Callable(self, \"_on_ad_speedup_pressed\").bind(zone_id, speedup_btn))
+		var content_canvas: Control = card.get_node(\"Margin/ContentCanvas\")
+		if content_canvas != null:
+			content_canvas.add_child(speedup_btn)	return card
 
 
 func _on_zone_deploy_pressed(zone: Dictionary) -> void:
@@ -431,6 +444,28 @@ func _claim_expedition(zone_id: int) -> void:
 	var cat_id: String = str(expedition.get("catId", "")).strip_edges()
 	_is_loading = true
 	ApiClient.claim_expedition(zone_id, Callable(self, "_on_claim_expedition_completed").bind(cat_id))
+
+
+func _on_ad_speedup_pressed(zone_id: int, btn: Button) -> void:
+	if _is_loading:
+		return
+	btn.disabled = true
+	_is_loading = true
+	ApiClient.expedition_ad_speedup(zone_id, Callable(self, "_on_ad_speedup_completed"))
+
+
+func _on_ad_speedup_completed(ok: bool, data: Variant, err: Dictionary) -> void:
+	_is_loading = false
+	if not ok:
+		ToastManager.error("巡視加速", str(err.get("message", "加速失敗")))
+		_refresh_zone_cards()
+		return
+	var result: Dictionary = data if data is Dictionary else {}
+	var active_variant: Variant = result.get("activeExpeditions", [])
+	if active_variant is Array:
+		GameState.expedition_active = active_variant
+	_refresh_zone_cards()
+	ToastManager.success("巡視加速", "已加速30分鐘！")
 
 
 func _on_claim_expedition_completed(ok: bool, data: Variant, err: Dictionary, cat_id: String) -> void:

--- a/scripts/gacha/GachaScene.gd
+++ b/scripts/gacha/GachaScene.gd
@@ -10,6 +10,7 @@ var _content_box: VBoxContainer
 var _pull_panel: Control
 var _pull_option_list: VBoxContainer
 var _free_button: Button
+var _ad_pull_button: Button
 var _technique_panel: Control
 var _technique_title: Label
 var _technique_desc: Label
@@ -73,6 +74,12 @@ func _build_ui() -> void:
 	_free_button.pressed.connect(_on_free_pull_pressed)
 	UiPalette.apply_button_kind(_free_button, "confirm")
 	pull_box.add_child(_free_button)
+
+	_ad_pull_button = Button.new()
+	_ad_pull_button.custom_minimum_size = Vector2(0.0, 52.0)
+	_ad_pull_button.pressed.connect(_on_ad_pull_pressed)
+	UiPalette.apply_button_kind(_ad_pull_button, "secondary")
+	pull_box.add_child(_ad_pull_button)
 
 	_technique_panel = Control.new()
 	_technique_panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
@@ -154,6 +161,24 @@ func _on_free_pull_pressed() -> void:
 	_request_pull(1, true)
 
 
+func _on_ad_pull_pressed() -> void:
+	_ad_pull_button.disabled = true
+	ApiClient.perform_gacha_ad_pull(Callable(self, "_on_ad_pull_completed"))
+
+
+func _on_ad_pull_completed(success: bool, data: Variant, error: Dictionary) -> void:
+	if not success:
+		ToastManager.error(UiText.GACHA_PULL_FAILED_TITLE, str(error.get("message", UiText.GACHA_PULL_FAILED_BODY)))
+		_ad_pull_button.disabled = false
+		return
+	var payload: Dictionary = data if data is Dictionary else {}
+	GameState.apply_gacha_pull_response(payload)
+	_refresh_view()
+	var results_variant: Variant = payload.get("results", [])
+	var results: Array = results_variant if results_variant is Array else []
+	_show_results(results)
+
+
 func _on_gacha_bootstrap_refreshed(success: bool, data: Variant, error: Dictionary, show_error_dialog: bool) -> void:
 	if success and data is Dictionary:
 		GameState.apply_player_bootstrap(data)
@@ -203,6 +228,21 @@ func _refresh_pull_options() -> void:
 	else:
 		_free_button.text = UiText.GACHA_FREE_PULL_FORMAT % maxi(free_pull_count, 1)
 		_free_button.disabled = false
+
+	var remaining_ad_pulls: int = int(GameState.gacha_data.get("remainingAdPullCount", 0))
+	var daily_ad_pull_limit: int = int(GameState.gacha_data.get("dailyAdPullLimit", 0))
+	var ad_used: int = int(GameState.gacha_data.get("dailyAdPullUsedCount", 0))
+	if daily_ad_pull_limit > 0 and has_used_free_pull_today:
+		_ad_pull_button.visible = true
+		if remaining_ad_pulls > 0:
+			var ad_free_label: String = "免費" if GameState.is_ad_free() else "廣告"
+			_ad_pull_button.text = "%s誘捕 (%d/%d)" % [ad_free_label, ad_used, daily_ad_pull_limit]
+			_ad_pull_button.disabled = false
+		else:
+			_ad_pull_button.text = "廣告誘捕已用完"
+			_ad_pull_button.disabled = true
+	else:
+		_ad_pull_button.visible = false
 	_apply_red_dots()
 
 


### PR DESCRIPTION
## 概述

新增三項廣告功能的客戶端實作。

Closes #399

### 變更內容
- ApiClient.gd — 新增 perform_gacha_ad_pull、expedition_ad_speedup、get_ad_speed_boost_status、use_ad_speed_boost
- GachaScene.gd — 免費次數用完後顯示廣告抽卡按鈕
- ExpeditionScene.gd — 進行中巡視顯示加速按鈕（最多2次）
- battle_scene.gd — 免費加速 2→1 次，新增廣告加速（每日1次，30分鐘）