### PR TITLE
refactor:統一使用 apply_catalog_texture 取代手動設定 texture

### DIFF
--- a/scripts/backpack/backpack_scene.gd
+++ b/scripts/backpack/backpack_scene.gd
@@ -143,17 +143,12 @@ func _make_item_card(item: Dictionary) -> Control:
 	var overlay_mask: TextureRect = slot.get_node("OverlayMask") as TextureRect
 	var name_label: Label = slot.get_node("ItemNameLabel") as Label
 	var qty_label: Label = slot.get_node("CountLabel") as Label
-	var texture: Texture2D = AssetResolver.resolve_catalog_texture(str(item.get("path", "")))
+	AssetResolver.apply_catalog_texture(icon, str(item.get("path", "")))
 
 	name_label.text = str(item.get("name", ""))
 	name_label.tooltip_text = name_label.text
 	qty_label.text = GameState.format_number(qty)
 	qty_label.tooltip_text = qty_label.text
-
-	if texture != null:
-		icon.texture = texture
-	else:
-		icon.visible = false
 
 	if has_qty:
 		frame.modulate = Color(1.0, 1.0, 1.0, 1.0)

--- a/scripts/dungeon/DungeonSceneUI.gd
+++ b/scripts/dungeon/DungeonSceneUI.gd
@@ -363,11 +363,10 @@ static func _bind_reward_slot(slot: Control, reward_items: Array[Dictionary], in
 	var reward_item: Dictionary = reward_items[index]
 	var reward_key: String = str(reward_item.get("key", ""))
 	var amount: int = int(reward_item.get("amount", 0))
-	var texture: Texture2D = AssetResolver.resolve_catalog_texture(_get_reward_catalog_path(reward_key))
+	AssetResolver.apply_catalog_texture(icon, _get_reward_catalog_path(reward_key))
 
 	frame.visible = true
-	icon.visible = texture != null
-	icon.texture = texture
+	icon.visible = true
 	overlay_mask.visible = true
 	item_name_label.visible = true
 	item_name_label.text = _get_reward_label(reward_key)

--- a/scripts/scooper/scooper_tab_treasure.gd
+++ b/scripts/scooper/scooper_tab_treasure.gd
@@ -140,11 +140,7 @@ func _show_treasure_detail(scene: Control, item: Dictionary) -> void:
 	var detail_frame: TextureRect = detail_slot.get_node("Frame") as TextureRect
 	var detail_overlay: TextureRect = detail_slot.get_node("OverlayMask") as TextureRect
 
-	var treasure_texture: Texture2D = AssetResolver.resolve_catalog_texture(item.get("imagePath", ""))
-	if treasure_texture != null:
-		detail_icon.texture = treasure_texture
-	else:
-		detail_icon.visible = false
+	AssetResolver.apply_catalog_texture(detail_icon, item.get("imagePath", ""))
 	detail_name.visible = false
 	detail_qty.text = GameState.format_number(int(item.get("quantity", 0)))
 	detail_frame.modulate = Color(1.0, 1.0, 1.0, 1.0)


### PR DESCRIPTION
## 概述

統一將 backpack、dungeon、scooper treasure 三個場景中的舊寫法（resolve_catalog_texture + 手動設 texture/visible）改為使用 apply_catalog_texture 一行呼叫。

### 變更檔案
- backpack_scene.gd
- DungeonSceneUI.gd
- scooper_tab_treasure.gd